### PR TITLE
feature : Spring Security 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    //implementation 'org.springframework.boot:spring-boot-starter-security'  <--- 스프링 시큐리티가 자동으로 인증 활성화 상태라 주석처리했습니다
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -57,7 +57,7 @@ dependencies {
 
     //Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    //testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // bcrypt
@@ -69,9 +69,14 @@ dependencies {
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
     //Mac에서 빌드시 필요한 의존성
-    //implementation 'io.netty:netty-resolver-dns-native-macos:4.1.121.Final:osx-aarch_64'
+    implementation 'io.netty:netty-resolver-dns-native-macos:4.1.121.Final:osx-aarch_64'
+
+    // actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 
+    //activemq
+    implementation 'org.apache.activemq:activemq-broker:6.1.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/auth/service/AuthService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/auth/service/AuthService.java
@@ -11,6 +11,7 @@ import org.ezcode.codetest.domain.user.model.entity.User;
 import org.ezcode.codetest.domain.user.service.UserDomainService;
 import org.springframework.stereotype.Service;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -80,5 +81,10 @@ public class AuthService {
 			loginUser.getTier());
 
 		return SigninResponse.from(bearToken);
+	}
+
+	public String logout(Long userId, HttpServletRequest request) {
+
+		return "로그아웃 성공";
 	}
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/security/config/SecurityConfig.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/security/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(authorizeRequests ->
 				authorizeRequests
-					.requestMatchers("/signin", "/signup", "/actuator/**").permitAll() //로그인, 회원가입은 인증 필요없음
+					.requestMatchers("/signin", "/signup", "/actuator/**", "/chatting", "/ws").permitAll() //로그인, 회원가입은 인증 필요없음
 					.requestMatchers("/admin/**").hasRole("ADMIN") //어드민 권한 필요 (문제 생성, 관리 등)
 					.anyRequest().authenticated() //나머지는 일반 인증
 			)

--- a/src/main/java/org/ezcode/codetest/infrastructure/security/config/SecurityConfig.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/security/config/SecurityConfig.java
@@ -1,0 +1,50 @@
+package org.ezcode.codetest.infrastructure.security.config;
+
+import org.ezcode.codetest.domain.user.model.enums.UserRole;
+import org.ezcode.codetest.infrastructure.security.jwt.JwtFilter;
+import org.ezcode.codetest.infrastructure.security.jwt.JwtUtilImpl;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+@EnableMethodSecurity(prePostEnabled = true)
+public class SecurityConfig {
+	private final JwtUtilImpl jwtUtil;
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		JwtFilter jwtFilter = new JwtFilter(jwtUtil);
+
+		return http
+			// CSRF, Form 로그인, HTTP Basic 인증 비활성화
+			.csrf(AbstractHttpConfigurer::disable)
+			.formLogin(AbstractHttpConfigurer::disable)
+			.httpBasic(AbstractHttpConfigurer::disable)
+			// JWT 사용을 위해 세션을 STATELESS로 설정 (세션 정보 저장 x)
+			.sessionManagement(session -> session
+				.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			)
+
+			//인증 URL 범위 설정
+			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests(authorizeRequests ->
+				authorizeRequests
+					.requestMatchers("/signin", "/signup", "/actuator/**").permitAll() //로그인, 회원가입은 인증 필요없음
+					.requestMatchers("/admin/**").hasRole("ADMIN") //어드민 권한 필요 (문제 생성, 관리 등)
+					.anyRequest().authenticated() //나머지는 일반 인증
+			)
+			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+			.build();
+	}
+}

