### PR TITLE
feat : 1차 캐시 사용하도록 코드 최적화

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/community/service/DiscussionVoteService.java
+++ b/src/main/java/org/ezcode/codetest/application/community/service/DiscussionVoteService.java
@@ -28,16 +28,6 @@ public class DiscussionVoteService extends BaseVoteService<DiscussionVote, Discu
 		this.discussionDomainService = discussionDomainService;
 	}
 
-	@Override
-	protected DiscussionVote buildVoteEntity(User voter, Long targetId) {
-		Discussion discussion = discussionDomainService.getDiscussionById(targetId);
-
-		return DiscussionVote.builder()
-			.voter(voter)
-			.discussion(discussion)
-			.build();
-	}
-
 	@Transactional
 	public VoteResponse validateAndToggleVote(Long problemId, Long discussionId, Long userId) {
 
@@ -49,5 +39,15 @@ public class DiscussionVoteService extends BaseVoteService<DiscussionVote, Discu
 
 		Optional<DiscussionVote> discussionVote = toggleVote(voter, discussionId);
 		return new VoteResponse(discussionVote.isPresent());
+	}
+
+	@Override
+	protected DiscussionVote buildVoteEntity(User voter, Long targetId) {
+		Discussion discussion = discussionDomainService.getDiscussionById(targetId);
+
+		return DiscussionVote.builder()
+			.voter(voter)
+			.discussion(discussion)
+			.build();
 	}
 }

--- a/src/main/java/org/ezcode/codetest/application/community/service/ReplyVoteService.java
+++ b/src/main/java/org/ezcode/codetest/application/community/service/ReplyVoteService.java
@@ -33,16 +33,6 @@ public class ReplyVoteService extends BaseVoteService<ReplyVote, ReplyVoteDomain
 		this.discussionDomainService = discussionDomainService;
 	}
 
