### PR TITLE
feature : 댓글, 대댓글 CRUD 구현

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/community/dto/request/ReplyCreateRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/community/dto/request/ReplyCreateRequest.java
@@ -1,0 +1,34 @@
+package org.ezcode.codetest.application.community.dto.request;
+
+import org.ezcode.codetest.domain.community.model.Discussion;
+import org.ezcode.codetest.domain.community.model.Reply;
+import org.ezcode.codetest.domain.user.model.entity.User;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ReplyCreateRequest(
+
+	// nullable
+	Long parentReplyId,
+
+	@NotBlank(message = "내용을 입력해야 합니다.")
+	@Size(max = 2000, message = "내용은 최대 2000자까지 허용됩니다.")
+	String content
+
+) {
+
+	public static Reply toEntity(
+		Discussion discussion,
+		User user,
+		Reply parent,
+		ReplyCreateRequest request
+	) {
+		return Reply.builder()
+			.discussion(discussion)
+			.user(user)
+			.parent(parent)
+			.content(request.content)
+			.build();
+	}
+}

--- a/src/main/java/org/ezcode/codetest/application/community/dto/request/ReplyModifyRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/community/dto/request/ReplyModifyRequest.java
@@ -1,0 +1,13 @@
+package org.ezcode.codetest.application.community.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ReplyModifyRequest(
+
+	@NotBlank(message = "내용을 입력해야 합니다.")
+	@Size(max = 2000, message = "내용은 최대 2000자까지 허용됩니다.")
+	String content
+
+) {
+}

--- a/src/main/java/org/ezcode/codetest/application/community/dto/response/ReplyResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/community/dto/response/ReplyResponse.java
@@ -1,0 +1,33 @@
+package org.ezcode.codetest.application.community.dto.response;
+
+import org.ezcode.codetest.application.usermanagement.user.dto.SimpleUserInfoResponse;
+import org.ezcode.codetest.domain.community.model.Reply;
+
+public record ReplyResponse(
+
+	Long replyId,
+
+	Long parentId,
+
+	Long discussionId,
+
+	SimpleUserInfoResponse userInfo,
+
+	String content
+
+) {
+
+	public static ReplyResponse fromEntity(Reply reply) {
+		Long parentId = (reply.getParent() != null)
+			? reply.getParent().getId()
+			: null;
+
+		return new ReplyResponse(
+			reply.getId(),
+			parentId,
+			reply.getDiscussion().getId(),
+			SimpleUserInfoResponse.fromEntity(reply.getUser()),
+			reply.getContent()
+		);
+	}
+}

--- a/src/main/java/org/ezcode/codetest/application/community/service/ReplyService.java
+++ b/src/main/java/org/ezcode/codetest/application/community/service/ReplyService.java
@@ -1,0 +1,108 @@
+package org.ezcode.codetest.application.community.service;
+
+import org.ezcode.codetest.application.community.dto.request.ReplyCreateRequest;
+import org.ezcode.codetest.application.community.dto.request.ReplyModifyRequest;
+import org.ezcode.codetest.application.community.dto.response.ReplyResponse;
+import org.ezcode.codetest.domain.community.model.Discussion;
+import org.ezcode.codetest.domain.community.model.Reply;
+import org.ezcode.codetest.domain.community.service.DiscussionDomainService;
+import org.ezcode.codetest.domain.community.service.ReplyDomainService;
+import org.ezcode.codetest.domain.user.model.entity.User;
+import org.ezcode.codetest.domain.user.service.UserDomainService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReplyService {
+
+	private final ReplyDomainService replyDomainService;
+
+	private final DiscussionDomainService discussionDomainService;
+	private final UserDomainService userDomainService;
+
+	@Transactional
+	public ReplyResponse createReply(
+		Long problemId,
+		Long discussionId,
+		ReplyCreateRequest request,
+		Long userId
+	) {
+
+		User user = userDomainService.getUserById(userId);
+		Discussion discussion = discussionDomainService.getDiscussionById(discussionId);
+
+		discussionDomainService.validateProblemMatches(discussion, problemId);
+
+		Reply parent = request.parentReplyId() == null
+			? null
+			: replyDomainService.getReplyById(request.parentReplyId());
+		Reply replyEntity = ReplyCreateRequest.toEntity(discussion, user, parent, request);
+
+		return ReplyResponse.fromEntity(replyDomainService.createReply(replyEntity));
+	}
+
+	@Transactional(readOnly = true)
+	public Page<ReplyResponse> getReplies(Long problemId, Long discussionId, Pageable pageable) {
+
+		Discussion discussion = discussionDomainService.getDiscussionById(discussionId);
+		discussionDomainService.validateProblemMatches(discussion, problemId);
+
+		Page<Reply> replies = replyDomainService.getRepliesByDiscussionId(discussion, pageable);
+		return replies.map(ReplyResponse::fromEntity);
+	}
+
+	@Transactional(readOnly = true)
+	public Page<ReplyResponse> getChildReplies(
+		Long problemId,
+		Long discussionId,
+		Long parentReplyId,
+		Pageable pageable
+	) {
+
+		Discussion discussion = discussionDomainService.getDiscussionById(discussionId);
+		discussionDomainService.validateProblemMatches(discussion, problemId);
+
+		Page<Reply> replies = replyDomainService.getRepliesByParentReplyId(parentReplyId, pageable);
+		return replies.map(ReplyResponse::fromEntity);
+	}
+
+	@Transactional
+	public ReplyResponse modifyReply(
+		Long problemId,
+		Long discussionId,
+		Long replyId,
+		ReplyModifyRequest request,
+		Long userId
+	) {
+
+		Discussion discussion = discussionDomainService.getDiscussionById(discussionId);
+		discussionDomainService.validateProblemMatches(discussion, problemId);
+
+		Reply reply = replyDomainService.getReplyById(replyId);
+		replyDomainService.validateDiscussionMatches(reply, discussion);
+		replyDomainService.validateIsAuthor(reply, userId);
+
+		replyDomainService.modify(reply, request.content());
+
+		return ReplyResponse.fromEntity(reply);
+	}
+
+	// TODO: 댓글 삭제 시 대댓글들을 어떻게 처리할지 추후 의논 필요
+	@Transactional
+	public void removeReply(Long problemId, Long discussionId, Long replyId, Long userId) {
+
+		Discussion discussion = discussionDomainService.getDiscussionById(discussionId);
+		discussionDomainService.validateProblemMatches(discussion, problemId);
+
+		Reply reply = replyDomainService.getReplyById(replyId);
+		replyDomainService.validateDiscussionMatches(reply, discussion);
+		replyDomainService.validateIsAuthor(reply, userId);
+
+		replyDomainService.remove(reply);
+	}
+}

