### PR TITLE
feat: 채점 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     //레디스
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/src/main/java/org/ezcode/codetest/application/submission/dto/request/CompileRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/dto/request/CompileRequest.java
@@ -1,0 +1,22 @@
+package org.ezcode.codetest.application.submission.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record CompileRequest(
+
+	String source_code,
+
+	Long language_id,
+
+	String stdin
+
+) {
+	public static CompileRequest of(String sourceCode, Long languageId, String stdin) {
+		return CompileRequest.builder()
+			.source_code(sourceCode)
+			.language_id(languageId)
+			.stdin(stdin)
+			.build();
+	}
+}

--- a/src/main/java/org/ezcode/codetest/application/submission/dto/request/SubmitRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/dto/request/SubmitRequest.java
@@ -1,0 +1,15 @@
+package org.ezcode.codetest.application.submission.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record SubmitRequest(
+
+	@NotNull(message = "언어 번호는 필수 입력 값입니다.")
+	Long languageId,
+
+	@NotBlank(message = "소스 코드는 필수 입력 값입니다.")
+	String sourceCode
+
+) {
+}

--- a/src/main/java/org/ezcode/codetest/application/submission/dto/response/CompileResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/dto/response/CompileResponse.java
@@ -1,0 +1,29 @@
+package org.ezcode.codetest.application.submission.dto.response;
+
+public record CompileResponse(
+
+	String stdout,
+
+	String time,
+
+	Long memory,
+
+	String stderr,
+
+	String token,
+
+	String compile_output,
+
+	int exit_code,
+
+	CompileStatus status
+
+) {
+	public record CompileStatus(
+
+		int id,
+
+		String description
+
+	) {}
+}

--- a/src/main/java/org/ezcode/codetest/application/submission/dto/response/SubmitResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/dto/response/SubmitResponse.java
@@ -1,0 +1,21 @@
+package org.ezcode.codetest.application.submission.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record SubmitResponse(
+
+	boolean isCorrect,
+
+	String expectedOutput,
+
+	String actualOutput,
+
+	String time,
+
+	Long memory,
+
+	String message
+
+) {
+}

--- a/src/main/java/org/ezcode/codetest/application/submission/model/JudgeResult.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/model/JudgeResult.java
@@ -1,0 +1,19 @@
+package org.ezcode.codetest.application.submission.model;
+
+import lombok.Builder;
+
+@Builder
+public record JudgeResult(
+
+	String output,
+
+	String time,
+
+	Long memory,
+
+	boolean success,
+
+	String message
+
+) {
+}

--- a/src/main/java/org/ezcode/codetest/application/submission/port/JudgeClient.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/port/JudgeClient.java
@@ -1,0 +1,8 @@
+package org.ezcode.codetest.application.submission.port;
+
+import org.ezcode.codetest.application.submission.dto.request.CompileRequest;
+import org.ezcode.codetest.application.submission.model.JudgeResult;
+
+public interface JudgeClient {
+	JudgeResult execute(CompileRequest request);
+}

--- a/src/main/java/org/ezcode/codetest/application/submission/service/SubmissionService.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/service/SubmissionService.java
@@ -1,0 +1,51 @@
+package org.ezcode.codetest.application.submission.service;
+
+import org.ezcode.codetest.common.model.TempProblemInfo;
+import org.ezcode.codetest.application.submission.dto.request.CompileRequest;
+import org.ezcode.codetest.application.submission.dto.request.SubmitRequest;
+import org.ezcode.codetest.application.submission.model.JudgeResult;
+import org.ezcode.codetest.application.submission.dto.response.SubmitResponse;
+import org.ezcode.codetest.application.submission.port.JudgeClient;
+import org.ezcode.codetest.domain.problem.model.AnswerEvaluation;
+import org.ezcode.codetest.domain.problem.model.entity.Language;
+import org.ezcode.codetest.domain.problem.service.LanguageDomainService;
+import org.ezcode.codetest.domain.problem.service.ProblemDomainService;
+import org.ezcode.codetest.domain.problem.service.SubmissionDomainService;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SubmissionService {
+
+	private final JudgeClient judgeClient;
+	private final ProblemDomainService problemDomainService;
+	private final LanguageDomainService languageDomainService;
+	private final SubmissionDomainService submissionDomainService;
+
+	public SubmitResponse submitCode(Long problemId, SubmitRequest request) {
+
+		// ProblemInfo problemInfo = problemDomainService.getProblemInfo(problemId);
+		Language language = languageDomainService.getLanguage(request.languageId());
+		JudgeResult result = judgeClient.execute(
+			CompileRequest.of(request.sourceCode(), language.getJudge0Id(), "2 10")
+		);
+
+		TempProblemInfo tempProblemInfo = new TempProblemInfo("12");
+		AnswerEvaluation eval = submissionDomainService.evaluate(
+			tempProblemInfo.output(),
+			result.output(),
+			result.success()
+		);
+
+		return SubmitResponse.builder()
+			.isCorrect(eval.isCorrect())
+			.expectedOutput(eval.expectedOutput())
+			.actualOutput(eval.actualOutput())
+			.time(result.time())
+			.memory(result.memory())
+			.message(result.message())
+			.build();
+	}
+}

