### PR TITLE
test : 채팅 도메인 서비스 테스트 코드 추가

### DIFF
--- a/src/test/java/org/ezcode/codetest/application/chatting/service/ChattingUseCaseTest.java
+++ b/src/test/java/org/ezcode/codetest/application/chatting/service/ChattingUseCaseTest.java
@@ -39,19 +39,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 @DisplayName("채팅 서비스 테스트")
 class ChattingUseCaseTest {
 
-	private static final String TEST_EMAIL      = "test@unknow.com";
-	private static final String TEST_PRINCIPAL  = "익명 Principal";
-	private static final String TEST_SESSION_ID = "임시 세션 ID";
-	private static final Long   TEST_ROOM_ID    = 1L;
-	private static final String TEMP_TITLE_1    = "임시 방 제목1";
-	private static final String TEMP_TITLE_2    = "임시 방 제목2";
-	private static final String TEMP_MESSAGE_1  = "임시 채팅 메시지";
-	private static final String TEMP_MESSAGE_2  = "임시 채팅 메시지2";
-	private static final String EVENT_CREATE    = "CREATE";
-	private static final String EVENT_DELETE    = "DELETE";
-	private static final String EVENT_GET       = "GET";
-	private static final String EVENT_UPDATE    = "UPDATE";
-
 	@InjectMocks
 	private ChattingUseCase chattingUseCase;
 
@@ -72,6 +59,19 @@ class ChattingUseCaseTest {
 	private List<ChatRoomCache> cacheChatRooms;
 	private List<ChatRoom>      chatRooms;
 	private List<Chat>          chats;
+
+	private static final String TEST_EMAIL      = "test@unknow.com";
+	private static final String TEST_PRINCIPAL  = "익명 Principal";
+	private static final String TEST_SESSION_ID = "임시 세션 ID";
+	private static final Long   TEST_ROOM_ID    = 1L;
+	private static final String TEMP_TITLE_1    = "임시 방 제목1";
+	private static final String TEMP_TITLE_2    = "임시 방 제목2";
+	private static final String TEMP_MESSAGE_1  = "임시 채팅 메시지";
+	private static final String TEMP_MESSAGE_2  = "임시 채팅 메시지2";
+	private static final String EVENT_CREATE    = "CREATE";
+	private static final String EVENT_DELETE    = "DELETE";
+	private static final String EVENT_GET       = "GET";
+	private static final String EVENT_UPDATE    = "UPDATE";
 
 	@BeforeEach
 	void setUp() {

--- a/src/test/java/org/ezcode/codetest/domain/chat/service/ChattingDomainServiceTest.java
+++ b/src/test/java/org/ezcode/codetest/domain/chat/service/ChattingDomainServiceTest.java
@@ -1,0 +1,214 @@
+package org.ezcode.codetest.domain.chat.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.ezcode.codetest.domain.chat.exception.ChattingException;
+import org.ezcode.codetest.domain.chat.exception.ChattingExceptionCode;
+import org.ezcode.codetest.domain.chat.model.Chat;
+import org.ezcode.codetest.domain.chat.model.ChatRoom;
+import org.ezcode.codetest.domain.chat.repository.ChatRepository;
+import org.ezcode.codetest.domain.chat.repository.ChatRoomRepository;
+import org.ezcode.codetest.domain.user.model.entity.User;
+import org.ezcode.codetest.domain.user.model.enums.Tier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("채팅 도메인 서비스 테스트")
+class ChattingDomainServiceTest {
+
+	@InjectMocks
+	private ChattingDomainService chattingDomainService;
+
+	@Mock
+	private ChatRepository chatRepository;
+
+	@Mock
+	private ChatRoomRepository chatRoomRepository;
+
+	@Spy
+	private ChatRoom chatRoom;
+
+	private User user;
+	private Chat chat;
+
+	private static final Long TEST_ROOM_ID = 1L;
+	private static final Long WRONG_USER_ID = 2L;
+	private static final String TEMP_TITLE_1 = "임시 방 제목1";
+	private static final String TEST_EMAIL = "test@unknow.com";
+	private static final String TEMP_MESSAGE_1 = "임시 채팅 메시지";
+
+	@BeforeEach
+	void setUp() {
+
+		user = User.builder()
+			.email(TEST_EMAIL)
+			.username("익명")
+			.password("P@ssw0rd1225")
+			.nickname("익명 닉네임")
+			.tier(Tier.NEWBIE)
+			.age(22)
+			.build();
+
+		ReflectionTestUtils.setField(user, "id", TEST_ROOM_ID);
+
+		chatRoom = ChatRoom.builder()
+			.title(TEMP_TITLE_1)
+			.user(user)
+			.isDeleted(false)
+			.build();
+
+		ReflectionTestUtils.setField(chatRoom, "id", TEST_ROOM_ID);
+
+		chatRoom = spy(chatRoom);
+
+		chat = Chat.builder()
+			.user(user)
+			.chatRoom(chatRoom)
+			.message(TEMP_MESSAGE_1)
+			.build();
+	}
+
+	@Nested
+	@DisplayName("채팅 도메인 서비스 성공 테스트")
+	class ChattingUseCaseSuccessTest {
+
+		@Test
+		@DisplayName("채팅룸 저장 성공")
+		void createChatRoom() {
+
+			// when
+			chattingDomainService.createChatRoom(chatRoom);
+
+			// then
+			verify(chatRoomRepository).save(chatRoom);
+		}
+
+		@Test
+		@DisplayName("채팅룸 삭제 성공")
+		void removeChatRoom() {
+
+			// when
+			chattingDomainService.removeChatRoom(chatRoom);
+
+			// then
+			verify(chatRoomRepository).delete(chatRoom);
+		}
+
+		@Test
+		@DisplayName("채팅룸 주인 확인 성공")
+		void isChatRoomOwner() {
+
+			// given
+			doReturn(true).when(chatRoom).isOwner(user.getId());
+
+			// when
+			chattingDomainService.isChatRoomOwner(chatRoom, user.getId());
+
+			// then
+			assertDoesNotThrow(() ->
+				chattingDomainService.isChatRoomOwner(chatRoom, user.getId())
+			);
+		}
+
+		@Test
+		@DisplayName("채팅룸 리스트 조회 성공")
+		void getChatRoomList() {
+
+			// when
+			chattingDomainService.getChatRoomList();
+
+			// then
+			verify(chatRoomRepository).findAll();
+		}
+
+		@Test
+		@DisplayName("채팅 저장 성공")
+		void createChatting() {
+
+			// when
+			chattingDomainService.createChatting(chat);
+
+			// then
+			verify(chatRepository).save(chat);
+		}
+
+		@Test
+		@DisplayName("채팅룸 단일 조회 성공")
+		void getChatRoom() {
+
+			// given
+			given(chatRoomRepository.findChatRoom(TEST_ROOM_ID)).willReturn(Optional.of(chatRoom));
+
+			// when
+			chattingDomainService.getChatRoom(TEST_ROOM_ID);
+
+			// then
+			verify(chatRoomRepository).findChatRoom(TEST_ROOM_ID);
+		}
+
+		@Test
+		@DisplayName("채팅룸 대화 내역 조회 성공")
+		void getRoomChatting() {
+
+			// when
+			chattingDomainService.getRoomChatting(TEST_ROOM_ID);
+
+			// then
+			verify(chatRepository).findChatsFromLastHour(TEST_ROOM_ID);
+		}
+
+	}
+
+	@Nested
+	@DisplayName("채팅 도메인 서비스 실패 테스트")
+	class ChattingUseCaseFailureTest {
+
+		@Test
+		@DisplayName("채팅룸 주인 확인 실패")
+		void isChatRoomOwner() {
+
+			// given
+			doReturn(false).when(chatRoom).isOwner(WRONG_USER_ID);
+
+			// when
+			ChattingException exception = assertThrows(ChattingException.class,
+				() -> chattingDomainService.isChatRoomOwner(chatRoom, WRONG_USER_ID));
+
+			// then
+			assertAll(
+				() -> assertEquals(ChattingExceptionCode.CHATROOM_NOT_OWNER, exception.getResponseCode())
+			);
+		}
+
+		@Test
+		@DisplayName("채팅룸 단일 조회 실패")
+		void getChatRoom() {
+
+			// given
+			given(chatRoomRepository.findChatRoom(TEST_ROOM_ID)).willReturn(Optional.empty());
+
+			// when
+			ChattingException exception = assertThrows(ChattingException.class,
+				() -> chattingDomainService.getChatRoom(TEST_ROOM_ID));
+
+			// then
+			verify(chatRoomRepository).findChatRoom(TEST_ROOM_ID);
+
+			assertAll(
+				() -> assertEquals(ChattingExceptionCode.CHATTING_ROOM_NOT_FOUND, exception.getResponseCode())
+			);
+		}
+	}
+}


### PR DESCRIPTION

---

## 작업 내용

- 채팅 도메인 서비스 테스트 코드 추가하였습니다.

---

## 변경 사항
![image](https://github.com/user-attachments/assets/51705897-f083-40ae-9c41-1feee1779d18)


### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
  - 채팅 도메인 서비스에 대한 단위 테스트가 추가되었습니다.
  - 기존 테스트 클래스 내 상수 선언 위치가 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->