### PR TITLE
feat : 한글 형태소 검색 알고리즘 추가(nori 플러그인)

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/problem/service/ProblemSearchService.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/service/ProblemSearchService.java
@@ -29,12 +29,14 @@ public class ProblemSearchService {
 				Optional.ofNullable(doc.getReference()).map(Enum::toString),
 				Optional.ofNullable(doc.getDifficulty()),
 				Optional.ofNullable(doc.getCategory()).map(Enum::toString),
-				Optional.ofNullable(doc.getDescription())
+				Optional.ofNullable(doc.getDescription()),
+				Optional.ofNullable(doc.getCategoryKor()),
+				Optional.ofNullable(doc.getDifficultyEn()).map(Enum::toString),
+				Optional.ofNullable(doc.getReferenceKor())
 			))
 			.flatMap(Optional::stream)
 			.map(String::toUpperCase)
 			.collect(Collectors.toSet());
-
 	}
 
 	public List<ProblemSearchResponse> getProblemSearchResult(String keyword) {

--- a/src/main/java/org/ezcode/codetest/domain/problem/exception/code/ProblemExceptionCode.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/exception/code/ProblemExceptionCode.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ProblemExceptionCode implements ResponseCode {
 
-	PROBLEM_NOT_FOUND(false, HttpStatus.NOT_FOUND, "삭제 되었거나, 문제를 찾을수 없습니다.");
+	PROBLEM_NOT_FOUND(false, HttpStatus.NOT_FOUND, "삭제 되었거나, 문제를 찾을수 없습니다."),
+	DIFFICULTY_NOT_FOUND(false, HttpStatus.NOT_FOUND, "삭제 되었거나, 난이도를 찾을수 없습니다.");
 
 	private final boolean success;
 

--- a/src/main/java/org/ezcode/codetest/domain/problem/model/entity/ProblemSearchDocument.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/model/entity/ProblemSearchDocument.java
@@ -1,6 +1,7 @@
 package org.ezcode.codetest.domain.problem.model.entity;
 
 import org.ezcode.codetest.domain.problem.model.enums.Category;
+import org.ezcode.codetest.domain.problem.model.enums.Difficulty;
 import org.ezcode.codetest.domain.problem.model.enums.Reference;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
@@ -60,6 +61,21 @@ public class ProblemSearchDocument {
 	@MultiField(
 		mainField = @Field(
 			type = FieldType.Text,
+			analyzer = "nori_ko_with_en",
+			searchAnalyzer = "nori_ko_with_en"
+		),
+		otherFields = {
+			@InnerField(
+				suffix = "keyword",
+				type = FieldType.Keyword
+			)
+		}
+	)
+	private String categoryKor;
+
+	@MultiField(
+		mainField = @Field(
+			type = FieldType.Text,
 			analyzer = "uppercase_analyzer",
 			searchAnalyzer = "uppercase_standard"
 		),
@@ -87,16 +103,47 @@ public class ProblemSearchDocument {
 			)
 		}
 	)
+	private Difficulty difficultyEn;
+
+	@MultiField(
+		mainField = @Field(
+			type = FieldType.Text,
+			analyzer = "uppercase_analyzer",
+			searchAnalyzer = "uppercase_standard"
+		),
+		otherFields = {
+			@InnerField(
+				suffix = "keyword",
+				type = FieldType.Keyword,
+				normalizer = "uppercase_normalizer"
+			)
+		}
+	)
 	private Reference reference;
+
+	@MultiField(
+		mainField = @Field(
+			type = FieldType.Text,
+			analyzer = "nori_ko_with_en",
+			searchAnalyzer = "nori_ko_with_en"
+		),
+		otherFields = {
+			@InnerField(
+				suffix = "keyword",
+				type = FieldType.Keyword
+			)
+		}
+	)
+	private String referenceKor;
 
 	@Field(
 		type = FieldType.Text,
 		analyzer = "nori_ko_with_en",
-		searchAnalyzer = "uppercase_standard"
+		searchAnalyzer = "nori_ko_with_en"
 	)
 	private String description;
 
-	@Field(type = FieldType.Keyword)
+	@Field(type = FieldType.Integer)
 	private int score;
 
 	@Field(type = FieldType.Boolean)
@@ -110,6 +157,9 @@ public class ProblemSearchDocument {
 		String difficulty,
 		Reference reference,
 		String description,
+		String categoryKor,
+		Difficulty difficultyEn,
+		String referenceKor,
 		int score,
 		Boolean isDeleted
 	) {
@@ -119,6 +169,9 @@ public class ProblemSearchDocument {
 		this.difficulty = difficulty;
 		this.reference = reference;
 		this.description = description;
+		this.categoryKor = categoryKor;
+		this.difficultyEn = difficultyEn;
+		this.referenceKor = referenceKor;
 		this.score = score;
 		this.isDeleted = isDeleted;
 	}
@@ -132,6 +185,9 @@ public class ProblemSearchDocument {
 			.reference(problem.getReference())
 			.description(problem.getDescription())
 			.score(problem.getScore())
+			.categoryKor(problem.getCategory().getDescription())
+			.difficultyEn(Difficulty.getDifficultyFromKor(problem.getDifficulty()))
+			.referenceKor(problem.getReference().getDescription())
 			.isDeleted(problem.getIsDeleted())
 			.build();
 	}

--- a/src/main/java/org/ezcode/codetest/domain/problem/model/enums/Difficulty.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/model/enums/Difficulty.java
@@ -1,5 +1,10 @@
 package org.ezcode.codetest.domain.problem.model.enums;
 
+import java.util.Arrays;
+
+import org.ezcode.codetest.domain.problem.exception.ProblemException;
+import org.ezcode.codetest.domain.problem.exception.code.ProblemExceptionCode;
+
 import lombok.Getter;
 
 @Getter
@@ -17,6 +22,15 @@ public enum Difficulty {
 	Difficulty(String difficulty, int score) {
 		this.difficulty = difficulty;
 		this.score = score;
+	}
+
+	public static Difficulty getDifficultyFromKor(String difficulty) {
+
+		return Arrays
+			.stream(values())
+			.filter(en -> en.getDifficulty().equals(difficulty))
+			.findFirst()
+			.orElseThrow(() -> new ProblemException(ProblemExceptionCode.DIFFICULTY_NOT_FOUND));
 	}
 
 }

--- a/src/main/java/org/ezcode/codetest/domain/problem/repository/ProblemDocumentRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/repository/ProblemDocumentRepository.java
@@ -10,6 +10,7 @@ public interface ProblemDocumentRepository {
 
 	ProblemSearchDocument save(ProblemSearchDocument problemSearch);
 
+	@Deprecated
 	List<ProblemSearchDocument> findAllByKeyword(String keyword);
 
 	List<ProblemSearchDocument> findProblemsByKeyword(String keyword);

--- a/src/main/java/org/ezcode/codetest/domain/problem/repository/ProblemDocumentRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/repository/ProblemDocumentRepository.java
@@ -12,6 +12,8 @@ public interface ProblemDocumentRepository {
 
 	List<ProblemSearchDocument> findAllByKeyword(String keyword);
 
+	List<ProblemSearchDocument> findProblemsByKeyword(String keyword);
+
 	Optional<ProblemSearchDocument> findById(Long id);
 
 	void delete(ProblemSearchDocument document);

--- a/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemSearchDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemSearchDomainService.java
@@ -22,6 +22,6 @@ public class ProblemSearchDomainService {
 
 	public List<ProblemSearchDocument> searchByKeywordMatch(String keyword) {
 
-		return searchRepository.findAllByKeyword(keyword);
+		return searchRepository.findProblemsByKeyword(keyword);
 	}
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/elasticsearch/repository/ProblemElasticsearchAdapter.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/elasticsearch/repository/ProblemElasticsearchAdapter.java
@@ -10,6 +10,7 @@ import org.ezcode.codetest.domain.problem.model.entity.ProblemSearchDocument;
 import org.ezcode.codetest.domain.problem.model.enums.Category;
 import org.ezcode.codetest.domain.problem.model.enums.Reference;
 import org.ezcode.codetest.domain.problem.repository.ProblemDocumentRepository;
+import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.stereotype.Repository;
 
@@ -62,6 +63,13 @@ public class ProblemElasticsearchAdapter implements ProblemDocumentRepository {
 	public List<ProblemSearchDocument> findAllByKeyword(String keyword) {
 
 		return searchRepository.findAllByKeyword(keyword);
+	}
+
+	public List<ProblemSearchDocument> findProblemsByKeyword(String keyword) {
+
+		SearchHits<ProblemSearchDocument> hits = searchRepository.findProblemsByKeyword(keyword);
+
+		return hits.getSearchHits().stream().map(SearchHit::getContent).toList();
 	}
 
 	public Optional<ProblemSearchDocument> findById(Long id) {

--- a/src/main/java/org/ezcode/codetest/infrastructure/elasticsearch/repository/ProblemElasticsearchAdapter.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/elasticsearch/repository/ProblemElasticsearchAdapter.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 
 import org.ezcode.codetest.domain.problem.model.entity.ProblemSearchDocument;
 import org.ezcode.codetest.domain.problem.model.enums.Category;
+import org.ezcode.codetest.domain.problem.model.enums.Difficulty;
 import org.ezcode.codetest.domain.problem.model.enums.Reference;
 import org.ezcode.codetest.domain.problem.repository.ProblemDocumentRepository;
 import org.springframework.data.elasticsearch.core.SearchHit;
@@ -44,12 +45,18 @@ public class ProblemElasticsearchAdapter implements ProblemDocumentRepository {
 				String referenceStr = getElement(hitHighlightFields.get("reference"));
 				String difficulty = getElement(hitHighlightFields.get("difficulty"));
 				String descHighlight = getElement(hitHighlightFields.get("description"));
+				String categoryKorStr = getElement(hitHighlightFields.get("categoryKor"));
+				String referenceKorStr = getElement(hitHighlightFields.get("referenceKor"));
+				String difficultyEn = getElement(hitHighlightFields.get("difficultyEn"));
 
 				ProblemSearchDocument.ProblemSearchDocumentBuilder builder = ProblemSearchDocument.builder()
 					.title(titleStr)
 					.category(categoryStr != null ? Category.valueOf(categoryStr) : null)
 					.reference(referenceStr != null ? Reference.valueOf(referenceStr) : null)
-					.difficulty(difficulty);
+					.difficulty(difficulty)
+					.categoryKor(categoryKorStr)
+					.referenceKor(referenceKorStr)
+					.difficultyEn(difficultyEn != null ? Difficulty.valueOf(difficultyEn) : null);
 
 				if (descHighlight != null) {
 					builder.description(keyword);

--- a/src/main/java/org/ezcode/codetest/infrastructure/elasticsearch/repository/ProblemElasticsearchAdapter.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/elasticsearch/repository/ProblemElasticsearchAdapter.java
@@ -60,6 +60,7 @@ public class ProblemElasticsearchAdapter implements ProblemDocumentRepository {
 			.collect(Collectors.toSet());
 	}
 
+	@Deprecated
 	public List<ProblemSearchDocument> findAllByKeyword(String keyword) {
 
 		return searchRepository.findAllByKeyword(keyword);

--- a/src/main/java/org/ezcode/codetest/infrastructure/elasticsearch/repository/ProblemElasticsearchRepository.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/elasticsearch/repository/ProblemElasticsearchRepository.java
@@ -10,6 +10,7 @@ public interface ProblemElasticsearchRepository extends
 	ElasticsearchRepository<ProblemSearchDocument, Long>,
 	ProblemElasticsearchRepositoryDsl {
 
+	@Deprecated
 	@Query("""
 		{
 		  "bool": {

--- a/src/main/java/org/ezcode/codetest/infrastructure/elasticsearch/repository/ProblemElasticsearchRepositoryDsl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/elasticsearch/repository/ProblemElasticsearchRepositoryDsl.java
@@ -6,4 +6,6 @@ import org.springframework.data.elasticsearch.core.SearchHits;
 public interface ProblemElasticsearchRepositoryDsl {
 
 	SearchHits<ProblemSearchDocument> findFieldsContainingKeyword(String keyword);
+
+	SearchHits<ProblemSearchDocument> findProblemsByKeyword(String keyword);
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/elasticsearch/repository/ProblemElasticsearchRepositoryDslImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/elasticsearch/repository/ProblemElasticsearchRepositoryDslImpl.java
@@ -29,11 +29,13 @@ public class ProblemElasticsearchRepositoryDslImpl implements ProblemElasticsear
 			.withQuery(q -> q.bool(b -> b
 				.filter(f -> f.term(t -> t.field("isDeleted").value(false)))
 				.should(s -> s.match(m -> m.field("title").query(keyword).boost(12f)))
-				.should(s -> s.match(m -> m.field("description").query(keyword).boost(5f)))
-				.should(s -> s.match(m -> m.field("category").query(keyword).boost(5f)))
-				.should(s -> s.match(m -> m.field("difficulty").query(keyword).boost(3f)))
-				.should(s -> s.match(m -> m.field("reference").query(keyword).boost(5f)))
-
+				.should(s -> s.match(m -> m.field("description").query(keyword).boost(3f)))
+				.should(s -> s.match(m -> m.field("category").query(keyword).boost(6f)))
+				.should(s -> s.match(m -> m.field("difficulty").query(keyword).boost(5f)))
+				.should(s -> s.match(m -> m.field("reference").query(keyword).boost(7f)))
+				.should(s -> s.match(m -> m.field("referenceKor").query(keyword).boost(7f)))
+				.should(s -> s.match(m -> m.field("categoryKor").query(keyword).boost(6f)))
+				.should(s -> s.match(m -> m.field("difficultyEn").query(keyword).boost(5f)))
 				.minimumShouldMatch("1")
 			))
 			.withHighlightQuery(
@@ -50,7 +52,10 @@ public class ProblemElasticsearchRepositoryDslImpl implements ProblemElasticsear
 							new HighlightField("category"),
 							new HighlightField("difficulty"),
 							new HighlightField("reference"),
-							new HighlightField("description")
+							new HighlightField("description"),
+							new HighlightField("categoryKor"),
+							new HighlightField("referenceKor"),
+							new HighlightField("difficultyEn")
 						)
 					),
 					ProblemSearchDocument.class
@@ -68,28 +73,33 @@ public class ProblemElasticsearchRepositoryDslImpl implements ProblemElasticsear
 		Query searchQuery = NativeQuery.builder()
 			.withQuery(q -> q.bool(b -> b
 				.filter(f -> f.term(t -> t.field("isDeleted").value(false)))
-
 				.should(s -> s.term(t -> t.field("title.keyword").value(keyword).boost(40f)))
 				.should(s -> s.term(t -> t.field("description.keyword").value(keyword).boost(40f)))
 				.should(s -> s.term(t -> t.field("category.keyword").value(keyword).boost(35f)))
 				.should(s -> s.term(t -> t.field("difficulty.keyword").value(keyword).boost(28f)))
 				.should(s -> s.term(t -> t.field("reference.keyword").value(keyword).boost(32f)))
-
+				.should(s -> s.term(t -> t.field("difficultyEn.keyword").value(keyword).boost(35f)))
+				.should(s -> s.term(t -> t.field("categoryKor.keyword").value(keyword).boost(28f)))
+				.should(s -> s.term(t -> t.field("referenceKor.keyword").value(keyword).boost(32f)))
 				.should(s -> s.bool(bs -> bs
 					.should(ss -> ss.match(m -> m.field("title").query(keyword).boost(12f)))
 					.should(ss -> ss.match(m -> m.field("description").query(keyword).boost(5f)))
 					.should(ss -> ss.match(m -> m.field("category").query(keyword).boost(5f)))
 					.should(ss -> ss.match(m -> m.field("difficulty").query(keyword).boost(3f)))
 					.should(ss -> ss.match(m -> m.field("reference").query(keyword).boost(5f)))
+					.should(ss -> ss.match(m -> m.field("categoryKor").query(keyword).boost(5f)))
+					.should(ss -> ss.match(m -> m.field("difficultyEn").query(keyword).boost(3f)))
+					.should(ss -> ss.match(m -> m.field("referenceKor").query(keyword).boost(5f)))
 					.minimumShouldMatch("1")
-
 					.mustNot(mn -> mn.term(t -> t.field("title.keyword").value(keyword)))
 					.mustNot(mn -> mn.term(t -> t.field("description.keyword").value(keyword)))
 					.mustNot(mn -> mn.term(t -> t.field("category.keyword").value(keyword)))
 					.mustNot(mn -> mn.term(t -> t.field("difficulty.keyword").value(keyword)))
 					.mustNot(mn -> mn.term(t -> t.field("reference.keyword").value(keyword)))
+					.mustNot(mn -> mn.term(t -> t.field("difficultyEn.keyword").value(keyword)))
+					.mustNot(mn -> mn.term(t -> t.field("categoryKor.keyword").value(keyword)))
+					.mustNot(mn -> mn.term(t -> t.field("referenceKor.keyword").value(keyword)))
 				))
-
 				.minimumShouldMatch("1")
 			))
 			.withSourceFilter(

--- a/src/main/java/org/ezcode/codetest/infrastructure/elasticsearch/repository/ProblemElasticsearchRepositoryDslImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/elasticsearch/repository/ProblemElasticsearchRepositoryDslImpl.java
@@ -63,4 +63,42 @@ public class ProblemElasticsearchRepositoryDslImpl implements ProblemElasticsear
 
 		return elasticsearchOperations.search(searchQuery, ProblemSearchDocument.class);
 	}
+
+	public SearchHits<ProblemSearchDocument> findProblemsByKeyword(String keyword) {
+		Query searchQuery = NativeQuery.builder()
+			.withQuery(q -> q.bool(b -> b
+				.filter(f -> f.term(t -> t.field("isDeleted").value(false)))
+
+				.should(s -> s.term(t -> t.field("title.keyword").value(keyword).boost(40f)))
+				.should(s -> s.term(t -> t.field("description.keyword").value(keyword).boost(40f)))
+				.should(s -> s.term(t -> t.field("category.keyword").value(keyword).boost(35f)))
+				.should(s -> s.term(t -> t.field("difficulty.keyword").value(keyword).boost(28f)))
+				.should(s -> s.term(t -> t.field("reference.keyword").value(keyword).boost(32f)))
+
+				.should(s -> s.bool(bs -> bs
+					.should(ss -> ss.match(m -> m.field("title").query(keyword).boost(12f)))
+					.should(ss -> ss.match(m -> m.field("description").query(keyword).boost(5f)))
+					.should(ss -> ss.match(m -> m.field("category").query(keyword).boost(5f)))
+					.should(ss -> ss.match(m -> m.field("difficulty").query(keyword).boost(3f)))
+					.should(ss -> ss.match(m -> m.field("reference").query(keyword).boost(5f)))
+					.minimumShouldMatch("1")
+
+					.mustNot(mn -> mn.term(t -> t.field("title.keyword").value(keyword)))
+					.mustNot(mn -> mn.term(t -> t.field("description.keyword").value(keyword)))
+					.mustNot(mn -> mn.term(t -> t.field("category.keyword").value(keyword)))
+					.mustNot(mn -> mn.term(t -> t.field("difficulty.keyword").value(keyword)))
+					.mustNot(mn -> mn.term(t -> t.field("reference.keyword").value(keyword)))
+				))
+
+				.minimumShouldMatch("1")
+			))
+			.withSourceFilter(
+				new FetchSourceFilterBuilder()
+					.withIncludes("title", "description", "category", "difficulty", "reference")
+					.build()
+			)
+			.build();
+
+		return elasticsearchOperations.search(searchQuery, ProblemSearchDocument.class);
+	}
 }

--- a/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemSearchController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/problemmanagement/ProblemSearchController.java
@@ -7,14 +7,18 @@ import org.ezcode.codetest.application.problem.service.ProblemSearchService;
 import org.ezcode.codetest.application.problem.dto.response.ProblemSearchResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 
 @RestController
+@Validated
 @RequiredArgsConstructor
 @RequestMapping("/problems/search")
 public class ProblemSearchController {
@@ -22,13 +26,21 @@ public class ProblemSearchController {
 	private final ProblemSearchService searchService;
 
 	@GetMapping("/suggestions")
-	public ResponseEntity<Set<String>> getProblemSuggestions(@RequestParam String keyword) {
+	public ResponseEntity<Set<String>> getProblemSuggestions(
+		@RequestParam
+		@NotBlank(message = "검색어를 입력하세요.")
+		@Size(min = 2, max = 25, message = "검색어 길이는 2~25 사이입니다.")
+		String keyword) {
 
 		return ResponseEntity.status(HttpStatus.OK).body(searchService.getProblemSuggestions(keyword));
 	}
 
 	@GetMapping
-	public ResponseEntity<List<ProblemSearchResponse>> getProblemSearchResult(@RequestParam String keyword) {
+	public ResponseEntity<List<ProblemSearchResponse>> getProblemSearchResult(
+		@RequestParam
+		@NotBlank(message = "검색어를 입력하세요.")
+		@Size(min = 2, max = 25, message = "검색어 길이는 2~25 사이입니다.")
+		String keyword) {
 
 		return ResponseEntity.status(HttpStatus.OK).body(searchService.getProblemSearchResult(keyword));
 	}

--- a/src/main/resources/elasticsearch/my_index-settings.json
+++ b/src/main/resources/elasticsearch/my_index-settings.json
@@ -28,23 +28,8 @@
         "nori_pos_filter": {
           "type": "nori_part_of_speech",
           "stoptags": [
-            "IC",
-            "MAG",
-            "MAJ",
-            "MM",
-            "VA",
-            "VX",
-            "VCP",
-            "VSV",
-            "SF",
-            "SP",
-            "SE",
-            "XPN",
-            "XSN",
-            "XSV",
-            "XSA",
-            "NA",
-            "UNA"
+            "IC","MAG","MAJ","MM","VA","VX","VCP","VSV",
+            "SF","SP","SE","XPN","XSN","XSV","XSA","NA","UNA"
           ]
         }
       },
@@ -66,13 +51,13 @@
         "lowercase_standard": {
           "tokenizer": "uax_url_email",
           "filter": [
-            "lowercase"
+            "lowercase_filter"
           ]
         },
         "uppercase_standard": {
           "tokenizer": "uax_url_email",
           "filter": [
-            "uppercase"
+            "uppercase_filter"
           ]
         },
         "nori_ko_with_en": {
@@ -129,7 +114,28 @@
           }
         }
       },
+      "categoryKor": {
+        "type": "text",
+        "analyzer": "nori_ko_with_en",
+        "search_analyzer": "nori_ko_with_en",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
       "difficulty": {
+        "type": "text",
+        "analyzer": "uppercase_analyzer",
+        "search_analyzer": "uppercase_standard",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "normalizer": "uppercase_normalizer"
+          }
+        }
+      },
+      "difficultyEn": {
         "type": "text",
         "analyzer": "uppercase_analyzer",
         "search_analyzer": "uppercase_standard",
@@ -151,11 +157,21 @@
           }
         }
       },
+      "referenceKor": {
+        "type": "text",
+        "analyzer": "nori_ko_with_en",
+        "search_analyzer": "nori_ko_with_en",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
       "isDeleted": {
         "type": "boolean"
       },
       "score": {
-        "type": "keyword"
+        "type": "integer"
       },
       "id": {
         "type": "keyword"
@@ -163,4 +179,3 @@
     }
   }
 }
-

--- a/src/main/resources/templates/search-page.html
+++ b/src/main/resources/templates/search-page.html
@@ -112,7 +112,7 @@
       padding: 27px 0;
       font-size: 1.78rem;
       width: 100%;
-      margin-top: 14px;
+      margin-top: 14px;  /* 버튼을 조금 더 아래로 내림 */
       letter-spacing: 0.01em;
       cursor: pointer;
       transition: background 0.17s, box-shadow 0.17s;
@@ -338,6 +338,10 @@
         return;
       }
       try {
+        const resultsDiv = document.getElementById('results');
+        // 이전 애니메이션 제거
+        resultsDiv.classList.remove('visible');
+
         const resp = await fetch('/problems/search?keyword=' + encodeURIComponent(keyword), {
           method: 'GET',
           headers: { 'Authorization': 'Bearer ' + token }
@@ -347,10 +351,6 @@
           return;
         }
         const data = await resp.json();
-        const resultsDiv = document.getElementById('results');
-
-        // 이전 애니메이션 제거
-        resultsDiv.classList.remove('visible');
 
         if (data.success && Array.isArray(data.result)) {
           const results = data.result;


### PR DESCRIPTION
MBA-7 #comment 한글 형태소 검색 알고리즘 추가(nori 플러그인)

---

## 작업 내용

- 검색엔진에서 한글로 검색 시 좀 더 세밀하게 검색조건이 필터 되게끔 변경되었습니다(nori 플러그인 설치).  토큰화 할시 단어의 조사(ex ~의 ~가) 등을 제거하고 실제 명사만 토큰화 해서 저장하기 때문에 명사만 맞아 떨어지면 검색 되게 끔 변경되었습니다.

---

## 변경 사항

![image](https://github.com/user-attachments/assets/1d999b60-9867-4494-a585-88d111eab534)

단순한 @Query 어노테이션으로는 상세한 검색조건이 불가능해서 쿼리Dsl 을 적용하여 좀 더 세밀하게 검색 결과를 긁어옵니다.

---

## 해결해야 할 문제

- 검색엔진의 경우, 지속적으로 성능 튜닝이 필요하기에 프로젝트가 마무리 될때까지 지속적으로 리팩토링 예정입니다.

---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
	- 키워드 검색 기능이 개선되어 더욱 정확한 문제 검색이 가능합니다.
	- 검색어 입력 시 최소 2자 이상, 최대 25자 이하로 제한되어 검색 품질이 향상되었습니다.
	- 문제 검색 결과에 한국어 카테고리, 난이도(영문), 참고 정보가 추가되어 더 풍부한 정보를 제공합니다.
- **버그 수정**
	- 검색 시 이전 결과 애니메이션이 즉시 제거되어 반응 속도가 개선되었습니다.
- **스타일**
	- 검색 버튼 위치 조정에 대한 설명이 CSS 주석으로 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->