### PR TITLE
feat : 문제 관리 CRUD 

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/problem/dto/request/ProblemCreateRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/dto/request/ProblemCreateRequest.java
@@ -7,10 +7,11 @@ import org.ezcode.codetest.domain.problem.model.enums.Reference;
 import org.ezcode.codetest.domain.user.model.entity.User;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record ProblemCreateRequest(
 
-	@NotBlank(message = "카테고리를 설정해야 합니다.")
+	@NotNull(message = "카테고리를 설정해야 합니다.")
 	Category category,
 
 	@NotBlank(message = "문제 제목을 입력하세요.")
@@ -19,18 +20,16 @@ public record ProblemCreateRequest(
 	@NotBlank(message = "문제 설명을 입력하세요.")
 	String description,
 
-	@NotBlank(message = "난이도를 설정해야 합니다.")
+	@NotNull(message = "난이도를 설정해야 합니다.")
 	Difficulty difficulty,
 
 	@NotBlank(message = "메모리 제한을 설정해야 합니다.")
 	String memoryLimit,
 
-	@NotBlank(message = "시간 제한을 설정해야 합니다.")
 	int timeLimit,
 
-	@NotBlank(message = "출처를 명시해야 합니다.")
+	@NotNull(message = "출처를 명시해야 합니다.")
 	Reference reference
-
 
 ) {
 

--- a/src/main/java/org/ezcode/codetest/application/problem/dto/request/ProblemCreateRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/dto/request/ProblemCreateRequest.java
@@ -26,7 +26,8 @@ public record ProblemCreateRequest(
 	@NotBlank(message = "메모리 제한을 설정해야 합니다.")
 	String memoryLimit,
 
-	int timeLimit,
+	@NotNull(message = "시간 제한을 설정해야 합니다.")
+	Integer timeLimit,
 
 	@NotNull(message = "출처를 명시해야 합니다.")
 	Reference reference

--- a/src/main/java/org/ezcode/codetest/application/problem/dto/request/ProblemCreateRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/dto/request/ProblemCreateRequest.java
@@ -10,20 +10,25 @@ import jakarta.validation.constraints.NotBlank;
 
 public record ProblemCreateRequest(
 
+	@NotBlank(message = "카테고리를 설정해야 합니다.")
 	Category category,
 
-	@NotBlank
+	@NotBlank(message = "문제 제목을 입력하세요.")
 	String title,
 
-	@NotBlank
+	@NotBlank(message = "문제 설명을 입력하세요.")
 	String description,
 
+	@NotBlank(message = "난이도를 설정해야 합니다.")
 	Difficulty difficulty,
 
+	@NotBlank(message = "메모리 제한을 설정해야 합니다.")
 	String memoryLimit,
 
+	@NotBlank(message = "시간 제한을 설정해야 합니다.")
 	int timeLimit,
 
+	@NotBlank(message = "출처를 명시해야 합니다.")
 	Reference reference
 
 

--- a/src/main/java/org/ezcode/codetest/application/problem/dto/request/ProblemCreateRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/dto/request/ProblemCreateRequest.java
@@ -1,0 +1,47 @@
+package org.ezcode.codetest.application.problem.dto.request;
+
+import org.ezcode.codetest.domain.problem.model.entity.Problem;
+import org.ezcode.codetest.domain.problem.model.enums.Category;
+import org.ezcode.codetest.domain.problem.model.enums.Difficulty;
+import org.ezcode.codetest.domain.problem.model.enums.Reference;
+import org.ezcode.codetest.domain.user.model.entity.User;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ProblemCreateRequest(
+
+	Category category,
+
+	@NotBlank
+	String title,
+
+	@NotBlank
+	String description,
+
+	Difficulty difficulty,
+
+	String memoryLimit,
+
+	int timeLimit,
+
+	Reference reference
+
+
+) {
+
+	// Dto -> Entity 변환
+	public static Problem toEntity(ProblemCreateRequest request, User user) {
+
+		return Problem.builder()
+			.creator(user)
+			.category(request.category)
+			.title(request.title)
+			.description(request.description)
+			.difficulty(request.difficulty.getDifficulty())
+			.score(request.difficulty.getScore())
+			.memoryLimit(request.memoryLimit)
+			.timeLimit(request.timeLimit)
+			.reference(request.reference)
+			.build();
+	}
+}

--- a/src/main/java/org/ezcode/codetest/application/problem/dto/request/ProblemUpdateRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/dto/request/ProblemUpdateRequest.java
@@ -1,0 +1,51 @@
+package org.ezcode.codetest.application.problem.dto.request;
+
+import org.ezcode.codetest.domain.problem.model.entity.Problem;
+import org.ezcode.codetest.domain.problem.model.enums.Category;
+import org.ezcode.codetest.domain.problem.model.enums.Difficulty;
+import org.ezcode.codetest.domain.problem.model.enums.Reference;
+import org.ezcode.codetest.domain.user.model.entity.User;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ProblemUpdateRequest(
+
+	@NotNull(message = "카테고리를 설정해야 합니다.")
+	Category category,
+
+	@NotBlank(message = "문제 제목을 입력하세요.")
+	String title,
+
+	@NotBlank(message = "문제 설명을 입력하세요.")
+	String description,
+
+	@NotNull(message = "난이도를 설정해야 합니다.")
+	Difficulty difficulty,
+
+	@NotBlank(message = "메모리 제한을 설정해야 합니다.")
+	String memoryLimit,
+
+	int timeLimit,
+
+	@NotNull(message = "출처를 명시해야 합니다.")
+	Reference reference
+
+) {
+
+	public static Problem from(ProblemUpdateRequest request, User user) {
+
+		return Problem.builder()
+			.creator(user)
+			.category(request.category)
+			.title(request.title)
+			.description(request.description)
+			.difficulty(request.difficulty.getDifficulty())
+			.score(request.difficulty.getScore())
+			.memoryLimit(request.memoryLimit)
+			.timeLimit(request.timeLimit)
+			.reference(request.reference)
+			.build();
+	}
+
+}

--- a/src/main/java/org/ezcode/codetest/application/problem/dto/request/ProblemUpdateRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/dto/request/ProblemUpdateRequest.java
@@ -6,29 +6,20 @@ import org.ezcode.codetest.domain.problem.model.enums.Difficulty;
 import org.ezcode.codetest.domain.problem.model.enums.Reference;
 import org.ezcode.codetest.domain.user.model.entity.User;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-
 public record ProblemUpdateRequest(
 
-	@NotNull(message = "카테고리를 설정해야 합니다.")
 	Category category,
 
-	@NotBlank(message = "문제 제목을 입력하세요.")
 	String title,
 
-	@NotBlank(message = "문제 설명을 입력하세요.")
 	String description,
 
-	@NotNull(message = "난이도를 설정해야 합니다.")
 	Difficulty difficulty,
 
-	@NotBlank(message = "메모리 제한을 설정해야 합니다.")
 	String memoryLimit,
 
-	int timeLimit,
+	Integer timeLimit,
 
-	@NotNull(message = "출처를 명시해야 합니다.")
 	Reference reference
 
 ) {

--- a/src/main/java/org/ezcode/codetest/application/problem/dto/response/ProblemDetailResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/dto/response/ProblemDetailResponse.java
@@ -1,0 +1,59 @@
+package org.ezcode.codetest.application.problem.dto.response;
+
+import java.time.LocalDateTime;
+
+import org.ezcode.codetest.domain.problem.model.entity.Problem;
+import org.ezcode.codetest.domain.problem.model.enums.Category;
+import org.ezcode.codetest.domain.problem.model.enums.Reference;
+
+import lombok.Builder;
+
+@Builder
+public record ProblemDetailResponse(
+
+	Long id,
+
+	String creator,
+
+	Category category,
+
+	String title,
+
+	String description,
+
+	int score,
+
+	String difficulty,
+
+	String memoryLimit,
+
+	int timeLimit,
+
+	Reference reference,
+
+	LocalDateTime createdAt,
+
+	LocalDateTime modifiedAt,
+
+	boolean isDeleted
+
+) {
+
+	public static ProblemDetailResponse from(Problem problem) {
+
+		return ProblemDetailResponse.builder()
+			.id(problem.getId())
+			.creator(problem.getCreator().getNickname())
+			.category(problem.getCategory())
+			.title(problem.getTitle())
+			.description(problem.getDescription())
+			.score(problem.getScore())
+			.difficulty(problem.getDifficulty())
+			.memoryLimit(problem.getMemoryLimit())
+			.timeLimit(problem.getTimeLimit())
+			.reference(problem.getReference())
+			.createdAt(problem.getCreatedAt())
+			.modifiedAt(problem.getModifiedAt())
+			.build();
+	}
+}

--- a/src/main/java/org/ezcode/codetest/application/problem/dto/response/ProblemDetailResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/dto/response/ProblemDetailResponse.java
@@ -33,9 +33,7 @@ public record ProblemDetailResponse(
 
 	LocalDateTime createdAt,
 
-	LocalDateTime modifiedAt,
-
-	boolean isDeleted
+	LocalDateTime modifiedAt
 
 ) {
 

--- a/src/main/java/org/ezcode/codetest/application/problem/dto/response/ProblemResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/dto/response/ProblemResponse.java
@@ -1,0 +1,24 @@
+package org.ezcode.codetest.application.problem.dto.response;
+
+import org.ezcode.codetest.domain.problem.model.enums.Category;
+import org.ezcode.codetest.domain.problem.model.enums.Reference;
+
+public record ProblemResponse(
+
+	Long id,
+
+	String creator,
+
+	Category category,
+
+	String title,
+
+	int score,
+
+	String difficulty,
+
+	Reference reference
+
+) {
+
+}

--- a/src/main/java/org/ezcode/codetest/application/problem/dto/response/ProblemResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/dto/response/ProblemResponse.java
@@ -1,8 +1,12 @@
 package org.ezcode.codetest.application.problem.dto.response;
 
+import org.ezcode.codetest.domain.problem.model.entity.Problem;
 import org.ezcode.codetest.domain.problem.model.enums.Category;
 import org.ezcode.codetest.domain.problem.model.enums.Reference;
 
+import lombok.Builder;
+
+@Builder
 public record ProblemResponse(
 
 	Long id,
@@ -21,4 +25,16 @@ public record ProblemResponse(
 
 ) {
 
+	public static ProblemResponse from(Problem problem) {
+
+		return ProblemResponse.builder()
+			.id(problem.getId())
+			.creator(problem.getCreator().getNickname())
+			.category(problem.getCategory())
+			.title(problem.getTitle())
+			.score(problem.getScore())
+			.difficulty(problem.getDifficulty())
+			.reference(problem.getReference())
+			.build();
+	}
 }

--- a/src/main/java/org/ezcode/codetest/application/problem/dto/response/ProblemResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/dto/response/ProblemResponse.java
@@ -27,9 +27,13 @@ public record ProblemResponse(
 
 	public static ProblemResponse from(Problem problem) {
 
+		if (problem == null) {
+			throw new IllegalArgumentException("문제는 null 값이 아니어야 합니다.");
+		}
+
 		return ProblemResponse.builder()
 			.id(problem.getId())
-			.creator(problem.getCreator().getNickname())
+			.creator(problem.getCreator() != null ? problem.getCreator().getNickname() : "존재하지 않는 이름.")
 			.category(problem.getCategory())
 			.title(problem.getTitle())
 			.score(problem.getScore())

--- a/src/main/java/org/ezcode/codetest/application/problem/port/repository/ProblemImageRepository.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/port/repository/ProblemImageRepository.java
@@ -1,4 +1,0 @@
-package org.ezcode.codetest.application.problem.port.repository;
-
-public interface ProblemImageRepository {
-}

--- a/src/main/java/org/ezcode/codetest/application/problem/port/repository/ProblemRepository.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/port/repository/ProblemRepository.java
@@ -1,4 +1,0 @@
-package org.ezcode.codetest.application.problem.port.repository;
-
-public interface ProblemRepository {
-}

--- a/src/main/java/org/ezcode/codetest/application/problem/port/repository/TestcaseRepository.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/port/repository/TestcaseRepository.java
@@ -1,4 +1,0 @@
-package org.ezcode.codetest.application.problem.port.repository;
-
-public interface TestcaseRepository {
-}

--- a/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
@@ -51,9 +51,9 @@ public class ProblemService {
 		return problems.map(ProblemResponse::from); // Entity → DTO 변환
 	}
 
-	public ProblemDetailResponse findByIdProblem(Long id) {
+	public ProblemDetailResponse findByIdProblem(Long problemId) {
 
-		Problem findProblem = problemDomainService.findByIdOrElseThrow(id);
+		Problem findProblem = problemDomainService.findByIdOrElseThrow(problemId);
 
 		return ProblemDetailResponse.from(findProblem);
 	}

--- a/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
@@ -6,8 +6,10 @@ import org.ezcode.codetest.application.problem.dto.request.ProblemCreateRequest;
 import org.ezcode.codetest.application.problem.dto.response.ProblemDetailResponse;
 import org.ezcode.codetest.application.problem.dto.response.ProblemResponse;
 import org.ezcode.codetest.domain.problem.model.entity.Problem;
+import org.ezcode.codetest.domain.problem.model.enums.Category;
 import org.ezcode.codetest.domain.problem.service.ProblemDomainService;
 import org.ezcode.codetest.domain.user.model.entity.User;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,6 +38,20 @@ public class ProblemService {
 
 		return ProblemDetailResponse.from(savedProblem);
 	}
+
+	public Page<ProblemResponse> findAllByCategory(Pageable pageable, Category category) {
+		Page<Problem> problems;
+
+		if (category != null) {
+			problems = problemDomainService.findByCategory(category, pageable);
+		} else {
+			problems = problemDomainService.findAll(pageable);
+		}
+
+		return problems.map(ProblemResponse::from); // Entity → DTO 변환
+	}
+
+
 	// 검증하는 메소드명을 불러와서 쓴다.
 
 }

--- a/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
@@ -54,6 +54,10 @@ public class ProblemService {
 
 		Problem findProblem = problemDomainService.getProblem(problemId);
 
+		if(findProblem.getIsDeleted()) {
+			throw new RuntimeException("삭제된 문제 입니다.");
+		}
+
 		return ProblemDetailResponse.from(findProblem);
 	}
 
@@ -67,8 +71,7 @@ public class ProblemService {
 			request.category(),
 			request.title(),
 			request.description(),
-			request.difficulty().getDifficulty(),
-			request.difficulty().getScore(),
+			request.difficulty(),
 			request.memoryLimit(),
 			request.timeLimit(),
 			request.reference()
@@ -76,4 +79,13 @@ public class ProblemService {
 
 		return ProblemDetailResponse.from(findProblem);
 	}
+
+	@Transactional
+	public void removeProblem(Long problemId) {
+
+		Problem findProblem = problemDomainService.getProblem(problemId);
+
+		findProblem.softDelete();
+	}
 }
+

--- a/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
@@ -38,6 +38,7 @@ public class ProblemService {
 		return ProblemDetailResponse.from(savedProblem);
 	}
 
+	@Transactional(readOnly = true)
 	public Page<ProblemResponse> getProblemsList(Pageable pageable, Category category) {
 		Page<Problem> problems;
 
@@ -50,13 +51,10 @@ public class ProblemService {
 		return problems.map(ProblemResponse::from); // Entity → DTO 변환
 	}
 
+	@Transactional(readOnly = true)
 	public ProblemDetailResponse getProblem(Long problemId) {
 
 		Problem findProblem = problemDomainService.getProblem(problemId);
-
-		if(findProblem.getIsDeleted()) {
-			throw new RuntimeException("삭제된 문제 입니다.");
-		}
 
 		return ProblemDetailResponse.from(findProblem);
 	}

--- a/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
@@ -81,7 +81,7 @@ public class ProblemService {
 
 		Problem findProblem = problemDomainService.getProblem(problemId);
 
-		findProblem.softDelete();
+		problemDomainService.removeProblem(findProblem);
 	}
 }
 

--- a/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
@@ -30,7 +30,7 @@ public class ProblemService {
 			.email("이메일")
 			.nickname("닉네임^^")
 			.build();
-		// user.setId(1L); User Entity Setter 필요
+		// user.setId(1L); // User Entity Setter 필요
 
 		Problem savedProblem = problemDomainService.saveProblem(
 			ProblemCreateRequest.toEntity(requestDto, user)
@@ -51,7 +51,11 @@ public class ProblemService {
 		return problems.map(ProblemResponse::from); // Entity → DTO 변환
 	}
 
+	public ProblemDetailResponse findByIdProblem(Long id) {
 
-	// 검증하는 메소드명을 불러와서 쓴다.
+		Problem findProblem = problemDomainService.findByIdOrElseThrow(id);
+
+		return ProblemDetailResponse.from(findProblem);
+	}
 
 }

--- a/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
@@ -1,6 +1,7 @@
 package org.ezcode.codetest.application.problem.service;
 
 import org.ezcode.codetest.application.problem.dto.request.ProblemCreateRequest;
+import org.ezcode.codetest.application.problem.dto.request.ProblemUpdateRequest;
 import org.ezcode.codetest.application.problem.dto.response.ProblemDetailResponse;
 import org.ezcode.codetest.application.problem.dto.response.ProblemResponse;
 import org.ezcode.codetest.domain.problem.model.entity.Problem;
@@ -56,4 +57,23 @@ public class ProblemService {
 		return ProblemDetailResponse.from(findProblem);
 	}
 
+	@Transactional
+	public ProblemDetailResponse modifyProblem(Long problemId, ProblemUpdateRequest request) {
+
+		Problem findProblem = problemDomainService.getProblem(problemId);
+
+		findProblem.update(
+			findProblem.getCreator(),
+			request.category(),
+			request.title(),
+			request.description(),
+			request.difficulty().getDifficulty(),
+			request.difficulty().getScore(),
+			request.memoryLimit(),
+			request.timeLimit(),
+			request.reference()
+		);
+
+		return ProblemDetailResponse.from(findProblem);
+	}
 }

--- a/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
@@ -30,7 +30,7 @@ public class ProblemService {
 			.build();
 		// user.setId(1L); User Entity Setter 필요
 
-		Problem savedProblem = problemDomainService.createProblem(
+		Problem savedProblem = problemDomainService.saveProblem(
 			ProblemCreateRequest.toEntity(requestDto, user)
 		);
 

--- a/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
@@ -1,7 +1,5 @@
 package org.ezcode.codetest.application.problem.service;
 
-import java.util.List;
-
 import org.ezcode.codetest.application.problem.dto.request.ProblemCreateRequest;
 import org.ezcode.codetest.application.problem.dto.response.ProblemDetailResponse;
 import org.ezcode.codetest.application.problem.dto.response.ProblemResponse;
@@ -32,28 +30,28 @@ public class ProblemService {
 			.build();
 		// user.setId(1L); // User Entity Setter 필요
 
-		Problem savedProblem = problemDomainService.saveProblem(
+		Problem savedProblem = problemDomainService.createProblem(
 			ProblemCreateRequest.toEntity(requestDto, user)
 		);
 
 		return ProblemDetailResponse.from(savedProblem);
 	}
 
-	public Page<ProblemResponse> findAllByCategory(Pageable pageable, Category category) {
+	public Page<ProblemResponse> getProblemsList(Pageable pageable, Category category) {
 		Page<Problem> problems;
 
 		if (category != null) {
-			problems = problemDomainService.findByCategory(category, pageable);
+			problems = problemDomainService.getProblemsByCategoryList(category, pageable);
 		} else {
-			problems = problemDomainService.findAll(pageable);
+			problems = problemDomainService.getProblemsList(pageable);
 		}
 
 		return problems.map(ProblemResponse::from); // Entity → DTO 변환
 	}
 
-	public ProblemDetailResponse findByIdProblem(Long problemId) {
+	public ProblemDetailResponse getProblem(Long problemId) {
 
-		Problem findProblem = problemDomainService.findByIdOrElseThrow(problemId);
+		Problem findProblem = problemDomainService.getProblem(problemId);
 
 		return ProblemDetailResponse.from(findProblem);
 	}

--- a/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
@@ -1,0 +1,41 @@
+package org.ezcode.codetest.application.problem.service;
+
+import java.util.List;
+
+import org.ezcode.codetest.application.problem.dto.request.ProblemCreateRequest;
+import org.ezcode.codetest.application.problem.dto.response.ProblemDetailResponse;
+import org.ezcode.codetest.application.problem.dto.response.ProblemResponse;
+import org.ezcode.codetest.domain.problem.model.entity.Problem;
+import org.ezcode.codetest.domain.problem.service.ProblemDomainService;
+import org.ezcode.codetest.domain.user.model.entity.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ProblemService {
+
+	private final ProblemDomainService problemDomainService;
+
+	@Transactional
+	public ProblemDetailResponse createProblem(ProblemCreateRequest requestDto) {
+
+		// 유저 정보가 없어서 임시로 테스트용
+		User user = User.builder()
+			.email("이메일")
+			.nickname("닉네임^^")
+			.build();
+		// user.setId(1L); User Entity Setter 필요
+
+		Problem savedProblem = problemDomainService.createProblem(
+			ProblemCreateRequest.toEntity(requestDto, user)
+		);
+
+		return ProblemDetailResponse.from(savedProblem);
+	}
+	// 검증하는 메소드명을 불러와서 쓴다.
+
+}

--- a/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
@@ -7,7 +7,9 @@ import org.ezcode.codetest.application.problem.dto.response.ProblemResponse;
 import org.ezcode.codetest.domain.problem.model.entity.Problem;
 import org.ezcode.codetest.domain.problem.model.enums.Category;
 import org.ezcode.codetest.domain.problem.service.ProblemDomainService;
+import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.ezcode.codetest.domain.user.model.entity.User;
+import org.ezcode.codetest.domain.user.service.UserDomainService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -20,16 +22,12 @@ import lombok.RequiredArgsConstructor;
 public class ProblemService {
 
 	private final ProblemDomainService problemDomainService;
+	private final UserDomainService userDomainService;
 
 	@Transactional
-	public ProblemDetailResponse createProblem(ProblemCreateRequest requestDto) {
+	public ProblemDetailResponse createProblem(ProblemCreateRequest requestDto, AuthUser authUser) {
 
-		// 유저 정보가 없어서 임시로 테스트용
-		User user = User.builder()
-			.email("이메일")
-			.nickname("닉네임^^")
-			.build();
-		// user.setId(1L); // User Entity Setter 필요
+		User user = userDomainService.getUserById(authUser.getId());
 
 		Problem savedProblem = problemDomainService.createProblem(
 			ProblemCreateRequest.toEntity(requestDto, user)

--- a/src/main/java/org/ezcode/codetest/domain/problem/model/entity/Problem.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/model/entity/Problem.java
@@ -2,6 +2,7 @@ package org.ezcode.codetest.domain.problem.model.entity;
 
 import org.ezcode.codetest.common.base.entity.BaseEntity;
 import org.ezcode.codetest.domain.problem.model.enums.Category;
+import org.ezcode.codetest.domain.problem.model.enums.Difficulty;
 import org.ezcode.codetest.domain.problem.model.enums.Reference;
 import org.ezcode.codetest.domain.user.model.entity.User;
 
@@ -94,19 +95,23 @@ public class Problem extends BaseEntity {
 	}
 
 	// 문제 수정 로직
-	public void update(User creator, Category category, String title, String description, String difficulty,
-		int score, String memoryLimit, int timeLimit, Reference reference) {
+	public void update(User creator, Category category, String title, String description, Difficulty difficulty,
+		String memoryLimit, Integer timeLimit, Reference reference) {
 
-		this.creator = creator;
-		this.category = category;
-		this.title = title;
-		this.description = description;
-		this.difficulty = difficulty;
-		this.score = score;
-		this.memoryLimit = memoryLimit;
-		this.timeLimit = timeLimit;
-		this.reference = reference;
+		if (creator != null) this.creator = creator;
+		if (category != null) this.category = category;
+		if (title != null) this.title = title;
+		if (description != null) this.description = description;
+		if (difficulty != null) {
+			this.difficulty = difficulty.getDifficulty();
+			this.score = difficulty.getScore();
+		}
+		if (memoryLimit != null)this.memoryLimit = memoryLimit;
+		if (timeLimit != null) this.timeLimit = timeLimit;
+		if (reference != null) this.reference = reference;
 	}
-	// problem id 받아서 problem 반환
-	// problem 받아서 testcase 반환 domainService
+
+	public void softDelete() {
+		this.isDeleted = true;
+	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/problem/model/entity/Problem.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/model/entity/Problem.java
@@ -92,4 +92,7 @@ public class Problem extends BaseEntity {
 			.reference(reference)
 			.build();
 	}
+
+	// problem id 받아서 problem 반환
+	// problem 받아서 testcase 반환 domainService
 }

--- a/src/main/java/org/ezcode/codetest/domain/problem/model/entity/Problem.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/model/entity/Problem.java
@@ -2,7 +2,6 @@ package org.ezcode.codetest.domain.problem.model.entity;
 
 import org.ezcode.codetest.common.base.entity.BaseEntity;
 import org.ezcode.codetest.domain.problem.model.enums.Category;
-import org.ezcode.codetest.domain.problem.model.enums.Difficulty;
 import org.ezcode.codetest.domain.problem.model.enums.Reference;
 import org.ezcode.codetest.domain.user.model.entity.User;
 
@@ -30,7 +29,7 @@ public class Problem extends BaseEntity {
 	private Long id;
 
 	@ManyToOne
-	@JoinColumn(nullable = false)
+	@JoinColumn(name = "creator_id", nullable = false)
 	private User creator;
 
 	@Enumerated(EnumType.STRING)
@@ -40,15 +39,14 @@ public class Problem extends BaseEntity {
 	@Column(nullable = false)
 	private String title;
 
-	@Column(columnDefinition = "TEXT", nullable = false)
-	private String content;
+	@Column(columnDefinition = "LONGTEXT", nullable = false)
+	private String description;
 
 	@Column(nullable = false)
 	private int score;
 
-	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private Difficulty difficulty;
+	private String difficulty;
 
 	@Column(nullable = false)
 	private String memoryLimit;
@@ -64,16 +62,34 @@ public class Problem extends BaseEntity {
 	private Boolean isDeleted;
 
 	@Builder
-	public Problem(User creator, Category category, String title, String content, int score, Difficulty difficulty,
+	public Problem(User creator, Category category, String title, String description, int score, String difficulty,
 		String memoryLimit, int timeLimit, Reference reference) {
 		this.creator = creator;
 		this.category = category;
 		this.title = title;
-		this.content = content;
+		this.description = description;
 		this.score = score;
 		this.difficulty = difficulty;
 		this.memoryLimit = memoryLimit;
 		this.timeLimit = timeLimit;
 		this.reference = reference;
+		isDeleted = false;
+	}
+
+	// 여러개를 하나의 객체로 만드는 것
+	public static Problem of(User creator, Category category, String title, String description, int score, String difficulty,
+		String memoryLimit, int timeLimit, Reference reference) {
+
+		return Problem.builder()
+			.creator(creator)
+			.category(category)
+			.title(title)
+			.description(description)
+			.score(score)
+			.difficulty(difficulty)
+			.memoryLimit(memoryLimit)
+			.timeLimit(timeLimit)
+			.reference(reference)
+			.build();
 	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/problem/model/entity/Problem.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/model/entity/Problem.java
@@ -93,6 +93,20 @@ public class Problem extends BaseEntity {
 			.build();
 	}
 
+	// 문제 수정 로직
+	public void update(User creator, Category category, String title, String description, String difficulty,
+		int score, String memoryLimit, int timeLimit, Reference reference) {
+
+		this.creator = creator;
+		this.category = category;
+		this.title = title;
+		this.description = description;
+		this.difficulty = difficulty;
+		this.score = score;
+		this.memoryLimit = memoryLimit;
+		this.timeLimit = timeLimit;
+		this.reference = reference;
+	}
 	// problem id 받아서 problem 반환
 	// problem 받아서 testcase 반환 domainService
 }

--- a/src/main/java/org/ezcode/codetest/domain/problem/model/enums/Difficulty.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/model/enums/Difficulty.java
@@ -1,5 +1,22 @@
 package org.ezcode.codetest.domain.problem.model.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum Difficulty {
-	BRONZE, SILVER, GOLD, PLATINUM, DIAMOND
+	BRONZE("브론즈", 20),
+	SILVER("실버", 40),
+	GOLD("골드", 60),
+	PLATINUM("플래티넘", 80),
+	DIAMOND("다이아", 100);
+
+	private final String difficulty;
+
+	private final int score;
+
+	Difficulty(String difficulty, int score) {
+		this.difficulty = difficulty;
+		this.score = score;
+	}
+
 }

--- a/src/main/java/org/ezcode/codetest/domain/problem/repository/ProblemImageRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/repository/ProblemImageRepository.java
@@ -1,0 +1,4 @@
+package org.ezcode.codetest.domain.problem.repository;
+
+public interface ProblemImageRepository {
+}

--- a/src/main/java/org/ezcode/codetest/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/repository/ProblemRepository.java
@@ -11,13 +11,13 @@ public interface ProblemRepository {
 
 	Problem save(Problem problem);
 
-	Optional<Problem> findById(Long id);
+	Optional<Problem> findById(Long problemId);
 
 	Page<Problem> findByCategory(Category category, Pageable pageable);
 
 	Page<Problem> findAll(Pageable pageable);
 
-	Problem findByIdOrElseThrow(Long id);
+	Problem findByIdOrElseThrow(Long problemId);
 
 	Problem delete(Problem problem);
 

--- a/src/main/java/org/ezcode/codetest/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/repository/ProblemRepository.java
@@ -15,7 +15,7 @@ public interface ProblemRepository {
 
 	Page<Problem> findByIsDeletedIsFalse(Pageable pageable);
 
-	Optional<Problem> findById(Long problemId);
+	Optional<Problem> findByIdNotDeleted(Long problemId);
 
 	void delete(Problem problem);
 

--- a/src/main/java/org/ezcode/codetest/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/repository/ProblemRepository.java
@@ -11,14 +11,12 @@ public interface ProblemRepository {
 
 	Problem save(Problem problem);
 
-	Optional<Problem> findById(Long problemId);
-
 	Page<Problem> findByCategoryAndIsDeletedIsFalse(Category category, Pageable pageable);
 
 	Page<Problem> findByIsDeletedIsFalse(Pageable pageable);
 
-	Problem findByIdOrElseThrow(Long problemId);
+	Optional<Problem> findById(Long problemId);
 
-	Problem delete(Problem problem);
+	void delete(Problem problem);
 
 }

--- a/src/main/java/org/ezcode/codetest/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/repository/ProblemRepository.java
@@ -13,9 +13,9 @@ public interface ProblemRepository {
 
 	Optional<Problem> findById(Long problemId);
 
-	Page<Problem> findByCategory(Category category, Pageable pageable);
+	Page<Problem> findByCategoryAndIsDeletedIsFalse(Category category, Pageable pageable);
 
-	Page<Problem> findAll(Pageable pageable);
+	Page<Problem> findByIsDeletedIsFalse(Pageable pageable);
 
 	Problem findByIdOrElseThrow(Long problemId);
 

--- a/src/main/java/org/ezcode/codetest/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/repository/ProblemRepository.java
@@ -1,11 +1,22 @@
-package org.ezcode.codetest.infrastructure.persitence.repository.problem;
+package org.ezcode.codetest.domain.problem.repository;
+
+import java.util.Optional;
 
 import org.ezcode.codetest.domain.problem.model.entity.Problem;
 import org.ezcode.codetest.domain.problem.model.enums.Category;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProblemJpaRepository extends JpaRepository<Problem, Long> {
+public interface ProblemRepository {
+
+	Problem save(Problem problem);
+
+	Optional<Problem> findById(Long id);
+
 	Page<Problem> findAllByCategory(Category category, Pageable pageable);
+
+	Problem findByIdOrElseThrow(Long id);
+
+	Problem delete(Problem problem);
+
 }

--- a/src/main/java/org/ezcode/codetest/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/repository/ProblemRepository.java
@@ -13,7 +13,9 @@ public interface ProblemRepository {
 
 	Optional<Problem> findById(Long id);
 
-	Page<Problem> findAllByCategory(Category category, Pageable pageable);
+	Page<Problem> findByCategory(Category category, Pageable pageable);
+
+	Page<Problem> findAll(Pageable pageable);
 
 	Problem findByIdOrElseThrow(Long id);
 

--- a/src/main/java/org/ezcode/codetest/domain/problem/repository/TestcaseRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/repository/TestcaseRepository.java
@@ -1,0 +1,4 @@
+package org.ezcode.codetest.domain.problem.repository;
+
+public interface TestcaseRepository {
+}

--- a/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
@@ -12,7 +12,7 @@ public class ProblemDomainService {
 
 	private final ProblemRepository problemRepository;
 
-	public Problem createProblem(Problem problem) {
+	public Problem saveProblem(Problem problem) {
 		return problemRepository.save(problem);
 	}
 

--- a/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
@@ -15,23 +15,23 @@ public class ProblemDomainService {
 
 	private final ProblemRepository problemRepository;
 
-	public Problem saveProblem(Problem problem) {
+	public Problem createProblem(Problem problem) {
 		return problemRepository.save(problem);
 	}
 
-	public Page<Problem> findByCategory(Category category, Pageable pageable) {
+	public Page<Problem> getProblemsByCategoryList(Category category, Pageable pageable) {
 		if (category == null) {
 			return problemRepository.findAll(pageable); // 전체 조회
 		}
 		return problemRepository.findByCategory(category, pageable);
 	}
 
-	public Page<Problem> findAll(Pageable pageable) {
+	public Page<Problem> getProblemsList(Pageable pageable) {
 
 		return problemRepository.findAll(pageable);
 	}
 
-	public Problem findByIdOrElseThrow(Long problemId) {
+	public Problem getProblem(Long problemId) {
 
 		return problemRepository.findByIdOrElseThrow(problemId);
 	}

--- a/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
@@ -38,7 +38,6 @@ public class ProblemDomainService {
 			.orElseThrow(() -> new EntityNotFoundException("문제를 찾을수 없습니다."));
 	}
 
-	// 하드 삭제
 	public void removeProblem(Problem problem) {
 
 		problemRepository.delete(problem);

--- a/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
@@ -21,9 +21,7 @@ public class ProblemDomainService {
 	}
 
 	public Page<Problem> getProblemsByCategoryList(Category category, Pageable pageable) {
-		if (category == null) {
-			return problemRepository.findByIsDeletedIsFalse(pageable); // 전체 조회
-		}
+
 		return problemRepository.findByCategoryAndIsDeletedIsFalse(category, pageable);
 	}
 
@@ -34,12 +32,13 @@ public class ProblemDomainService {
 
 	public Problem getProblem(Long problemId) {
 
-		return problemRepository.findById(problemId)
+		return problemRepository.findByIdNotDeleted(problemId)
 			.orElseThrow(() -> new EntityNotFoundException("문제를 찾을수 없습니다."));
 	}
 
 	public void removeProblem(Problem problem) {
 
 		problemRepository.delete(problem);
+
 	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
@@ -22,19 +22,25 @@ public class ProblemDomainService {
 
 	public Page<Problem> getProblemsByCategoryList(Category category, Pageable pageable) {
 		if (category == null) {
-			return problemRepository.findAll(pageable); // 전체 조회
+			return problemRepository.findByIsDeletedIsFalse(pageable); // 전체 조회
 		}
-		return problemRepository.findByCategory(category, pageable);
+		return problemRepository.findByCategoryAndIsDeletedIsFalse(category, pageable);
 	}
 
 	public Page<Problem> getProblemsList(Pageable pageable) {
 
-		return problemRepository.findAll(pageable);
+		return problemRepository.findByIsDeletedIsFalse(pageable);
 	}
 
 	public Problem getProblem(Long problemId) {
 
 		return problemRepository.findById(problemId)
 			.orElseThrow(() -> new EntityNotFoundException("문제를 찾을수 없습니다."));
+	}
+
+	// 하드 삭제
+	public void removeProblem(Problem problem) {
+
+		problemRepository.delete(problem);
 	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
@@ -31,8 +31,8 @@ public class ProblemDomainService {
 		return problemRepository.findAll(pageable);
 	}
 
-	public Problem findByIdOrElseThrow(Long id) {
+	public Problem findByIdOrElseThrow(Long problemId) {
 
-		return problemRepository.findByIdOrElseThrow(id);
+		return problemRepository.findByIdOrElseThrow(problemId);
 	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
@@ -1,7 +1,10 @@
 package org.ezcode.codetest.domain.problem.service;
 
 import org.ezcode.codetest.domain.problem.model.entity.Problem;
+import org.ezcode.codetest.domain.problem.model.enums.Category;
 import org.ezcode.codetest.domain.problem.repository.ProblemRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -16,6 +19,20 @@ public class ProblemDomainService {
 		return problemRepository.save(problem);
 	}
 
+	public Page<Problem> findByCategory(Category category, Pageable pageable) {
+		if (category == null) {
+			return problemRepository.findAll(pageable); // 전체 조회
+		}
+		return problemRepository.findByCategory(category, pageable);
+	}
 
+	public Page<Problem> findAll(Pageable pageable) {
 
+		return problemRepository.findAll(pageable);
+	}
+
+	public Problem findByIdOrElseThrow(Long id) {
+
+		return problemRepository.findByIdOrElseThrow(id);
+	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -33,6 +34,7 @@ public class ProblemDomainService {
 
 	public Problem getProblem(Long problemId) {
 
-		return problemRepository.findByIdOrElseThrow(problemId);
+		return problemRepository.findById(problemId)
+			.orElseThrow(() -> new EntityNotFoundException("문제를 찾을수 없습니다."));
 	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
@@ -1,8 +1,21 @@
 package org.ezcode.codetest.domain.problem.service;
 
+import org.ezcode.codetest.domain.problem.model.entity.Problem;
+import org.ezcode.codetest.domain.problem.repository.ProblemRepository;
 import org.springframework.stereotype.Service;
 
+import lombok.RequiredArgsConstructor;
+
 @Service
+@RequiredArgsConstructor
 public class ProblemDomainService {
+
+	private final ProblemRepository problemRepository;
+
+	public Problem createProblem(Problem problem) {
+		return problemRepository.save(problem);
+	}
+
+
 
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/persitence/repository/problem/ProblemJpaRepository.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persitence/repository/problem/ProblemJpaRepository.java
@@ -8,5 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProblemJpaRepository extends JpaRepository<Problem, Long> {
 
-	Page<Problem> findByCategory(Category category, Pageable pageable);
+	Page<Problem> findByCategoryAndIsDeletedIsFalse(Category category, Pageable pageable);
+
+	Page<Problem> findByIsDeletedIsFalse(Pageable pageable);
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/persitence/repository/problem/ProblemJpaRepository.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persitence/repository/problem/ProblemJpaRepository.java
@@ -1,14 +1,20 @@
 package org.ezcode.codetest.infrastructure.persitence.repository.problem;
 
+import java.util.Optional;
+
 import org.ezcode.codetest.domain.problem.model.entity.Problem;
 import org.ezcode.codetest.domain.problem.model.enums.Category;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ProblemJpaRepository extends JpaRepository<Problem, Long> {
 
 	Page<Problem> findByCategoryAndIsDeletedIsFalse(Category category, Pageable pageable);
 
 	Page<Problem> findByIsDeletedIsFalse(Pageable pageable);
+
+	@Query("SELECT p FROM Problem p WHERE p.isDeleted = false AND p.id = :problemId")
+	Optional<Problem> findByIdNotDeleted(Long problemId);
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/persitence/repository/problem/ProblemJpaRepository.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persitence/repository/problem/ProblemJpaRepository.java
@@ -17,4 +17,5 @@ public interface ProblemJpaRepository extends JpaRepository<Problem, Long> {
 
 	@Query("SELECT p FROM Problem p WHERE p.isDeleted = false AND p.id = :problemId")
 	Optional<Problem> findByIdNotDeleted(Long problemId);
+
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/persitence/repository/problem/ProblemJpaRepository.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persitence/repository/problem/ProblemJpaRepository.java
@@ -7,5 +7,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProblemJpaRepository extends JpaRepository<Problem, Long> {
-	Page<Problem> findAllByCategory(Category category, Pageable pageable);
+
+	Page<Problem> findByCategory(Category category, Pageable pageable);
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/persitence/repository/problem/ProblemRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persitence/repository/problem/ProblemRepositoryImpl.java
@@ -23,8 +23,8 @@ public class ProblemRepositoryImpl implements ProblemRepository {
 	}
 
 	@Override
-	public Optional<Problem> findById(Long id) {
-		return problemJpaRepository.findById(id);
+	public Optional<Problem> findById(Long problemId) {
+		return problemJpaRepository.findById(problemId);
 	}
 
 	@Override
@@ -38,8 +38,8 @@ public class ProblemRepositoryImpl implements ProblemRepository {
 	}
 
 	@Override
-	public Problem findByIdOrElseThrow(Long id) {
-		return problemJpaRepository.findById(id).orElseThrow();
+	public Problem findByIdOrElseThrow(Long problemId) {
+		return problemJpaRepository.findById(problemId).orElseThrow();
 	}
 
 	@Override

--- a/src/main/java/org/ezcode/codetest/infrastructure/persitence/repository/problem/ProblemRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persitence/repository/problem/ProblemRepositoryImpl.java
@@ -28,13 +28,13 @@ public class ProblemRepositoryImpl implements ProblemRepository {
 	}
 
 	@Override
-	public Page<Problem> findByCategory(Category category, Pageable pageable) {
-		return problemJpaRepository.findByCategory(category, pageable);
+	public Page<Problem> findByCategoryAndIsDeletedIsFalse(Category category, Pageable pageable) {
+		return problemJpaRepository.findByCategoryAndIsDeletedIsFalse(category, pageable);
 	}
 
 	@Override
-	public Page<Problem> findAll(Pageable pageable) {
-		return problemJpaRepository.findAll(pageable);
+	public Page<Problem> findByIsDeletedIsFalse(Pageable pageable) {
+		return problemJpaRepository.findByIsDeletedIsFalse(pageable);
 	}
 
 	@Override

--- a/src/main/java/org/ezcode/codetest/infrastructure/persitence/repository/problem/ProblemRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persitence/repository/problem/ProblemRepositoryImpl.java
@@ -28,8 +28,13 @@ public class ProblemRepositoryImpl implements ProblemRepository {
 	}
 
 	@Override
-	public Page<Problem> findAllByCategory(Category category, Pageable pageable) {
-		return problemJpaRepository.findAllByCategory(category, pageable);
+	public Page<Problem> findByCategory(Category category, Pageable pageable) {
+		return problemJpaRepository.findByCategory(category, pageable);
+	}
+
+	@Override
+	public Page<Problem> findAll(Pageable pageable) {
+		return problemJpaRepository.findAll(pageable);
 	}
 
 	@Override

--- a/src/main/java/org/ezcode/codetest/infrastructure/persitence/repository/problem/ProblemRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persitence/repository/problem/ProblemRepositoryImpl.java
@@ -33,14 +33,13 @@ public class ProblemRepositoryImpl implements ProblemRepository {
 	}
 
 	@Override
-	public Optional<Problem> findById(Long problemId) {
+	public Optional<Problem> findByIdNotDeleted(Long problemId) {
 		return problemJpaRepository.findByIdNotDeleted(problemId);
 	}
 
 	@Override
 	public void delete(Problem problem) {
 
-		problemJpaRepository.delete(problem);
-
+		problem.softDelete();
 	}
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/persitence/repository/problem/ProblemRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persitence/repository/problem/ProblemRepositoryImpl.java
@@ -1,0 +1,47 @@
+package org.ezcode.codetest.infrastructure.persitence.repository.problem;
+
+import java.util.Optional;
+
+import org.ezcode.codetest.domain.problem.model.enums.Category;
+import org.ezcode.codetest.domain.problem.repository.ProblemRepository;
+import org.ezcode.codetest.domain.problem.model.entity.Problem;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ProblemRepositoryImpl implements ProblemRepository {
+
+	private final ProblemJpaRepository problemJpaRepository;
+
+	@Override
+	public Problem save(Problem problem) {
+		return problemJpaRepository.save(problem);
+	}
+
+	@Override
+	public Optional<Problem> findById(Long id) {
+		return problemJpaRepository.findById(id);
+	}
+
+	@Override
+	public Page<Problem> findAllByCategory(Category category, Pageable pageable) {
+		return problemJpaRepository.findAllByCategory(category, pageable);
+	}
+
+	@Override
+	public Problem findByIdOrElseThrow(Long id) {
+		return problemJpaRepository.findById(id).orElseThrow();
+	}
+
+	@Override
+	public Problem delete(Problem problem) {
+
+		problemJpaRepository.delete(problem);
+
+		return problem;
+	}
+}

--- a/src/main/java/org/ezcode/codetest/infrastructure/persitence/repository/problem/ProblemRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persitence/repository/problem/ProblemRepositoryImpl.java
@@ -23,11 +23,6 @@ public class ProblemRepositoryImpl implements ProblemRepository {
 	}
 
 	@Override
-	public Optional<Problem> findById(Long problemId) {
-		return problemJpaRepository.findById(problemId);
-	}
-
-	@Override
 	public Page<Problem> findByCategoryAndIsDeletedIsFalse(Category category, Pageable pageable) {
 		return problemJpaRepository.findByCategoryAndIsDeletedIsFalse(category, pageable);
 	}
@@ -38,15 +33,14 @@ public class ProblemRepositoryImpl implements ProblemRepository {
 	}
 
 	@Override
-	public Problem findByIdOrElseThrow(Long problemId) {
-		return problemJpaRepository.findById(problemId).orElseThrow();
+	public Optional<Problem> findById(Long problemId) {
+		return problemJpaRepository.findByIdNotDeleted(problemId);
 	}
 
 	@Override
-	public Problem delete(Problem problem) {
+	public void delete(Problem problem) {
 
 		problemJpaRepository.delete(problem);
 
-		return problem;
 	}
 }

--- a/src/main/java/org/ezcode/codetest/presentation/ProblemController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/ProblemController.java
@@ -1,4 +1,0 @@
-package org.ezcode.codetest.presentation;
-
-public class ProblemController {
-}

--- a/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemAdminController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemAdminController.java
@@ -25,8 +25,8 @@ public class ProblemAdminController {
 	public ResponseEntity<ProblemDetailResponse> createProblem(@Valid @RequestBody ProblemCreateRequest request) {
 
 		return ResponseEntity
-			.status(HttpStatus.CREATED)
-			.body(problemService.createProblem(request));
+				.status(HttpStatus.CREATED)
+				.body(problemService.createProblem(request));
 	}
 
 }

--- a/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemAdminController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemAdminController.java
@@ -1,11 +1,14 @@
 package org.ezcode.codetest.presentation.problemmanagement;
 
 import org.ezcode.codetest.application.problem.dto.request.ProblemCreateRequest;
+import org.ezcode.codetest.application.problem.dto.request.ProblemUpdateRequest;
 import org.ezcode.codetest.application.problem.dto.response.ProblemDetailResponse;
 import org.ezcode.codetest.application.problem.service.ProblemService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,4 +32,12 @@ public class ProblemAdminController {
 				.body(problemService.createProblem(request));
 	}
 
+	@PutMapping("/{problemId}")
+	public ResponseEntity<ProblemDetailResponse> modifyProblem(
+		@PathVariable Long problemId,
+		@Valid @RequestBody ProblemUpdateRequest request
+	) {
+
+		return ResponseEntity.status(HttpStatus.OK).body(problemService.modifyProblem(problemId, request));
+	}
 }

--- a/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemAdminController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemAdminController.java
@@ -4,6 +4,8 @@ import org.ezcode.codetest.application.problem.dto.request.ProblemCreateRequest;
 import org.ezcode.codetest.application.problem.dto.request.ProblemUpdateRequest;
 import org.ezcode.codetest.application.problem.dto.response.ProblemDetailResponse;
 import org.ezcode.codetest.application.problem.service.ProblemService;
+import org.ezcode.codetest.common.annotation.Auth;
+import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -26,11 +28,14 @@ public class ProblemAdminController {
 	private final ProblemService problemService;
 
 	@PostMapping
-	public ResponseEntity<ProblemDetailResponse> createProblem(@Valid @RequestBody ProblemCreateRequest request) {
+	public ResponseEntity<ProblemDetailResponse> createProblem(
+		@Valid @RequestBody ProblemCreateRequest request,
+		@Auth AuthUser user
+	) {
 
 		return ResponseEntity
 				.status(HttpStatus.CREATED)
-				.body(problemService.createProblem(request));
+				.body(problemService.createProblem(request,user));
 	}
 
 	@PutMapping("/{problemId}")

--- a/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemAdminController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemAdminController.java
@@ -6,6 +6,7 @@ import org.ezcode.codetest.application.problem.dto.response.ProblemDetailRespons
 import org.ezcode.codetest.application.problem.service.ProblemService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -19,11 +20,11 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/admin/problems")
 @RequiredArgsConstructor
+// @PreAuthorize("hasRole('ADMIN')") // 관리자만 가능
 public class ProblemAdminController {
 
 	private final ProblemService problemService;
 
-	// @PreAuthorize("hasRole('ADMIN')")
 	@PostMapping
 	public ResponseEntity<ProblemDetailResponse> createProblem(@Valid @RequestBody ProblemCreateRequest request) {
 
@@ -38,6 +39,18 @@ public class ProblemAdminController {
 		@Valid @RequestBody ProblemUpdateRequest request
 	) {
 
-		return ResponseEntity.status(HttpStatus.OK).body(problemService.modifyProblem(problemId, request));
+		return ResponseEntity
+				.status(HttpStatus.OK)
+				.body(problemService.modifyProblem(problemId, request));
+	}
+
+	@DeleteMapping("/{problemId}")
+	public ResponseEntity<Void> removeProblem(@PathVariable Long problemId) {
+
+		problemService.removeProblem(problemId);
+
+		return ResponseEntity
+				.noContent()
+				.build();
 	}
 }

--- a/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemAdminController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemAdminController.java
@@ -1,0 +1,32 @@
+package org.ezcode.codetest.presentation.problemmanagement;
+
+import org.ezcode.codetest.application.problem.dto.request.ProblemCreateRequest;
+import org.ezcode.codetest.application.problem.dto.response.ProblemDetailResponse;
+import org.ezcode.codetest.application.problem.service.ProblemService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/admin/problems")
+@RequiredArgsConstructor
+public class ProblemAdminController {
+
+	private final ProblemService problemService;
+
+	// @PreAuthorize("hasRole('ADMIN')")
+	@PostMapping
+	public ResponseEntity<ProblemDetailResponse> createProblem(@Valid @RequestBody ProblemCreateRequest request) {
+
+		return ResponseEntity
+			.status(HttpStatus.CREATED)
+			.body(problemService.createProblem(request));
+	}
+
+}

--- a/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemController.java
@@ -1,0 +1,13 @@
+package org.ezcode.codetest.presentation.problemmanagement;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/problems")
+@RequiredArgsConstructor
+public class ProblemController {
+
+}

--- a/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemController.java
@@ -1,5 +1,6 @@
 package org.ezcode.codetest.presentation.problemmanagement;
 
+import org.ezcode.codetest.application.problem.dto.response.ProblemDetailResponse;
 import org.ezcode.codetest.application.problem.dto.response.ProblemResponse;
 import org.ezcode.codetest.application.problem.service.ProblemService;
 import org.ezcode.codetest.domain.problem.model.enums.Category;
@@ -10,6 +11,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,5 +34,13 @@ public class ProblemController {
 		return ResponseEntity
 				.status(HttpStatus.OK)
 				.body(problemService.findAllByCategory(pageable, category));
+	}
+
+	@GetMapping("/{id}")
+	public ResponseEntity<ProblemDetailResponse> findByIdProblem(@PathVariable Long id) {
+
+		return ResponseEntity
+				.status(HttpStatus.OK)
+				.body(problemService.findByIdProblem(id));
 	}
 }

--- a/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemController.java
@@ -1,6 +1,17 @@
 package org.ezcode.codetest.presentation.problemmanagement;
 
+import org.ezcode.codetest.application.problem.dto.response.ProblemResponse;
+import org.ezcode.codetest.application.problem.service.ProblemService;
+import org.ezcode.codetest.domain.problem.model.enums.Category;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
@@ -10,4 +21,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ProblemController {
 
+	private final ProblemService problemService;
+
+	@GetMapping
+	public ResponseEntity<Page<ProblemResponse>> findAllProblems(
+		@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+		@RequestParam(required = false) Category category
+	) {
+
+		return ResponseEntity
+				.status(HttpStatus.OK)
+				.body(problemService.findAllByCategory(pageable, category));
+	}
 }

--- a/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemController.java
@@ -26,14 +26,14 @@ public class ProblemController {
 	private final ProblemService problemService;
 
 	@GetMapping
-	public ResponseEntity<Page<ProblemResponse>> findAllProblems(
+	public ResponseEntity<Page<ProblemResponse>> getProblemsList(
 		@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
 		@RequestParam(required = false) Category category
 	) {
 
 		return ResponseEntity
 				.status(HttpStatus.OK)
-				.body(problemService.findAllByCategory(pageable, category));
+				.body(problemService.getProblemsList(pageable, category));
 	}
 
 	@GetMapping("/{problemId}")
@@ -41,6 +41,6 @@ public class ProblemController {
 
 		return ResponseEntity
 				.status(HttpStatus.OK)
-				.body(problemService.findByIdProblem(problemId));
+				.body(problemService.getProblem(problemId));
 	}
 }

--- a/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemController.java
@@ -36,11 +36,11 @@ public class ProblemController {
 				.body(problemService.findAllByCategory(pageable, category));
 	}
 
-	@GetMapping("/{id}")
-	public ResponseEntity<ProblemDetailResponse> findByIdProblem(@PathVariable Long id) {
+	@GetMapping("/{problemId}")
+	public ResponseEntity<ProblemDetailResponse> findByIdProblem(@PathVariable Long problemId) {
 
 		return ResponseEntity
 				.status(HttpStatus.OK)
-				.body(problemService.findByIdProblem(id));
+				.body(problemService.findByIdProblem(problemId));
 	}
 }

--- a/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemController.java
@@ -37,7 +37,7 @@ public class ProblemController {
 	}
 
 	@GetMapping("/{problemId}")
-	public ResponseEntity<ProblemDetailResponse> findByIdProblem(@PathVariable Long problemId) {
+	public ResponseEntity<ProblemDetailResponse> getProblem(@PathVariable Long problemId) {
 
 		return ResponseEntity
 				.status(HttpStatus.OK)


### PR DESCRIPTION
## 작업 내용

1. 문제 등록

- 문제 등록시, 로그인한 유저만 등록 가능 ( 아직 관리자 X )

2. 문제 전체 조회 기능

- 페이징 처리, 삭제된 문제는 안보임
- 카테고리 필터적용 ( 해당하는 카테고리만 리스트에 출력, 없으면 전체 조회 )

3. 문제 상세 조회 기능
 
- 문제 없으면 예외처리 적용

4. 문제 수정 기능

-  DB에 저장된 문제를 찾아서 요청한 값에 맞춰 수정

5. 문제 삭제 기능

- 문제 삭제는 데이터에 남아야 하기 때문에 SoftDelete 처리
- true인 값은 조회 불가능

---

## 변경 사항

---

## 트러블 슈팅

---

## 해결해야 할 문제

- 기능은 동작하나, 아직 문제 등록, 수정, 삭제 기능은 관리자가 사용하게 처리되지 않음.
- 목록 조회시, 카테고리 Enum 필드만 검색됨 ( 정확히 입력해줘야 함 )
- 문제 이미지는 일단 후순위로 둠 ( 현재 없음 )
- 구현체 에서 update, delete 처리하기 ( 구현체 변경에 유연해지기 위함 )
- ProblemDomainService에서 ( 태익님 요구사항 )
![image](https://github.com/user-attachments/assets/847262da-ecac-4138-a00f-9e30b103869a)

---

## 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 문제 생성, 수정, 삭제를 위한 관리자용 REST API가 추가되었습니다.
    - 문제 목록 조회 및 단일 문제 상세 조회를 위한 사용자용 REST API가 추가되었습니다.
    - 문제 생성/수정/상세/목록 응답을 위한 데이터 전송 객체(DTO)가 도입되었습니다.
    - 문제 서비스 및 도메인 서비스가 구현되어 문제의 생성, 조회, 수정, 삭제를 지원합니다.
    - 문제 저장소 인터페이스 및 구현체가 도입되어 문제 데이터 관리가 강화되었습니다.
    - 난이도(enum)에 한글명과 점수 필드가 추가되어 난이도 표현이 개선되었습니다.
    - 문제 엔티티에 소프트 삭제 기능이 추가되었습니다.

- **리팩터**
    - 문제 엔티티의 일부 필드명 및 타입이 변경되었습니다.
    - 난이도 enum이 세분화되어 난이도와 점수를 포함하도록 개선되었습니다.

- **삭제**
    - 기존의 비어 있던 컨트롤러 및 저장소 인터페이스가 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->