-	@Override
-	protected ReplyVote buildVoteEntity(User voter, Long targetId) {
-		Reply reply = replyDomainService.getReplyById(targetId);
-
-		return ReplyVote.builder()
-			.voter(voter)
-			.reply(reply)
-			.build();
-	}
-
 	@Transactional
 	public VoteResponse validateAndToggleVote(Long problemId, Long discussionId, Long replyId, Long userId) {
 
@@ -56,5 +46,15 @@ public class ReplyVoteService extends BaseVoteService<ReplyVote, ReplyVoteDomain
 
 		Optional<ReplyVote> replyVote = toggleVote(voter, replyId);
 		return new VoteResponse(replyVote.isPresent());
+	}
+
+	@Override
+	protected ReplyVote buildVoteEntity(User voter, Long targetId) {
+		Reply reply = replyDomainService.getReplyById(targetId);
+
+		return ReplyVote.builder()
+			.voter(voter)
+			.reply(reply)
+			.build();
 	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/community/model/BaseVote.java
+++ b/src/main/java/org/ezcode/codetest/domain/community/model/BaseVote.java
@@ -14,7 +14,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseVote {

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/community/discussion/DiscussionJpaRepository.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/community/discussion/DiscussionJpaRepository.java
@@ -1,7 +1,5 @@
 package org.ezcode.codetest.infrastructure.persistence.repository.community.discussion;
 
-import java.util.Optional;
-
 import org.ezcode.codetest.domain.community.model.Discussion;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -10,14 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface DiscussionJpaRepository extends JpaRepository<Discussion, Long> {
-
-	@Query("""
-		SELECT d
-		FROM Discussion d
-		WHERE d.id = :discussionId
-		AND d.isDeleted = false
-		""")
-	Optional<Discussion> findByDiscussionId(Long discussionId);
 
 	@EntityGraph(attributePaths = { "user", "problem", "language" })
 	@Query("""

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/community/discussion/DiscussionRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/community/discussion/DiscussionRepositoryImpl.java
@@ -19,26 +19,32 @@ public class DiscussionRepositoryImpl implements DiscussionRepository {
 
 	@Override
 	public Discussion save(Discussion discussion) {
+
 		return discussionJpaRepository.save(discussion);
 	}
 
 	@Override
 	public Optional<Discussion> findById(Long discussionId) {
-		return discussionJpaRepository.findByDiscussionId(discussionId);
+
+		return discussionJpaRepository.findById(discussionId)
+			.filter(d -> !d.isDeleted());
 	}
 
 	@Override
 	public Page<Discussion> findAllByProblemId(Long problemId, Pageable pageable) {
+
 		return discussionJpaRepository.findAllByProblemId(problemId, pageable);
 	}
 
 	@Override
 	public void updateDiscussion(Discussion discussion, Language language, String content) {
+
 		discussion.update(language, content);
 	}
 
 	@Override
 	public void deleteDiscussion(Discussion discussion) {
+
 		discussion.setDeleted();
 	}
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/community/reply/ReplyJpaRepository.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/community/reply/ReplyJpaRepository.java
@@ -1,7 +1,5 @@
 package org.ezcode.codetest.infrastructure.persistence.repository.community.reply;
 
-import java.util.Optional;
-
 import org.ezcode.codetest.domain.community.model.Reply;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -10,14 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface ReplyJpaRepository extends JpaRepository<Reply, Long> {
-
-	@Query("""
-		SELECT r
-		FROM Reply r
-		WHERE r.id = :replyId
-		AND r.isDeleted = false
-		""")
-	Optional<Reply> findByReplyId(Long replyId);
 
 	@EntityGraph(attributePaths = { "user" })
 	@Query("""

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/community/reply/ReplyRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/community/reply/ReplyRepositoryImpl.java
@@ -25,7 +25,8 @@ public class ReplyRepositoryImpl implements ReplyRepository {
 	@Override
 	public Optional<Reply> findReplyById(Long replyId) {
 
-		return replyJpaRepository.findByReplyId(replyId);
+		return replyJpaRepository.findById(replyId)
+			.filter(r -> !r.isDeleted());
 	}
 
 	@Override


### PR DESCRIPTION
---

## 작업 내용

- 중복으로 쿼리를 발생시키지 않고 1차 캐시를 사용하도록 코드를 수정했다.

---

## 변경 사항

- JPQL 사용한 커스텀 쿼리 대신 JPA에서 제공하는 `findById()` 메서드 사용

---

## 트러블 슈팅

- 하나의 트랜잭션 안에서 같은 조회 쿼리가 두 번 호출되는 문제가 있었다.
  - 호출된 쿼리의 결과는 1차 캐시에 저장되므로 중복으로 호출되지 않을 것이라고 생각했지만, 쿼리가 또 날라감
- `@Query("SELECT d FROM Discussion d WHERE d.id = :discussionId ...")` 처럼 JPQL을 명시적으로 작성한 메서드는, 무조건 “JPQL → SQL” 로 변환되어 DB에 조회를 요청한다. 
  - 따라서 1차 캐시에 동일 엔티티가 있어도 SQL이 찍히고, DB에서 다시 데이터를 가져오게 된다.
- 1차 캐시를 사용하려면 `findById(...)` 메서드와 엔티티 필드를 활용하자
  - 아래는 infra의 `ReplyRepositoryImpl.java` 클래스 코드 중 일부
```java
@Override
public Optional<Reply> findReplyById(Long replyId) {

	return replyJpaRepository.findById(replyId)
		.filter(r -> !r.isDeleted());
}

```
- PK를 사용해 조회하므로 속도도 빠르다.

---

## 참고 사항

- MBA-42
- #27 
- https://www.notion.so/teamsparta/1-2082dc3ef51480a98729d199ddc67d3c#2082dc3ef51480b18784e1d0e862f0e1

---

### 코드 리뷰 전 확인 체크리스트

- [x]  불필요한 콘솔 로그, 주석 제거
- [x]  커밋 메시지 컨벤션 준수 (`type : `)
- [x]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
    - 삭제된 토론 및 답글이 조회되지 않도록 개선되었습니다.

- **리팩터링**
    - 투표 엔터티 생성 메서드의 클래스 내 위치가 조정되었습니다.
    - 반복적으로 작성되던 getter 메서드가 자동 생성되도록 개선되었습니다.

- **기타**
    - 불필요한 저장소 메서드가 제거되어 코드가 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->