--- a/src/main/java/org/ezcode/codetest/application/community/service/ReplyService.java
+++ b/src/main/java/org/ezcode/codetest/application/community/service/ReplyService.java
@@ -38,9 +38,12 @@ public class ReplyService {
 
 		discussionDomainService.validateProblemMatches(discussion, problemId);
 
-		Reply parent = request.parentReplyId() == null
-			? null
-			: replyDomainService.getReplyById(request.parentReplyId());
+		Reply parent = null;
+		if (request.parentReplyId() != null) {
+			parent = replyDomainService.getReplyById(request.parentReplyId());
+			replyDomainService.validateDiscussionMatches(parent, discussion);
+		}
+
 		Reply replyEntity = ReplyCreateRequest.toEntity(discussion, user, parent, request);
 
 		return ReplyResponse.fromEntity(replyDomainService.createReply(replyEntity));
@@ -66,6 +69,9 @@ public class ReplyService {
 
 		Discussion discussion = discussionDomainService.getDiscussionById(discussionId);
 		discussionDomainService.validateProblemMatches(discussion, problemId);
+
+		Reply parent = replyDomainService.getReplyById(parentReplyId);
+		replyDomainService.validateDiscussionMatches(parent, discussion);
 
 		Page<Reply> replies = replyDomainService.getRepliesByParentReplyId(parentReplyId, pageable);
 		return replies.map(ReplyResponse::fromEntity);

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/auth/port/JwtUtil.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/auth/port/JwtUtil.java
@@ -12,4 +12,8 @@ public interface JwtUtil {
 	String substringToken(String token);
 
 	Claims extractClaims(String token);
+
+	Long getExpiration(String token);
+
+	Long getRemainingTime(String token);
 }

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/auth/service/AuthService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/auth/service/AuthService.java
@@ -1,16 +1,21 @@
 package org.ezcode.codetest.application.usermanagement.auth.service;
 
+import java.util.concurrent.TimeUnit;
+
 import org.ezcode.codetest.application.usermanagement.auth.dto.signin.SigninRequest;
 import org.ezcode.codetest.application.usermanagement.auth.dto.signin.SigninResponse;
 import org.ezcode.codetest.application.usermanagement.auth.dto.signup.SignupRequest;
 import org.ezcode.codetest.application.usermanagement.auth.dto.signup.SignupResponse;
 import org.ezcode.codetest.application.usermanagement.auth.port.JwtUtil;
+import org.ezcode.codetest.application.usermanagement.user.dto.LogoutResponse;
 import org.ezcode.codetest.domain.user.exception.AuthException;
 import org.ezcode.codetest.domain.user.exception.AuthExceptionCode;
 import org.ezcode.codetest.domain.user.model.entity.User;
 import org.ezcode.codetest.domain.user.service.UserDomainService;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
@@ -24,6 +29,9 @@ public class AuthService {
 
 	private final UserDomainService userDomainService;
 	private final JwtUtil jwtUtil;
+	private final RedisTemplate<String, String> redisTemplate;
+
+
 	/*
 	이메일 로그인
 	- 이미 가입된 이메일 거절
@@ -80,11 +88,41 @@ public class AuthService {
 			loginUser.getNickname(),
 			loginUser.getTier());
 
+		String redisToken = jwtUtil.substringToken(bearToken);
+		redisTemplate.opsForValue().set(
+			"LOGIN:" + loginUser.getId(),
+			redisToken,
+			jwtUtil.getExpiration(redisToken),
+			TimeUnit.MILLISECONDS);
+
 		return SigninResponse.from(bearToken);
 	}
 
-	public String logout(Long userId, HttpServletRequest request) {
+	public LogoutResponse logout(Long userId, HttpServletRequest request) {
+		String bearerToken = request.getHeader("Authorization");
 
-		return "로그아웃 성공";
+		if (bearerToken == null || !bearerToken.startsWith("Bearer ")) {
+			throw new AuthException(AuthExceptionCode.INVALID_AUTHORIZATION_HEADER);
+		}
+
+		String token = jwtUtil.substringToken(bearerToken);
+
+		Long expiration = jwtUtil.getRemainingTime(token);
+
+		// Redis 실패 시에도 로그아웃 성공으로 처리 (보안상 사용자에게 노출하지 않음)
+		try {
+			//블랙리스트로 등록하기
+			redisTemplate.opsForValue().set(
+				"LOGOUT:" + token,
+				"blacklisted",
+				expiration,
+				TimeUnit.MILLISECONDS
+			);
+
+			redisTemplate.delete("LOGIN:" + userId);
+			} catch (Exception e) {
+				log.error("Redis 오류로 인한 로그아웃 처리 실패", e);}
+
+		return new LogoutResponse("success");
 	}
 }

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/LogoutResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/LogoutResponse.java
@@ -1,0 +1,12 @@
+package org.ezcode.codetest.application.usermanagement.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LogoutResponse {
+	String message;
+
+	public LogoutResponse(String message) {
+		this.message = message;
+	}
+}

--- a/src/main/java/org/ezcode/codetest/domain/community/exception/CommunityExceptionCode.java
+++ b/src/main/java/org/ezcode/codetest/domain/community/exception/CommunityExceptionCode.java
@@ -10,9 +10,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum CommunityExceptionCode implements ResponseCode {
 
-	DISCUSSION_NOT_FOUND(false, HttpStatus.NOT_FOUND, "해당 ID의 글이 존재하지 않습니다."),
+	DISCUSSION_NOT_FOUND(false, HttpStatus.NOT_FOUND, "해당 ID의 자유글이 존재하지 않습니다."),
 	DISCUSSION_PROBLEM_MISMATCH(false, HttpStatus.BAD_REQUEST, "해당 글이 요청된 문제에 속하지 않습니다."),
-	USER_NOT_AUTHOR(false, HttpStatus.FORBIDDEN, "작성자만 수정/삭제할 수 있습니다.");
+	
+	REPLY_NOT_FOUND(false, HttpStatus.NOT_FOUND, "해당 ID의 댓글이 존재하지 않습니다."),
+	REPLY_DISCUSSION_MISMATCH(false, HttpStatus.BAD_REQUEST, "해당 댓글이 요청된 자유글에 속하지 않습니다."),
+	
+	USER_NOT_AUTHOR(false, HttpStatus.FORBIDDEN, "작성자만 수정/삭제할 수 있습니다."),
+	;
 
 	private final boolean success;
 	private final HttpStatus status;

--- a/src/main/java/org/ezcode/codetest/domain/community/model/Reply.java
+++ b/src/main/java/org/ezcode/codetest/domain/community/model/Reply.java
@@ -2,6 +2,7 @@ package org.ezcode.codetest.domain.community.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.ezcode.codetest.common.base.entity.BaseEntity;
 import org.ezcode.codetest.domain.user.model.entity.User;
@@ -16,6 +17,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -51,4 +53,27 @@ public class Reply extends BaseEntity {
 	@Column(nullable = false)
 	private boolean isDeleted;
 
+	@Builder
+	public Reply(Discussion discussion, User user, Reply parent, List<Reply> replies, String content) {
+		this.discussion = discussion;
+		this.user = user;
+		this.parent = parent;
+		this.content = content;
+	}
+
+	public void update(String content) {
+		this.content = content;
+	}
+
+	public void setDeleted() {
+		this.isDeleted = true;
+	}
+
+	public boolean isDiscussionMatches(Long discussionId) {
+		return Objects.equals(this.discussion.getId(), discussionId);
+	}
+
+	public boolean isAuthor(Long userId) {
+		return Objects.equals(this.user.getId(), userId);
+	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/community/model/Reply.java
+++ b/src/main/java/org/ezcode/codetest/domain/community/model/Reply.java
@@ -43,10 +43,6 @@ public class Reply extends BaseEntity {
 	@JoinColumn(name = "parent_reply_id")
 	private Reply parent;
 
-	// 자식(대댓글) 목록
-	@OneToMany(mappedBy = "parent")
-	private List<Reply> replies = new ArrayList<>();
-
 	@Column(nullable = false)
 	private String content;
 

--- a/src/main/java/org/ezcode/codetest/domain/community/model/Reply.java
+++ b/src/main/java/org/ezcode/codetest/domain/community/model/Reply.java
@@ -54,7 +54,7 @@ public class Reply extends BaseEntity {
 	private boolean isDeleted;
 
 	@Builder
-	public Reply(Discussion discussion, User user, Reply parent, List<Reply> replies, String content) {
+	public Reply(Discussion discussion, User user, Reply parent, String content) {
 		this.discussion = discussion;
 		this.user = user;
 		this.parent = parent;

--- a/src/main/java/org/ezcode/codetest/domain/community/repository/ReplyRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/community/repository/ReplyRepository.java
@@ -1,0 +1,23 @@
+package org.ezcode.codetest.domain.community.repository;
+
+import java.util.Optional;
+
+import org.ezcode.codetest.domain.community.model.Reply;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReplyRepository {
+
+	Reply save(Reply reply);
+
+	Optional<Reply> findReplyById(Long replyId);
+
+	Page<Reply> findAllRepliesByDiscussionId(Long discussionId, Pageable pageable);
+
+	Page<Reply> findAllChildRepliesByParentReplyId(Long parentReplyId, Pageable pageable);
+
+	void updateReply(Reply reply, String content);
+
+	void deleteReply(Reply reply);
+
+}

--- a/src/main/java/org/ezcode/codetest/domain/community/service/ReplyDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/community/service/ReplyDomainService.java
@@ -1,5 +1,12 @@
 package org.ezcode.codetest.domain.community.service;
 
+import org.ezcode.codetest.domain.community.exception.CommunityException;
+import org.ezcode.codetest.domain.community.exception.CommunityExceptionCode;
+import org.ezcode.codetest.domain.community.model.Discussion;
+import org.ezcode.codetest.domain.community.model.Reply;
+import org.ezcode.codetest.domain.community.repository.ReplyRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -7,4 +14,52 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class ReplyDomainService {
+
+	private final ReplyRepository replyRepository;
+
+	public Reply createReply(Reply reply) {
+
+		return replyRepository.save(reply);
+	}
+
+	public Reply getReplyById(Long replyId) {
+
+		return replyRepository.findReplyById(replyId)
+			.orElseThrow(() -> new CommunityException(CommunityExceptionCode.REPLY_NOT_FOUND));
+	}
+
+	public Page<Reply> getRepliesByDiscussionId(Discussion discussion, Pageable pageable) {
+
+		return replyRepository.findAllRepliesByDiscussionId(discussion.getId(), pageable);
+	}
+
+	public Page<Reply> getRepliesByParentReplyId(Long parentReplyId, Pageable pageable) {
+
+		return replyRepository.findAllChildRepliesByParentReplyId(parentReplyId, pageable);
+	}
+
+	public void modify(Reply reply, String content) {
+
+		replyRepository.updateReply(reply, content);
+	}
+
+	public void remove(Reply reply) {
+
+		replyRepository.deleteReply(reply);
+	}
+
+
+	public void validateDiscussionMatches(Reply reply, Discussion discussion) {
+
+		if (!reply.isDiscussionMatches(discussion.getId())) {
+			throw new CommunityException(CommunityExceptionCode.REPLY_DISCUSSION_MISMATCH);
+		}
+	}
+
+	public void validateIsAuthor(Reply reply, Long userId) {
+
+		if (!reply.isAuthor(userId)) {
+			throw new CommunityException(CommunityExceptionCode.USER_NOT_AUTHOR);
+		}
+	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/user/exception/AuthExceptionCode.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/exception/AuthExceptionCode.java
@@ -13,7 +13,8 @@ public enum AuthExceptionCode implements ResponseCode {
 	EXIST_USER_EMAIL(false, HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
 	USER_NOT_FOUND(false, HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다"),
 	PASSWORD_NOT_MATCH(false, HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다"),
-	;
+	LOGOUT_USER(false, HttpStatus.BAD_REQUEST, "이미 로그아웃한 유저입니다."),
+	INVALID_AUTHORIZATION_HEADER(false, HttpStatus.BAD_REQUEST, "유효하지 않은 Authorization 헤더");
 
 	private final boolean success;
 	private final HttpStatus status;

--- a/src/main/java/org/ezcode/codetest/domain/user/model/entity/AuthUser.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/model/entity/AuthUser.java
@@ -1,12 +1,17 @@
 package org.ezcode.codetest.domain.user.model.entity;
 
+import java.util.Collection;
+import java.util.List;
+
 import org.ezcode.codetest.domain.user.model.enums.Tier;
 import org.ezcode.codetest.domain.user.model.enums.UserRole;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import lombok.Getter;
 
 @Getter
-public class AuthUser {
+public class AuthUser implements UserDetails {
 	private final Long id;
 	private final String email;
 	private final String username;
@@ -22,4 +27,11 @@ public class AuthUser {
 		this.role = role;
 		this.tier = tier;
 	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() { return List.of(() -> "ROLE_" + role.name()); }
+
+	@Override
+	public String getPassword() { return ""; }
+
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/community/ReplyJpaRepository.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/community/ReplyJpaRepository.java
@@ -1,7 +1,43 @@
 package org.ezcode.codetest.infrastructure.persistence.repository.community;
 
+import java.util.Optional;
+
 import org.ezcode.codetest.domain.community.model.Reply;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ReplyJpaRepository extends JpaRepository<Reply, Long> {
+
+	@Query("""
+		SELECT r
+		FROM Reply r
+		WHERE r.id = :replyId
+		AND r.isDeleted = false
+		""")
+	Optional<Reply> findByReplyId(Long replyId);
+
+	@EntityGraph(attributePaths = { "user" })
+	@Query("""
+		SELECT r
+		FROM Reply r
+		WHERE r.discussion.id = :discussionId
+		AND r.isDeleted = false
+		AND r.parent IS NULL
+		ORDER BY r.createdAt DESC
+		""")
+	Page<Reply> findAllByDiscussionId(Long discussionId, Pageable pageable);
+
+	@EntityGraph(attributePaths = { "user" })
+	@Query("""
+		SELECT r
+		FROM Reply r
+		WHERE r.parent.id = :parentReplyId
+		AND r.isDeleted = false
+		ORDER BY r.createdAt ASC
+		""")
+	Page<Reply> findAllByParentReplyId(Long parentReplyId, Pageable pageable);
+
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/community/ReplyRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/community/ReplyRepositoryImpl.java
@@ -1,0 +1,54 @@
+package org.ezcode.codetest.infrastructure.persistence.repository.community;
+
+import java.util.Optional;
+
+import org.ezcode.codetest.domain.community.model.Reply;
+import org.ezcode.codetest.domain.community.repository.ReplyRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ReplyRepositoryImpl implements ReplyRepository {
+
+	private final ReplyJpaRepository replyJpaRepository;
+
+	@Override
+	public Reply save(Reply reply) {
+
+		return replyJpaRepository.save(reply);
+	}
+
+	@Override
+	public Optional<Reply> findReplyById(Long replyId) {
+
+		return replyJpaRepository.findByReplyId(replyId);
+	}
+
+	@Override
+	public Page<Reply> findAllRepliesByDiscussionId(Long discussionId, Pageable pageable) {
+
+		return replyJpaRepository.findAllByDiscussionId(discussionId, pageable);
+	}
+
+	@Override
+	public Page<Reply> findAllChildRepliesByParentReplyId(Long parentReplyId, Pageable pageable) {
+
+		return replyJpaRepository.findAllByParentReplyId(parentReplyId, pageable);
+	}
+
+	@Override
+	public void updateReply(Reply reply, String content) {
+
+		reply.update(content);
+	}
+
+	@Override
+	public void deleteReply(Reply reply) {
+
+		reply.setDeleted();
+	}
+}

--- a/src/main/java/org/ezcode/codetest/infrastructure/security/config/FilterConfig.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/security/config/FilterConfig.java
@@ -5,6 +5,7 @@ import org.ezcode.codetest.infrastructure.security.jwt.JwtUtilImpl;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
 
 import lombok.RequiredArgsConstructor;
 
@@ -12,11 +13,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class FilterConfig {
 	private final JwtUtilImpl jwtUtil;
+	private final RedisTemplate<String, String> redisTemplate;
 
 	@Bean
 	public FilterRegistrationBean<JwtFilter> jwtFilter() {
 		FilterRegistrationBean<JwtFilter> registrationBean = new FilterRegistrationBean<>();
-		registrationBean.setFilter(new JwtFilter(jwtUtil));
+		registrationBean.setFilter(new JwtFilter(jwtUtil, redisTemplate));
 		registrationBean.addUrlPatterns("/*");
 
 		return registrationBean;

--- a/src/main/java/org/ezcode/codetest/infrastructure/security/config/SecurityConfig.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/security/config/SecurityConfig.java
@@ -1,10 +1,12 @@
 package org.ezcode.codetest.infrastructure.security.config;
 
 import org.ezcode.codetest.domain.user.model.enums.UserRole;
+import org.ezcode.codetest.infrastructure.security.jwt.ExceptionHandlingFilter;
 import org.ezcode.codetest.infrastructure.security.jwt.JwtFilter;
 import org.ezcode.codetest.infrastructure.security.jwt.JwtUtilImpl;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -21,30 +23,45 @@ import lombok.RequiredArgsConstructor;
 @EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
 	private final JwtUtilImpl jwtUtil;
+	private final RedisTemplate<String, String> redisTemplate;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		JwtFilter jwtFilter = new JwtFilter(jwtUtil);
+		JwtFilter jwtFilter = new JwtFilter(jwtUtil, redisTemplate);
+		ExceptionHandlingFilter exceptionFilter = new ExceptionHandlingFilter();
 
 		return http
 			// CSRF, Form 로그인, HTTP Basic 인증 비활성화
 			.csrf(AbstractHttpConfigurer::disable)
 			.formLogin(AbstractHttpConfigurer::disable)
 			.httpBasic(AbstractHttpConfigurer::disable)
+			.logout(AbstractHttpConfigurer::disable)
 			// JWT 사용을 위해 세션을 STATELESS로 설정 (세션 정보 저장 x)
 			.sessionManagement(session -> session
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			)
 
 			//인증 URL 범위 설정
-			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(authorizeRequests ->
 				authorizeRequests
-					.requestMatchers("/signin", "/signup", "/actuator/**", "/chatting", "/ws/**").permitAll() //로그인, 회원가입은 인증 필요없음
+					.requestMatchers(
+						"/signin",
+						"/signup",
+						"/logout",
+						"/actuator/**",
+						"/chatting",
+						"/ws/**",
+						"/swagger-ui/**",
+						"/swagger-resources/**",
+						"/v2/**",
+						"/v3/**",
+						"/webjars/**").permitAll()
 					.requestMatchers("/admin/**").hasRole("ADMIN") //어드민 권한 필요 (문제 생성, 관리 등)
 					.anyRequest().authenticated() //나머지는 일반 인증
 			)
 			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+			.addFilterBefore(exceptionFilter, JwtFilter.class)
+
 			.build();
 	}
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/security/jwt/ExceptionHandlingFilter.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/security/jwt/ExceptionHandlingFilter.java
@@ -1,0 +1,40 @@
+package org.ezcode.codetest.infrastructure.security.jwt;
+
+import java.io.IOException;
+
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ExceptionHandlingFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		try {
+			filterChain.doFilter(request, response);
+		} catch (SecurityException | MalformedJwtException e) {
+			log.info("Invalid JWT signature", e);
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 JWT 서명입니다.");
+		} catch (ExpiredJwtException e) {
+			log.info("Expired JWT token", e);
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "만료된 JWT 토큰입니다.");
+		} catch (UnsupportedJwtException e) {
+			log.info("Unsupported JWT token", e);
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "지원되지 않는 JWT 토큰입니다.");
+		} catch (Exception e) {
+			log.info("Unexpected error in filter chain", e);
+			response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+		}
+
+	}
+}
+

--- a/src/main/java/org/ezcode/codetest/infrastructure/security/jwt/JwtFilter.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/security/jwt/JwtFilter.java
@@ -4,22 +4,19 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
+import org.ezcode.codetest.domain.user.exception.AuthException;
+import org.ezcode.codetest.domain.user.exception.AuthExceptionCode;
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.ezcode.codetest.domain.user.model.enums.Tier;
 import org.ezcode.codetest.domain.user.model.enums.UserRole;
-import org.springframework.core.annotation.Order;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.util.PatternMatchUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
-
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -29,17 +26,16 @@ import lombok.extern.slf4j.Slf4j;
 
 @AllArgsConstructor
 @Slf4j
-@Order(1)
 public class JwtFilter extends OncePerRequestFilter {
 
 	private final JwtUtilImpl jwtUtilImpl;
+	private final RedisTemplate<String, String> redisTemplate;
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 									FilterChain filterChain) throws ServletException, IOException {
 
 		String bearerToken = request.getHeader("Authorization");
-		String url = request.getRequestURI();
 
 		if (bearerToken == null || !bearerToken.startsWith("Bearer ")) {
 			filterChain.doFilter(request, response);
@@ -48,66 +44,46 @@ public class JwtFilter extends OncePerRequestFilter {
 
 		String jwt = jwtUtilImpl.substringToken(bearerToken);
 
-		try {
-			Claims claims = jwtUtilImpl.extractClaims(jwt);
-
-			if(claims == null){
-				response.sendError(HttpServletResponse.SC_BAD_REQUEST, "잘못된 JWT 토큰입니다");
-				return;
-			}
-
-			UserRole userRole = UserRole.valueOf(claims.get("userRole", String.class));
-			String tierClaim = claims.get("tier", String.class);
-			Tier tier = tierClaim != null ? Tier.valueOf(tierClaim) : Tier.NEWBIE;
-
-			if (url.startsWith("/admin") && !UserRole.ADMIN.equals(userRole)) {
-					response.sendError(HttpServletResponse.SC_FORBIDDEN, "관리자 권한이 없습니다");
-					return;
-			}
-
-			//생성자 순서가 틀려서 다시 정렬해서 넣었습니다
-			AuthUser authUser = new AuthUser(
-				Long.parseLong(claims.getSubject()),
-				(String) claims.get("username"),
-				(String) claims.get("nickname"),
-				(String) claims.get("email"),
-				userRole,
-				tier
-			);
-
-			request.setAttribute("authUser", authUser);
-			request.setAttribute("userId", Long.parseLong(claims.getSubject()));
-			request.setAttribute("email", claims.get("email"));
-			request.setAttribute("userRole", claims.get("userRole"));
-			request.setAttribute("username", claims.get("username"));
-			request.setAttribute("nickname", claims.get("nickname"));
-
-			// 인가를 위한 권한 정보 저장
-			Collection<? extends GrantedAuthority> authorities =
-				List.of(new SimpleGrantedAuthority(authUser.getRole().toString()));
-
-			// Spring Security 인증 토큰 생성
-			Authentication authToken = new UsernamePasswordAuthenticationToken(authUser,
-				null, authorities);
-
-			// SecurityContextHolder(세션)에 토큰 담기
-			SecurityContextHolder.getContext().setAuthentication(authToken);
-
-
-			filterChain.doFilter(request, response);
-		} catch (SecurityException | MalformedJwtException e) {
-			log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.", e);
-			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않는 JWT 서명입니다.");
-		} catch (ExpiredJwtException e) {
-			log.error("Expired JWT token, 만료된 JWT token 입니다.", e);
-			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "만료된 JWT 토큰입니다.");
-		} catch (UnsupportedJwtException e) {
-			log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.", e);
-			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "지원되지 않는 JWT 토큰입니다.");
-		} catch (Exception e) {
-			log.error("Internal server error", e);
-			response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+		if (redisTemplate.opsForValue().get("LOGOUT:" + jwt) != null) {
+			throw new AuthException(AuthExceptionCode.NO_AUTH_INFO);
 		}
-	}
 
-}
+		Claims claims = jwtUtilImpl.extractClaims(jwt);
+
+		if (claims == null) {
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "잘못된 JWT 토큰입니다");
+			return;
+		}
+
+		UserRole userRole = UserRole.valueOf(claims.get("userRole", String.class));
+		String tierClaim = claims.get("tier", String.class);
+		Tier tier = tierClaim != null ? Tier.valueOf(tierClaim) : Tier.NEWBIE;
+
+		AuthUser authUser = new AuthUser(
+			Long.parseLong(claims.getSubject()),
+			(String)claims.get("username"),
+			(String)claims.get("nickname"),
+			(String)claims.get("email"),
+			userRole,
+			tier
+		);
+
+		// 인가를 위한 권한 정보 저장
+		Collection<? extends GrantedAuthority> authorities =
+			List.of(new SimpleGrantedAuthority("ROLE_" + authUser.getRole().name()));
+
+		// Spring Security 인증 토큰 생성
+		Authentication authToken;
+		authToken = new UsernamePasswordAuthenticationToken(authUser, null, authorities);
+
+		// SecurityContextHolder(세션)에 토큰 담기
+		SecurityContextHolder.getContext().setAuthentication(authToken);
+
+		log.info("Authentication 등록됨: {}", SecurityContextHolder.getContext().getAuthentication());
+		log.info("Principal: {}", SecurityContextHolder.getContext().getAuthentication().getPrincipal());
+
+
+		filterChain.doFilter(request, response);
+		}
+
+	}

--- a/src/main/java/org/ezcode/codetest/infrastructure/security/jwt/JwtUtilImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/security/jwt/JwtUtilImpl.java
@@ -37,13 +37,15 @@ public class JwtUtilImpl implements JwtUtil {
 		key = Keys.hmacShaKeyFor(secretKey.getBytes());
 	}
 
+	/*
+	토큰 발급
+	 */
 	public String createToken(Long userId, String email, UserRole userRole, String username, String nickname, Tier tier) {
 		if (userId == null || email == null || username == null || nickname == null) {
 			throw new IllegalArgumentException("토큰에 필요한 필수 매개변수가 null입니다.");
 		}
 
 		Date date = new Date();
-		log.info("-----------jwtUtil 토큰 생성 시작---------------");
 
 		return BEARER_PREFIX +
 			Jwts.builder()
@@ -59,6 +61,9 @@ public class JwtUtilImpl implements JwtUtil {
 				.compact();
 	}
 
+	/*
+	토큰 추출
+	 */
 	public String substringToken(String token) {
 		if (StringUtils.hasText(token) && token.startsWith(BEARER_PREFIX)) {
 			return token.substring(BEARER_PREFIX.length());
@@ -80,5 +85,33 @@ public class JwtUtilImpl implements JwtUtil {
 			log.error("JWT 토큰 파싱 실패: {}", e.getMessage());
 			throw new ServerException("유효한 토큰이 아닙니다");
 		}
+	}
+
+	//토큰 유효시간 계산
+	public Long getExpiration(String token) {
+		Claims claims = extractClaims(token);
+		Date expiration = claims.getExpiration();
+		return expiration.getTime() - System.currentTimeMillis(); // 남은시간을 ms 단위로 계산해서 반환
+	}
+
+	@Override
+	public Long getRemainingTime(String token) {
+		Date expiration = extractClaims(token).getExpiration();
+		return expiration.getTime() - System.currentTimeMillis();
+	}
+
+	/*
+	토큰 갱신
+	 */
+	public String createRefreshToken(String userId) {
+		Date now = new Date();
+		Date expirationDate = new Date(now.getTime() + TOKEN_EXPIRATION_TIME * 1000L); //만료 시간
+
+		return Jwts.builder()
+			.setSubject(String.valueOf(userId)) // 주제설정, string 으로만 주입 가능
+			.setIssuedAt(now) // 발급날짜
+			.setExpiration(expirationDate) // 만료날짜
+			.signWith(key, signatureAlgorithm) // 암호화 알고리즘
+			.compact();
 	}
 }

--- a/src/main/java/org/ezcode/codetest/presentation/community/DiscussionController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/community/DiscussionController.java
@@ -4,13 +4,13 @@ import org.ezcode.codetest.application.community.dto.request.DiscussionCreateReq
 import org.ezcode.codetest.application.community.dto.request.DiscussionModifyRequest;
 import org.ezcode.codetest.application.community.dto.response.DiscussionResponse;
 import org.ezcode.codetest.application.community.service.DiscussionService;
-import org.ezcode.codetest.common.annotation.Auth;
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,7 +34,7 @@ public class DiscussionController {
 	public ResponseEntity<DiscussionResponse> createDiscussion(
 		@PathVariable Long problemId,
 		@RequestBody @Valid DiscussionCreateRequest request,
-		@Auth AuthUser authUser
+		@AuthenticationPrincipal AuthUser authUser
 	) {
 		return ResponseEntity
 			.status(HttpStatus.CREATED)
@@ -56,7 +56,7 @@ public class DiscussionController {
 		@PathVariable Long problemId,
 		@PathVariable Long discussionId,
 		@RequestBody @Valid DiscussionModifyRequest request,
-		@Auth AuthUser authUser
+		@AuthenticationPrincipal AuthUser authUser
 	) {
 		return ResponseEntity
 			.ok()
@@ -67,7 +67,7 @@ public class DiscussionController {
 	public ResponseEntity<Void> removeDiscussion(
 		@PathVariable Long problemId,
 		@PathVariable Long discussionId,
-		@Auth AuthUser authUser
+		@AuthenticationPrincipal AuthUser authUser
 	) {
 		discussionService.removeDiscussion(problemId, discussionId, authUser.getId());
 		return ResponseEntity.ok().build();

--- a/src/main/java/org/ezcode/codetest/presentation/community/ReplyController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/community/ReplyController.java
@@ -1,0 +1,93 @@
+package org.ezcode.codetest.presentation.community;
+
+import org.ezcode.codetest.application.community.dto.request.ReplyCreateRequest;
+import org.ezcode.codetest.application.community.dto.request.ReplyModifyRequest;
+import org.ezcode.codetest.application.community.dto.response.ReplyResponse;
+import org.ezcode.codetest.application.community.service.ReplyService;
+import org.ezcode.codetest.domain.user.model.entity.AuthUser;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/problems/{problemId}/discussions/{discussionId}/replies")
+@RequiredArgsConstructor
+public class ReplyController {
+
+	private final ReplyService replyService;
+
+	@PostMapping
+	public ResponseEntity<ReplyResponse> createReply(
+		@PathVariable Long problemId,
+		@PathVariable Long discussionId,
+		@RequestBody @Valid ReplyCreateRequest request,
+		@AuthenticationPrincipal AuthUser authUser
+	) {
+		return ResponseEntity
+			.status(HttpStatus.CREATED)
+			.body(replyService.createReply(problemId, discussionId, request, authUser.getId()));
+	}
+
+	// 댓글 목록 조회
+	@GetMapping
+	public ResponseEntity<Page<ReplyResponse>> getReplies(
+		@PathVariable Long problemId,
+		@PathVariable Long discussionId,
+		@PageableDefault Pageable pageable
+	) {
+		return ResponseEntity
+			.ok()
+			.body(replyService.getReplies(problemId, discussionId, pageable));
+	}
+
+	// 대댓글 목록 조회
+	@GetMapping("/{parentReplyId}")
+	public ResponseEntity<Page<ReplyResponse>> getReplies(
+		@PathVariable Long problemId,
+		@PathVariable Long discussionId,
+		@PathVariable Long parentReplyId,
+		@PageableDefault Pageable pageable
+	) {
+		return ResponseEntity
+			.ok()
+			.body(replyService.getChildReplies(problemId, discussionId, parentReplyId, pageable));
+	}
+
+	@PutMapping("/{replyId}")
+	public ResponseEntity<ReplyResponse> modifyReply(
+		@PathVariable Long problemId,
+		@PathVariable Long discussionId,
+		@PathVariable Long replyId,
+		@RequestBody @Valid ReplyModifyRequest request,
+		@AuthenticationPrincipal AuthUser authUser
+	) {
+		return ResponseEntity
+			.ok()
+			.body(replyService.modifyReply(problemId, discussionId, replyId, request, authUser.getId()));
+	}
+
+	@DeleteMapping("/{replyId}")
+	public ResponseEntity<Void> removeReply(
+		@PathVariable Long problemId,
+		@PathVariable Long discussionId,
+		@PathVariable Long replyId,
+		@AuthenticationPrincipal AuthUser authUser
+	) {
+		replyService.removeReply(problemId, discussionId, replyId, authUser.getId());
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/AuthController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/AuthController.java
@@ -5,10 +5,11 @@ import org.ezcode.codetest.application.usermanagement.auth.dto.signin.SigninResp
 import org.ezcode.codetest.application.usermanagement.auth.dto.signup.SignupRequest;
 import org.ezcode.codetest.application.usermanagement.auth.dto.signup.SignupResponse;
 import org.ezcode.codetest.application.usermanagement.auth.service.AuthService;
-import org.ezcode.codetest.common.annotation.Auth;
+import org.ezcode.codetest.application.usermanagement.user.dto.LogoutResponse;
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,8 +36,8 @@ public class AuthController {
 	}
 
 	@PostMapping("/logout")
-	public ResponseEntity<String> logout(
-			@Auth AuthUser authUser,
+	public ResponseEntity<LogoutResponse> logout(
+			@AuthenticationPrincipal AuthUser authUser,
 			HttpServletRequest request) {
 		return ResponseEntity.status(HttpStatus.OK).body(authService.logout(authUser.getId(), request));
 	}

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
@@ -7,6 +7,7 @@ import org.ezcode.codetest.common.annotation.Auth;
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,14 +23,14 @@ public class UserController {
 	private final UserService userService;
 
 	@GetMapping("/users")
-	public ResponseEntity<UserInfoResponse> getUserInfo(@Auth AuthUser authUser){
+	public ResponseEntity<UserInfoResponse> getUserInfo(@AuthenticationPrincipal AuthUser authUser){
 		log.info("authUserEmail: {}, authUserID : {}", authUser.getEmail(), authUser.getId());
 		return ResponseEntity.status(HttpStatus.OK).body(userService.getUserInfo(authUser));
 	}
 
 	@PutMapping("/users")
 	public ResponseEntity<UserInfoResponse> modifyUserInfo(
-		@Auth AuthUser authUser,
+		@AuthenticationPrincipal AuthUser authUser,
 		@RequestBody ModifyUserInfoRequest modifyUserInfoRequest
 	){
 		return ResponseEntity.status(HttpStatus.OK).body(userService.modifyUserInfo(authUser, modifyUserInfoRequest));


### PR DESCRIPTION
## 작업 내용

- 댓글과 대댓글의 CRUD를 구현함

---

## 변경 사항

- 댓글 관련 클래스 구현
- `Reply` 엔티티 내부에 메서드 추가

---

## 트러블 슈팅

- 구현 중 마주한 문제와 해결 방법을 기술해주세요.
- 예)
    - 문제: `@Transactional`이 적용되지 않음
    - 해결: 메서드 호출 방식 변경 (`this.` → `AopProxyUtils.` 사용)

---

## 해결해야 할 문제

- 댓글 삭제 시 대댓글들을 어떻게 처리할지 추후 의논 필요
  - 댓글 삭제 시 "삭제된 댓글입니다"라고 표시하고 대댓글은 남기기
  - 댓글 삭제 시 대댓글도 삭제 처리 (조회 불가)

![image](https://github.com/user-attachments/assets/9f7dd0a0-9a42-4da7-9f9d-fdc9ea2357a5)

---

## 참고 사항

- jira : MBA-34

---

### 코드 리뷰 전 확인 체크리스트

- [x]  불필요한 콘솔 로그, 주석 제거
- [x]  커밋 메시지 컨벤션 준수 (`type : `)
- [x]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 자유글(커뮤니티)에서 댓글 작성, 조회, 수정, 삭제 및 대댓글 기능이 추가되었습니다.
    - 댓글과 대댓글 목록을 페이지네이션으로 편리하게 조회할 수 있습니다.
    - 로그아웃 시 토큰 관리를 위한 Redis 연동이 도입되어 보안이 강화되었습니다.
    - JWT 토큰 만료 시간 조회 및 리프레시 토큰 생성 기능이 추가되었습니다.
    - JWT 인증 필터 및 예외 처리 필터가 개선되어 인증 안정성이 향상되었습니다.
- **버그 수정**
    - 일부 예외 메시지가 더 명확하게 변경되었습니다.
- **기타**
    - 인증 사용자 주입 방식이 표준 Spring Security 방식(@AuthenticationPrincipal)으로 개선되었습니다.
    - 로그아웃 API 응답이 구조화된 메시지 형태로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->