### PR TITLE
feat : 채팅 도배 방지 시스템 추가(Redis 기반)

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/chatting/port/session/ChattingLimitService.java
+++ b/src/main/java/org/ezcode/codetest/application/chatting/port/session/ChattingLimitService.java
@@ -1,0 +1,11 @@
+package org.ezcode.codetest.application.chatting.port.session;
+
+public interface ChattingLimitService {
+
+	Long increaseChatCount(String email);
+
+	void applyChatBlock(String email);
+
+	Boolean isBlocked(String email);
+
+}

--- a/src/main/java/org/ezcode/codetest/application/chatting/port/session/SessionChangedEvent.java
+++ b/src/main/java/org/ezcode/codetest/application/chatting/port/session/SessionChangedEvent.java
@@ -1,9 +1,9 @@
-package org.ezcode.codetest.application.chatting.port.event;
+package org.ezcode.codetest.application.chatting.port.session;
 
 import lombok.Builder;
 
 @Builder
-public record ChatRoomChange(
+public record SessionChangedEvent(
 
 	Long roomId,
 

--- a/src/main/java/org/ezcode/codetest/application/chatting/service/ChatSpamPreventionService.java
+++ b/src/main/java/org/ezcode/codetest/application/chatting/service/ChatSpamPreventionService.java
@@ -1,0 +1,32 @@
+package org.ezcode.codetest.application.chatting.service;
+
+import org.ezcode.codetest.application.chatting.port.event.ChattingMessageService;
+import org.ezcode.codetest.application.chatting.port.session.ChattingLimitService;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ChatSpamPreventionService {
+
+	private final ChattingLimitService limitService;
+	private final ChattingMessageService messageService;
+
+	public Boolean isChatBlocked(String email) {
+
+		return limitService.isBlocked(email);
+	}
+
+	public void applyChatBlock(String email, String nickName, Long roomId) {
+
+		limitService.applyChatBlock(email);
+
+		messageService.handleBroadCastChat(nickName + " 님께서 지나친 도배로 30초 동안 차단되었습니다.", roomId);
+	}
+
+	public Long countChatsInLast10Seconds(String email) {
+
+		return limitService.increaseChatCount(email);
+	}
+}

--- a/src/main/java/org/ezcode/codetest/application/chatting/service/ChattingUseCase.java
+++ b/src/main/java/org/ezcode/codetest/application/chatting/service/ChattingUseCase.java
@@ -11,7 +11,7 @@ import org.ezcode.codetest.application.chatting.dto.response.ChatRoomResponse;
 import org.ezcode.codetest.application.chatting.port.cache.ChatRoomCacheService;
 import org.ezcode.codetest.application.chatting.port.event.ChattingMessageService;
 import org.ezcode.codetest.application.chatting.port.session.ChattingSessionService;
-import org.ezcode.codetest.application.chatting.port.event.ChatRoomChange;
+import org.ezcode.codetest.application.chatting.port.session.SessionChangedEvent;
 import org.ezcode.codetest.application.chatting.port.cache.ChatRoomCache;
 import org.ezcode.codetest.domain.chat.model.Chat;
 import org.ezcode.codetest.domain.chat.model.ChatRoom;
@@ -42,7 +42,7 @@ public class ChattingUseCase {
 
 		cacheService.addChatRoomToCache(ChatRoomCache.from(savedRoom));
 
-		messageService.handleRoomChangeEvent(ChatRoomChange.builder()
+		messageService.handleRoomChangeEvent(SessionChangedEvent.builder()
 			.roomId(savedRoom.getId())
 			.headCount(0L)
 			.title(savedRoom.getTitle())
@@ -65,7 +65,7 @@ public class ChattingUseCase {
 
 		sessionService.removeRoom(request.roomId());
 
-		messageService.handleRoomChangeEvent(ChatRoomChange.builder()
+		messageService.handleRoomChangeEvent(SessionChangedEvent.builder()
 			.roomId(removedRoom.getId())
 			.title(removedRoom.getTitle())
 			.headCount(0L)
@@ -118,13 +118,13 @@ public class ChattingUseCase {
 
 		ChatRoom chatRoom = chattingDomainService.getChatRoom(roomId);
 
-		Long headCount = sessionService.addSession(sessionId, roomId);
-
 		List<ChatResponse> chatLists = chattingDomainService
 			.getRoomChatting(roomId)
 			.stream()
 			.map(ChatResponse::from)
 			.toList();
+
+		Long headCount = sessionService.addSession(sessionId, roomId);
 
 		messageService.handleRoomEnter(chatLists, principalName);
 

--- a/src/main/java/org/ezcode/codetest/application/chatting/service/ChattingUseCase.java
+++ b/src/main/java/org/ezcode/codetest/application/chatting/service/ChattingUseCase.java
@@ -156,5 +156,4 @@ public class ChattingUseCase {
 			.headCount(roomData.get("headCount"))
 			.build());
 	}
-
 }

--- a/src/main/java/org/ezcode/codetest/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/ezcode/codetest/common/advice/GlobalExceptionHandler.java
@@ -1,7 +1,39 @@
 package org.ezcode.codetest.common.advice;
 
+import org.ezcode.codetest.common.base.exception.BaseException;
+import org.ezcode.codetest.common.dto.CommonResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<CommonResponse<Void>> handleMethodArgumentNotValidException(
+		MethodArgumentNotValidException e,
+		HttpServletRequest request
+	) {
+		String errorMessage = e.getBindingResult().getFieldErrors().stream()
+			.findFirst()
+			.map(FieldError::getDefaultMessage)
+			.orElse("잘못된 요청입니다.");
+
+		return ResponseEntity
+			.badRequest()
+			.body(CommonResponse.of(false, errorMessage, 400, null));
+	}
+
+	@ExceptionHandler(BaseException.class)
+	public ResponseEntity<CommonResponse<Void>> handleBaseException(
+		BaseException e
+	) {
+		return ResponseEntity
+			.status(e.getHttpStatus())
+			.body(CommonResponse.from(e.getResponseCode()));
+	}
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/event/listener/WebSocketEventListener.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/event/listener/WebSocketEventListener.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import org.ezcode.codetest.domain.chat.model.ChatRoom;
 import org.ezcode.codetest.domain.chat.service.ChattingDomainService;
 import org.ezcode.codetest.infrastructure.event.service.StompMessageService;
-import org.ezcode.codetest.infrastructure.session.service.RedisSessionService;
+import org.ezcode.codetest.infrastructure.session.service.RedisSessionCountService;
 import org.springframework.context.ApplicationListener;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 public class WebSocketEventListener implements ApplicationListener<SessionDisconnectEvent> {
 
 	private final StompMessageService messageService;
-	private final RedisSessionService sessionService;
+	private final RedisSessionCountService sessionService;
 	private final ChattingDomainService chattingDomainService;
 
 	@Override

--- a/src/main/java/org/ezcode/codetest/infrastructure/security/config/SecurityConfig.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/security/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(authorizeRequests ->
 				authorizeRequests
-					.requestMatchers("/signin", "/signup", "/actuator/**", "/chatting", "/ws").permitAll() //로그인, 회원가입은 인증 필요없음
+					.requestMatchers("/signin", "/signup", "/actuator/**", "/chatting", "/ws/**").permitAll() //로그인, 회원가입은 인증 필요없음
 					.requestMatchers("/admin/**").hasRole("ADMIN") //어드민 권한 필요 (문제 생성, 관리 등)
 					.anyRequest().authenticated() //나머지는 일반 인증
 			)

--- a/src/main/java/org/ezcode/codetest/infrastructure/session/constant/RedisKeyConstants.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/session/constant/RedisKeyConstants.java
@@ -1,0 +1,19 @@
+package org.ezcode.codetest.infrastructure.session.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RedisKeyConstants {
+
+	public static final String CHAT_COUNT_KEY_PREFIX = "session:chat:count:";
+	public static final String BLOCKED_SESSION_KEY_PREFIX = "session:blocked:";
+
+	public static final String CHATROOM_KEY_PREFIX = "chatroom:";
+	public static final String SESSION_KEY_PREFIX = "session:";
+	public static final String ROOM_COUNT_KEY_PREFIX = "roomCount:";
+
+	public static final long CHAT_COUNT_TTL = 10L;
+	public static final long BLOCKED_SESSION_TTL = 30L;
+
+}

--- a/src/main/java/org/ezcode/codetest/infrastructure/session/service/RedisChatLimitService.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/session/service/RedisChatLimitService.java
@@ -1,0 +1,53 @@
+package org.ezcode.codetest.infrastructure.session.service;
+
+import java.time.Duration;
+
+import org.ezcode.codetest.application.chatting.port.session.ChattingLimitService;
+import org.ezcode.codetest.infrastructure.session.constant.RedisKeyConstants;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RedisChatLimitService implements ChattingLimitService {
+
+	private final RedisTemplate<String, Long> redisTemplate;
+
+	public Long increaseChatCount(String email) {
+
+		String sessionKey = RedisKeyConstants.CHAT_COUNT_KEY_PREFIX + email;
+
+		Long count = redisTemplate.opsForValue().increment(sessionKey);
+
+		if (count != null && count == 1L) {
+			redisTemplate.expire(
+				sessionKey,
+				Duration.ofSeconds(RedisKeyConstants.CHAT_COUNT_TTL)
+			);
+		}
+
+		return count;
+	}
+
+	public void applyChatBlock(String email) {
+
+		String sessionKey = RedisKeyConstants.BLOCKED_SESSION_KEY_PREFIX + email;
+
+		redisTemplate.opsForValue().set(
+			sessionKey,
+			1L,
+			Duration.ofSeconds(RedisKeyConstants.BLOCKED_SESSION_TTL)
+		);
+	}
+
+	public Boolean isBlocked(String email) {
+
+		String sessionKey = RedisKeyConstants.BLOCKED_SESSION_KEY_PREFIX + email;
+
+		Long isBlocked = redisTemplate.opsForValue().get(sessionKey);
+
+		return isBlocked != null;
+	}
+}

--- a/src/main/java/org/ezcode/codetest/infrastructure/session/service/RedisSessionCountService.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/session/service/RedisSessionCountService.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import org.ezcode.codetest.application.chatting.port.session.ChattingSessionService;
 import org.ezcode.codetest.domain.chat.exception.ChattingException;
 import org.ezcode.codetest.domain.chat.exception.ChattingExceptionCode;
+import org.ezcode.codetest.infrastructure.session.constant.RedisKeyConstants;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.data.redis.core.script.RedisScript;
@@ -19,12 +20,9 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class RedisSessionService implements ChattingSessionService {
+public class RedisSessionCountService implements ChattingSessionService {
 
 	private final RedisTemplate<String, Long> redisTemplate;
-	private static final String CHATROOM_KEY_PREFIX = "chatroom:";
-	private static final String SESSION_KEY_PREFIX = "session:";
-	private static final String ROOM_COUNT_KEY_PREFIX = "roomCount:";
 
 	private final RedisScript<Long> addSessionScript = new DefaultRedisScript<>(
 		"local roomId = ARGV[2]\n" +
@@ -73,9 +71,9 @@ public class RedisSessionService implements ChattingSessionService {
 	@Override
 	public Long addSession(String sessionId, Long roomId) {
 
-		String roomKey = CHATROOM_KEY_PREFIX + roomId;
-		String sessionKey = SESSION_KEY_PREFIX + sessionId;
-		String roomCountKey = ROOM_COUNT_KEY_PREFIX + roomId;
+		String roomKey = RedisKeyConstants.CHATROOM_KEY_PREFIX + roomId;
+		String sessionKey = RedisKeyConstants.SESSION_KEY_PREFIX + sessionId;
+		String roomCountKey = RedisKeyConstants.ROOM_COUNT_KEY_PREFIX + roomId;
 
 		List<String> keys = Arrays.asList(roomKey, sessionKey, roomCountKey);
 		Object[] args = new Object[] {sessionId, roomId.toString()};
@@ -90,8 +88,8 @@ public class RedisSessionService implements ChattingSessionService {
 
 	public Long removeRoom(Long roomId) {
 
-		String roomKey = CHATROOM_KEY_PREFIX + roomId;
-		String roomCountKey = ROOM_COUNT_KEY_PREFIX + roomId;
+		String roomKey = RedisKeyConstants.CHATROOM_KEY_PREFIX + roomId;
+		String roomCountKey = RedisKeyConstants.ROOM_COUNT_KEY_PREFIX + roomId;
 		List<String> keys = Arrays.asList(roomKey, roomCountKey);
 
 		Long deletedSessionCount = redisTemplate.execute(
@@ -105,7 +103,7 @@ public class RedisSessionService implements ChattingSessionService {
 	@Override
 	public Map<String, Long> removeSession(String sessionId) {
 
-		String sessionKey = SESSION_KEY_PREFIX + sessionId;
+		String sessionKey = RedisKeyConstants.SESSION_KEY_PREFIX + sessionId;
 
 		List<Long> result = redisTemplate.execute(
 			removeSessionScript,
@@ -134,7 +132,7 @@ public class RedisSessionService implements ChattingSessionService {
 	@Override
 	public Long viewSession(Long roomId) {
 
-		String roomCountKey = ROOM_COUNT_KEY_PREFIX + roomId;
+		String roomCountKey = RedisKeyConstants.ROOM_COUNT_KEY_PREFIX + roomId;
 
 		Long count = redisTemplate.opsForValue().get(roomCountKey);
 		return (count != null ? count : 0L);

--- a/src/main/java/org/ezcode/codetest/presentation/chattingmanagement/chatting/config/ChatWebConfig.java
+++ b/src/main/java/org/ezcode/codetest/presentation/chattingmanagement/chatting/config/ChatWebConfig.java
@@ -1,0 +1,21 @@
+package org.ezcode.codetest.presentation.chattingmanagement.chatting.config;
+
+import org.ezcode.codetest.presentation.chattingmanagement.chatting.interceptor.ChatLimitInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class ChatWebConfig implements WebMvcConfigurer {
+
+	private final ChatLimitInterceptor chatSpamInterceptor;
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(chatSpamInterceptor)
+			.addPathPatterns("/room/*/chat");
+	}
+}

--- a/src/main/java/org/ezcode/codetest/presentation/chattingmanagement/chatting/controller/ChatController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/chattingmanagement/chatting/controller/ChatController.java
@@ -1,9 +1,9 @@
-package org.ezcode.codetest.presentation.chattingmanagement.chatting;
+package org.ezcode.codetest.presentation.chattingmanagement.chatting.controller;
 
 import org.ezcode.codetest.application.chatting.dto.request.ChatSaveRequest;
 import org.ezcode.codetest.application.chatting.service.ChattingUseCase;
-import org.ezcode.codetest.common.annotation.Auth;
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,7 +23,7 @@ public class ChatController {
 	@PostMapping
 	@ResponseBody
 	public void createChat(
-		@Auth AuthUser authUser,
+		@AuthenticationPrincipal AuthUser authUser,
 		@PathVariable Long roomId,
 		@RequestBody ChatSaveRequest request
 	) {

--- a/src/main/java/org/ezcode/codetest/presentation/chattingmanagement/chatting/controller/ChatRoomController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/chattingmanagement/chatting/controller/ChatRoomController.java
@@ -1,13 +1,13 @@
-package org.ezcode.codetest.presentation.chattingmanagement.chatting;
+package org.ezcode.codetest.presentation.chattingmanagement.chatting.controller;
 
 import org.ezcode.codetest.application.chatting.dto.request.ChatRoomDeleteRequest;
 import org.ezcode.codetest.application.chatting.dto.request.ChatRoomSaveRequest;
 import org.ezcode.codetest.application.chatting.service.ChattingUseCase;
-import org.ezcode.codetest.common.annotation.Auth;
 import org.ezcode.codetest.common.annotation.ResponseMessage;
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,7 +27,7 @@ public class ChatRoomController {
 	@ResponseMessage("정상적으로 채팅방이 생성되었습니다.")
 	@PostMapping
 	public ResponseEntity<Void> createChatRoom(
-		@Auth AuthUser authUser,
+		@AuthenticationPrincipal AuthUser authUser,
 		@RequestBody @Validated ChatRoomSaveRequest request
 	) {
 		chatUseCase.createChatRoom(request, authUser.getEmail());
@@ -38,12 +38,11 @@ public class ChatRoomController {
 	@ResponseMessage("정상적으로 채팅방이 삭제되었습니다.")
 	@DeleteMapping
 	public ResponseEntity<Void> removeChatRoom(
-		@Auth AuthUser authUser,
+		@AuthenticationPrincipal AuthUser authUser,
 		@RequestBody @Validated ChatRoomDeleteRequest request
 	) {
 		chatUseCase.removeChatRoom(request, authUser.getEmail());
 
 		return ResponseEntity.status(HttpStatus.OK).build();
 	}
-
 }

--- a/src/main/java/org/ezcode/codetest/presentation/chattingmanagement/chatting/interceptor/ChatLimitInterceptor.java
+++ b/src/main/java/org/ezcode/codetest/presentation/chattingmanagement/chatting/interceptor/ChatLimitInterceptor.java
@@ -1,0 +1,67 @@
+package org.ezcode.codetest.presentation.chattingmanagement.chatting.interceptor;
+
+import java.util.Map;
+
+import org.ezcode.codetest.application.chatting.service.ChatSpamPreventionService;
+import org.ezcode.codetest.domain.user.model.entity.AuthUser;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ChatLimitInterceptor implements HandlerInterceptor {
+
+	private final ChatSpamPreventionService spamPreventionService;
+
+	@Override
+	public boolean preHandle(
+		@NonNull HttpServletRequest request,
+		@NonNull HttpServletResponse response,
+		@NonNull Object handler) throws Exception {
+
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication == null) return false;
+
+		Long roomId = extractRoomId(request);
+
+		AuthUser authUser = (AuthUser)authentication.getPrincipal();
+
+		String email = authUser.getEmail();
+		String nickName = authUser.getNickname();
+
+		if (spamPreventionService.isChatBlocked(email)) {
+			return false;
+		}
+
+		Long count = spamPreventionService.countChatsInLast10Seconds(email);
+
+		if (count >= 11L) {
+			spamPreventionService.applyChatBlock(email, nickName, roomId);
+			return false;
+		}
+
+		return true;
+	}
+
+	private Long extractRoomId(HttpServletRequest request) {
+
+		@SuppressWarnings("unchecked")
+		Map<String, String> pathVars =
+			(Map<String, String>)request.getAttribute(
+				HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+
+		String roomIdStr = pathVars.get("roomId");
+
+		return Long.parseLong(roomIdStr);
+	}
+}


### PR DESCRIPTION

## 작업 내용

- 글로벌 예외 처리 코드 추가
- 채팅 도배 방지 시스템 추가

![Honeycam 2025-06-03 15-07-55](https://github.com/user-attachments/assets/e1a5c269-d8b9-47db-9f53-ca69968e0355)


---

## 변경 사항

글로벌 예외 처리 코드가 추가되었습니다. 
커스텀 예외 처리시 랩핑 된 예외 메시지가 반환되게끔 변경되었습니다.
채팅 도배시스템이 추가되었습니다. Redis 기반으로 10초간 10개 이상 채팅을 보냈는지 확인하고
30초간 차단이 적용됩니다.



## 해결해야 할 문제

메소드  및 클래스 네이밍을 추후 좀 더 가독있게끔 변경이 필요해보입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 채팅 스팸 방지 및 차단 기능이 추가되었습니다. 사용자가 10초 내 11회 이상 채팅 시 30초간 채팅이 차단됩니다.
  - 채팅 요청 시 스팸 방지 인터셉터가 적용되어 과도한 채팅 시 자동 차단됩니다.

- **버그 수정**
  - 유효성 검사 및 커스텀 예외 발생 시 표준화된 에러 메시지와 상태 코드가 반환됩니다.

- **개선 사항**
  - WebSocket 엔드포인트 접근 권한이 "/ws/**" 전체로 확장되었습니다.
  - 인증 사용자 정보 주입 방식이 표준 Spring Security 방식으로 변경되었습니다.
  - 내부 키 관리 및 세션 관리가 일관성 있게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->