--- a/src/main/java/org/ezcode/codetest/common/model/TempProblemInfo.java
+++ b/src/main/java/org/ezcode/codetest/common/model/TempProblemInfo.java
@@ -1,0 +1,10 @@
+package org.ezcode.codetest.common.model;
+
+public record TempProblemInfo(
+
+	String output
+
+) {
+
+
+}

--- a/src/main/java/org/ezcode/codetest/domain/problem/model/AnswerEvaluation.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/model/AnswerEvaluation.java
@@ -1,0 +1,15 @@
+package org.ezcode.codetest.domain.problem.model;
+
+import lombok.Builder;
+
+@Builder
+public record AnswerEvaluation(
+
+	boolean isCorrect,
+
+	String expectedOutput,
+
+	String actualOutput
+
+) {
+}

--- a/src/main/java/org/ezcode/codetest/domain/problem/repository/SubmissionRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/repository/SubmissionRepository.java
@@ -1,0 +1,4 @@
+package org.ezcode.codetest.domain.problem.repository;
+
+public interface SubmissionRepository {
+}

--- a/src/main/java/org/ezcode/codetest/domain/problem/service/SubmissionDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/service/SubmissionDomainService.java
@@ -1,0 +1,23 @@
+package org.ezcode.codetest.domain.problem.service;
+
+import org.ezcode.codetest.domain.problem.model.AnswerEvaluation;
+import org.ezcode.codetest.domain.problem.repository.SubmissionRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SubmissionDomainService {
+
+	private SubmissionRepository submissionRepository;
+
+	public AnswerEvaluation evaluate(String expectedOutput, String actualOutput, boolean success) {
+		boolean isCorrect = success && expectedOutput.equals(actualOutput);
+		return  AnswerEvaluation.builder()
+			.isCorrect(isCorrect)
+			.expectedOutput(expectedOutput)
+			.actualOutput(actualOutput)
+			.build();
+	}
+}

--- a/src/main/java/org/ezcode/codetest/infrastructure/judge0/Judge0Client.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/judge0/Judge0Client.java
@@ -1,0 +1,40 @@
+package org.ezcode.codetest.infrastructure.judge0;
+
+import org.ezcode.codetest.application.submission.dto.request.CompileRequest;
+import org.ezcode.codetest.application.submission.dto.response.CompileResponse;
+import org.ezcode.codetest.application.submission.model.JudgeResult;
+import org.ezcode.codetest.application.submission.port.JudgeClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class Judge0Client implements JudgeClient {
+
+	@Value("${external.judge0.url}")
+	private String judge0ApiUrl;
+	private WebClient webClient;
+	private final Judge0ResponseMapper interpreter;
+
+	@PostConstruct
+	private void init() {
+		this.webClient = WebClient.create(judge0ApiUrl);
+	}
+
+	public JudgeResult execute(CompileRequest request) {
+		CompileResponse compileResponse = webClient.post()
+			.uri("/submissions?base64_encoded=false&wait=true")
+			.contentType(MediaType.APPLICATION_JSON)
+			.bodyValue(request)
+			.retrieve()
+			.bodyToMono(CompileResponse.class)
+			.block();
+
+		return interpreter.toJudgeResult(compileResponse);
+	}
+}