--- a/src/main/java/org/ezcode/codetest/infrastructure/security/jwt/JwtFilter.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/security/jwt/JwtFilter.java
@@ -1,11 +1,18 @@
 package org.ezcode.codetest.infrastructure.security.jwt;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
 
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.ezcode.codetest.domain.user.model.enums.Tier;
 import org.ezcode.codetest.domain.user.model.enums.UserRole;
 import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.PatternMatchUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -27,13 +34,6 @@ public class JwtFilter extends OncePerRequestFilter {
 
 	private final JwtUtilImpl jwtUtilImpl;
 
-	private static final String[] WHITE_LIST = {
-		"/signin",
-		"/signup",
-		"/chatting",
-		"/ws"
-	};
-
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 									FilterChain filterChain) throws ServletException, IOException {
@@ -41,15 +41,7 @@ public class JwtFilter extends OncePerRequestFilter {
 		String bearerToken = request.getHeader("Authorization");
 		String url = request.getRequestURI();
 
-		if(isWhiteList(url)) {
-			filterChain.doFilter(request, response);
-			return;
-		}
-
 		if (bearerToken == null || !bearerToken.startsWith("Bearer ")) {
-			if (request.getRequestURI().startsWith("/admin")){
-				response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "관리자 기능은 인증이 필요합니다");
-			}
 			filterChain.doFilter(request, response);
 			return;
 		}
@@ -83,14 +75,23 @@ public class JwtFilter extends OncePerRequestFilter {
 				tier
 			);
 
-			log.info("authUserEmail: {}, authUserID : {}", authUser.getEmail(), authUser.getId());
-
 			request.setAttribute("authUser", authUser);
 			request.setAttribute("userId", Long.parseLong(claims.getSubject()));
 			request.setAttribute("email", claims.get("email"));
 			request.setAttribute("userRole", claims.get("userRole"));
 			request.setAttribute("username", claims.get("username"));
 			request.setAttribute("nickname", claims.get("nickname"));
+
+			// 인가를 위한 권한 정보 저장
+			Collection<? extends GrantedAuthority> authorities =
+				List.of(new SimpleGrantedAuthority(authUser.getRole().toString()));
+
+			// Spring Security 인증 토큰 생성
+			Authentication authToken = new UsernamePasswordAuthenticationToken(authUser,
+				null, authorities);
+
+			// SecurityContextHolder(세션)에 토큰 담기
+			SecurityContextHolder.getContext().setAuthentication(authToken);
 
 
 			filterChain.doFilter(request, response);
@@ -109,7 +110,4 @@ public class JwtFilter extends OncePerRequestFilter {
 		}
 	}
 
-	private boolean isWhiteList(String requestURI) {
-		return PatternMatchUtils.simpleMatch(WHITE_LIST, requestURI);
-	}
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/security/jwt/JwtUtilImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/security/jwt/JwtUtilImpl.java
@@ -43,7 +43,7 @@ public class JwtUtilImpl implements JwtUtil {
 		}
 
 		Date date = new Date();
-		log.info("토큰 생성 시작");
+		log.info("-----------jwtUtil 토큰 생성 시작---------------");
 
 		return BEARER_PREFIX +
 			Jwts.builder()

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/AuthController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/AuthController.java
@@ -5,16 +5,20 @@ import org.ezcode.codetest.application.usermanagement.auth.dto.signin.SigninResp
 import org.ezcode.codetest.application.usermanagement.auth.dto.signup.SignupRequest;
 import org.ezcode.codetest.application.usermanagement.auth.dto.signup.SignupResponse;
 import org.ezcode.codetest.application.usermanagement.auth.service.AuthService;
+import org.ezcode.codetest.common.annotation.Auth;
+import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class AuthController {
@@ -28,5 +32,12 @@ public class AuthController {
 	@PostMapping("/signin")
 	public ResponseEntity<SigninResponse> signin(@Valid @RequestBody SigninRequest signinRequest) {
 		return ResponseEntity.status(HttpStatus.OK).body(authService.signin(signinRequest));
+	}
+
+	@PostMapping("/logout")
+	public ResponseEntity<String> logout(
+			@Auth AuthUser authUser,
+			HttpServletRequest request) {
+		return ResponseEntity.status(HttpStatus.OK).body(authService.logout(authUser.getId(), request));
 	}
 }

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/resolver/AuthUserArgumentResolver.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/resolver/AuthUserArgumentResolver.java
@@ -34,6 +34,7 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
 			NativeWebRequest webRequest,
 			 WebDataBinderFactory webDataBinderFactory
 	){
+		log.info("--------------------AuthUserArgumentResolver 진입-----------------");
 		HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
 
 		AuthUser authUser = (AuthUser) request.getAttribute("authUser");


### PR DESCRIPTION
## 작업 내용
- 기존 Jwt인증 -> Sprinf Security 적용

---

## 변경 사항
- **`SecurityConfig` 클래스 추가**
  -> signin, signup, actuator 는 인증 없이 사용 가능
  -> admin 으로 시작하는 URL은 ADMIN 권한 필요
- 의존성 추가
-> actuator, activemq(의존성이 없으니 오류나서 추가했습니다!)

---

## 참고 사항
- "/chatting", "/ws"도 기존 whiteList에 저장되어있었는데, 우선 security에도 추가해주었습니다. 

---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 로그아웃 엔드포인트가 추가되어 사용자가 로그아웃할 수 있습니다.
    - Spring Security 기반 인증 및 권한 관리가 도입되었습니다.
    - 애플리케이션 모니터링을 위한 Actuator와 메시징 기능을 위한 ActiveMQ가 추가되었습니다.
- **버그 수정**
    - JWT 인증 처리 시 Spring Security와의 연동이 개선되어 권한 기반 접근 제어가 강화되었습니다.
- **문서화**
    - 주요 인증 관련 클래스에 로그가 추가되어 진입 시점 확인이 용이해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->