--- a/src/main/java/org/ezcode/codetest/infrastructure/judge0/Judge0ResponseMapper.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/judge0/Judge0ResponseMapper.java
@@ -1,0 +1,32 @@
+package org.ezcode.codetest.infrastructure.judge0;
+
+import org.ezcode.codetest.application.submission.dto.response.CompileResponse;
+import org.ezcode.codetest.application.submission.model.JudgeResult;
+import org.springframework.stereotype.Component;
+
+@Component
+public class Judge0ResponseMapper {
+
+	public JudgeResult toJudgeResult(CompileResponse compileResponse) {
+		String output = extractActualOutput(compileResponse);
+		boolean success = isSuccessful(compileResponse);
+		return JudgeResult.builder()
+			.output(output)
+			.time(compileResponse.time())
+			.memory(compileResponse.memory())
+			.success(success)
+			.message(compileResponse.status().description())
+			.build();
+	}
+
+	private String extractActualOutput(CompileResponse compileResponse) {
+		if (compileResponse.stdout() != null) return compileResponse.stdout();
+		if (compileResponse.compile_output() != null) return compileResponse.compile_output();
+		if (compileResponse.stderr() != null) return compileResponse.stderr();
+		return "(No output)";
+	}
+
+	private boolean isSuccessful(CompileResponse compileResponse) {
+		return compileResponse.stdout() != null && compileResponse.status().id() == 3;
+	}
+}

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/problem/SubmissionRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/problem/SubmissionRepositoryImpl.java
@@ -1,0 +1,14 @@
+package org.ezcode.codetest.infrastructure.persistence.repository.problem;
+
+import org.ezcode.codetest.domain.problem.repository.SubmissionRepository;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class SubmissionRepositoryImpl implements SubmissionRepository {
+
+	private final SubmissionJpaRepository submissionJpaRepository;
+
+}

--- a/src/main/java/org/ezcode/codetest/presentation/SubmissionController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/SubmissionController.java
@@ -1,4 +1,32 @@
 package org.ezcode.codetest.presentation;
 
+import org.ezcode.codetest.application.submission.dto.request.SubmitRequest;
+import org.ezcode.codetest.application.submission.dto.response.SubmitResponse;
+import org.ezcode.codetest.application.submission.service.SubmissionService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/submissions")
 public class SubmissionController {
+
+	private final SubmissionService submissionService;
+
+	@PostMapping("/{problemId}")
+	public ResponseEntity<SubmitResponse> submitCode(
+		@PathVariable Long problemId,
+		@RequestBody @Valid SubmitRequest request) {
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(submissionService.submitCode(problemId, request));
+	}
 }


### PR DESCRIPTION
---

## 작업 내용

- Judge0 외부 API와 연동하여 사용자 제출 코드의 컴파일 및 실행 처리
- 테스트 케이스와 제출 코드 결과를 비교하여 정답 여부 판단
- 실행 결과(정답 여부, 메모리 사용량, 실행 시간)를 사용자에게 응답

---

## 트러블 슈팅

- 문제: EC2에서 Judge0 Docker 이미지 실행 시, 리눅스 커널 버전 문제로 인해 통신 오류 발생 (cgroup)

---

## 해결해야 할 문제

- 문제 정보 및 테스트케이스 정보를 Projection 기반 DTO로 전달하는 도메인 메서드 요청, 담당자 분께서 구현 필요
- 배열 등 다양한 input/output 타입 조사 및 대응 로직 추가 필요
- 웹 에디터에서 소스코드 입력 시, 코드가 정렬되는 지 여부 확인 필요 (Judge0로 요청을 보낼 때 소스코드가 한 줄로 정렬 되어야 함)
- 기능 고도화 때, 통신 속도나 로직 처리 속도, 다건의 테스트 케이스 처리 방식 등 고려

---

## 참고 사항

- 현재는 "정상 동작 우선"으로 구현 완료
- 예외 처리, 장애 대응, 부적절한 코드 실행 등의 케이스는 추후 리팩토링 예정

---
