### PR TITLE
Refactor : User OAuth, 부가적 메서드 추가

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/community/dto/response/DiscussionResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/community/dto/response/DiscussionResponse.java
@@ -1,6 +1,6 @@
 package org.ezcode.codetest.application.community.dto.response;
 
-import org.ezcode.codetest.application.usermanagement.user.dto.SimpleUserInfoResponse;
+import org.ezcode.codetest.application.usermanagement.user.dto.response.SimpleUserInfoResponse;
 import org.ezcode.codetest.domain.community.model.Discussion;
 
 public record DiscussionResponse(

--- a/src/main/java/org/ezcode/codetest/application/community/dto/response/ReplyResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/community/dto/response/ReplyResponse.java
@@ -1,6 +1,6 @@
 package org.ezcode.codetest.application.community.dto.response;
 
-import org.ezcode.codetest.application.usermanagement.user.dto.SimpleUserInfoResponse;
+import org.ezcode.codetest.application.usermanagement.user.dto.response.SimpleUserInfoResponse;
 import org.ezcode.codetest.domain.community.model.Reply;
 
 public record ReplyResponse(

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/auth/dto/signin/OAuthResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/auth/dto/signin/OAuthResponse.java
@@ -1,0 +1,10 @@
+package org.ezcode.codetest.application.usermanagement.auth.dto.signin;
+
+public record OAuthResponse(
+	String accessToken,
+	String refreshToken
+){
+	public static OAuthResponse from(String accessToken, String refreshToken) {
+		return new OAuthResponse(accessToken, refreshToken);
+	}
+}

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/auth/dto/signin/SigninResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/auth/dto/signin/SigninResponse.java
@@ -1,7 +1,8 @@
 package org.ezcode.codetest.application.usermanagement.auth.dto.signin;
 
-public record SigninResponse(String token)  {
-	public static SigninResponse from(String token) {
-		return new SigninResponse(token);
+
+public record SigninResponse(String accessToken, String refreshToken)  {
+	public static SigninResponse from(String accessToken, String refreshToken) {
+		return new SigninResponse(accessToken, refreshToken);
 	}
 }

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/auth/service/AuthService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/auth/service/AuthService.java
@@ -80,6 +80,8 @@ public class AuthService {
 
     	User loginUser = userDomainService.getUser(signinRequest.getEmail());
 
+		userDomainService.isDeletedUser(loginUser);
+
 		//OAuth 가입 유저는 일반 로그인 불가능(향후 이메일과 소셜 모두 가입되어있는 회원의 경우 로그인 가능할 수 있도록 리팩토링)
 		if (!loginUser.getAuthType().equals(AuthType.EMAIL)) {
 			throw new AuthException(AuthExceptionCode.AUTH_TYPE_MISMATCH);

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/auth/service/AuthService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/auth/service/AuthService.java
@@ -112,7 +112,7 @@ public class AuthService {
 			jwtUtil.getExpiration(refreshToken),
 			TimeUnit.MILLISECONDS);
 
-		return SigninResponse.from(bearToken);
+		return SigninResponse.from(bearToken, refreshToken);
 	}
 
 	public LogoutResponse logout(Long userId, HttpServletRequest request) {

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/auth/service/AuthService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/auth/service/AuthService.java
@@ -126,7 +126,7 @@ public class AuthService {
 
 		Long expiration = jwtUtil.getRemainingTime(token);
 
-		// Redis 실패 시에도 로그아웃 성공으로 처리 (보안상 사용자에게 노출하지 않음)
+		// Redis 실패 시에도 로그아웃 성공으로 처리 (보안상 사용자에게 노출하지 않음!)
 		try {
 			//블랙리스트로 등록하기
 			redisTemplate.opsForValue().set(
@@ -138,9 +138,9 @@ public class AuthService {
 
 			redisTemplate.delete("RefreshToken:" + userId);
 			} catch (Exception e) {
-				log.error("Redis 오류로 인한 로그아웃 처리 실패", e);}
+				log.error("Redis 오류로 인한 로그아웃 실패", e);}
 
-		return new LogoutResponse("success");
+		return new LogoutResponse("로그아웃 성공");
 	}
 
 	//토큰 재발급

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/auth/service/AuthService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/auth/service/AuthService.java
@@ -8,17 +8,15 @@ import org.ezcode.codetest.application.usermanagement.auth.dto.signin.SigninResp
 import org.ezcode.codetest.application.usermanagement.auth.dto.signup.SignupRequest;
 import org.ezcode.codetest.application.usermanagement.auth.dto.signup.SignupResponse;
 import org.ezcode.codetest.application.usermanagement.auth.port.JwtUtil;
-import org.ezcode.codetest.application.usermanagement.user.dto.LogoutResponse;
+import org.ezcode.codetest.application.usermanagement.user.dto.response.LogoutResponse;
 import org.ezcode.codetest.domain.user.exception.AuthException;
 import org.ezcode.codetest.domain.user.exception.AuthExceptionCode;
 import org.ezcode.codetest.domain.user.model.entity.User;
 import org.ezcode.codetest.domain.user.model.enums.AuthType;
 import org.ezcode.codetest.domain.user.service.UserDomainService;
-import org.ezcode.codetest.infrastructure.security.jwt.JwtUtilImpl;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
-import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/request/ChangeUserPasswordRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/request/ChangeUserPasswordRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record ChangeUserPasswordRequest(
+	@NotBlank
 	String oldPassword,
 
 	@NotBlank(message = "비밀번호는 공백일 수 없습니다.")

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/request/ChangeUserPasswordRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/request/ChangeUserPasswordRequest.java
@@ -1,7 +1,15 @@
 package org.ezcode.codetest.application.usermanagement.user.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
 public record ChangeUserPasswordRequest(
 	String oldPassword,
+
+	@NotBlank(message = "비밀번호는 공백일 수 없습니다.")
+	@Pattern(
+		regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,20}$",
+		message = "비밀번호는 영문, 숫자, 특수문자를 포함한 8~20자리여야 합니다.")
 	String newPassword
 ) {
 }

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/request/ChangeUserPasswordRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/request/ChangeUserPasswordRequest.java
@@ -1,0 +1,7 @@
+package org.ezcode.codetest.application.usermanagement.user.dto.request;
+
+public record ChangeUserPasswordRequest(
+	String oldPassword,
+	String newPassword
+) {
+}

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/request/ModifyUserInfoRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/request/ModifyUserInfoRequest.java
@@ -1,6 +1,5 @@
 package org.ezcode.codetest.application.usermanagement.user.dto.request;
 
-
 public record ModifyUserInfoRequest(
 	String nickname,
 

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/request/ModifyUserInfoRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/request/ModifyUserInfoRequest.java
@@ -1,4 +1,4 @@
-package org.ezcode.codetest.application.usermanagement.user.dto;
+package org.ezcode.codetest.application.usermanagement.user.dto.request;
 
 
 public record ModifyUserInfoRequest(

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/ChangeUserPasswordResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/ChangeUserPasswordResponse.java
@@ -1,0 +1,11 @@
+package org.ezcode.codetest.application.usermanagement.user.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class ChangeUserPasswordResponse {
+	String message;
+	public ChangeUserPasswordResponse(String message) {
+		this.message = message;
+	}
+}

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/GoogleOAuth2Response.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/GoogleOAuth2Response.java
@@ -1,4 +1,4 @@
-package org.ezcode.codetest.application.usermanagement.user.dto;
+package org.ezcode.codetest.application.usermanagement.user.dto.response;
 
 import java.util.Map;
 

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/LogoutResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/LogoutResponse.java
@@ -1,4 +1,4 @@
-package org.ezcode.codetest.application.usermanagement.user.dto;
+package org.ezcode.codetest.application.usermanagement.user.dto.response;
 
 import lombok.Getter;
 

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/OAuth2Response.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/OAuth2Response.java
@@ -1,4 +1,4 @@
-package org.ezcode.codetest.application.usermanagement.user.dto;
+package org.ezcode.codetest.application.usermanagement.user.dto.response;
 
 public interface OAuth2Response {
 	//제공자가 누군지

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/SimpleUserInfoResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/SimpleUserInfoResponse.java
@@ -1,4 +1,4 @@
-package org.ezcode.codetest.application.usermanagement.user.dto;
+package org.ezcode.codetest.application.usermanagement.user.dto.response;
 
 import org.ezcode.codetest.domain.user.model.entity.User;
 import org.ezcode.codetest.domain.user.model.enums.Tier;

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/UserInfoResponse.java
@@ -1,4 +1,4 @@
-package org.ezcode.codetest.application.usermanagement.user.dto;
+package org.ezcode.codetest.application.usermanagement.user.dto.response;
 
 import org.ezcode.codetest.domain.user.model.entity.User;
 import org.ezcode.codetest.domain.user.model.enums.Tier;

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/WithdrawUserResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/WithdrawUserResponse.java
@@ -1,0 +1,4 @@
+package org.ezcode.codetest.application.usermanagement.user.dto.response;
+
+public record WithdrawUserResponse(String message) {
+}

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
@@ -83,6 +83,8 @@ public class UserService {
 			throw new AuthException(AuthExceptionCode.NOT_EMAIL_USER);
 		}
 
+		userDomainService.userPasswordCheck(authUser.getEmail(), changeUserPasswordRequest.oldPassword());
+
 		//기존 비밀번호와 새로운 비밀번호가 같은지 확인 -> 기존과 같으면 변경 불가
 		userDomainService.passwordComparison(changeUserPasswordRequest.newPassword(), user.getPassword());
 
@@ -97,6 +99,8 @@ public class UserService {
 	@Transactional
 	public WithdrawUserResponse withdrawUser(AuthUser authUser) {
 		User user = userDomainService.getUserById(authUser.getId());
+
+		userDomainService.isDeletedUser(user);
 
 		user.setDeleted();
 

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
@@ -1,9 +1,14 @@
 package org.ezcode.codetest.application.usermanagement.user.service;
 
-import org.ezcode.codetest.application.usermanagement.user.dto.ModifyUserInfoRequest;
-import org.ezcode.codetest.application.usermanagement.user.dto.UserInfoResponse;
+import org.ezcode.codetest.application.usermanagement.user.dto.request.ChangeUserPasswordRequest;
+import org.ezcode.codetest.application.usermanagement.user.dto.request.ModifyUserInfoRequest;
+import org.ezcode.codetest.application.usermanagement.user.dto.response.ChangeUserPasswordResponse;
+import org.ezcode.codetest.application.usermanagement.user.dto.response.UserInfoResponse;
+import org.ezcode.codetest.domain.user.exception.AuthException;
+import org.ezcode.codetest.domain.user.exception.AuthExceptionCode;
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.ezcode.codetest.domain.user.model.entity.User;
+import org.ezcode.codetest.domain.user.model.enums.AuthType;
 import org.ezcode.codetest.domain.user.service.UserDomainService;
 import org.springframework.stereotype.Service;
 
@@ -62,5 +67,24 @@ public class UserService {
 			.userRole(user.getRole())
 			.tier(user.getTier())
 			.build();
+	}
+
+	@Transactional
+	public ChangeUserPasswordResponse modifyUserPassword(AuthUser authUser, ChangeUserPasswordRequest changeUserPasswordRequest) {
+		User user = userDomainService.getUserById(authUser.getId());
+
+		//소셜로그인 회원은 변경 불가
+		if (!user.getAuthType().equals(AuthType.EMAIL)) {
+			throw new AuthException(AuthExceptionCode.NOT_EMAIL_USER);
+		}
+
+		//기존 비밀번호와 새로운 비밀번호가 같은지 확인 -> 기존과 같으면 변경 불가
+		userDomainService.passwordComparison(changeUserPasswordRequest.newPassword(), user.getPassword());
+
+		String newPassword = userDomainService.encodePassword(changeUserPasswordRequest.newPassword());
+
+		user.modifyPassword(newPassword);
+
+		return new ChangeUserPasswordResponse("비밀번호를 성공적으로 변경했습니다");
 	}
 }

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
@@ -11,9 +11,12 @@ import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.ezcode.codetest.domain.user.model.entity.User;
 import org.ezcode.codetest.domain.user.model.enums.AuthType;
 import org.ezcode.codetest.domain.user.service.UserDomainService;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -23,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 public class UserService {
 
 	private final UserDomainService userDomainService;
+	private final RedisTemplate<String, String> redisTemplate;
 
 	@Transactional(readOnly = true)
 	public UserInfoResponse getUserInfo(AuthUser authUser) {
@@ -95,6 +99,9 @@ public class UserService {
 		User user = userDomainService.getUserById(authUser.getId());
 
 		user.setDeleted();
+
+
+		redisTemplate.delete("RefreshToken:"+authUser.getId());
 
 		return new WithdrawUserResponse("탈퇴가 완료되었습니다");
 	}

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
@@ -4,6 +4,7 @@ import org.ezcode.codetest.application.usermanagement.user.dto.request.ChangeUse
 import org.ezcode.codetest.application.usermanagement.user.dto.request.ModifyUserInfoRequest;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.ChangeUserPasswordResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.UserInfoResponse;
+import org.ezcode.codetest.application.usermanagement.user.dto.response.WithdrawUserResponse;
 import org.ezcode.codetest.domain.user.exception.AuthException;
 import org.ezcode.codetest.domain.user.exception.AuthExceptionCode;
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
@@ -86,5 +87,15 @@ public class UserService {
 		user.modifyPassword(newPassword);
 
 		return new ChangeUserPasswordResponse("비밀번호를 성공적으로 변경했습니다");
+	}
+
+
+	@Transactional
+	public WithdrawUserResponse withdrawUser(AuthUser authUser) {
+		User user = userDomainService.getUserById(authUser.getId());
+
+		user.setDeleted();
+
+		return new WithdrawUserResponse("탈퇴가 완료되었습니다");
 	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/user/exception/AuthExceptionCode.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/exception/AuthExceptionCode.java
@@ -3,6 +3,7 @@ package org.ezcode.codetest.domain.user.exception;
 import org.ezcode.codetest.common.base.exception.ResponseCode;
 import org.springframework.http.HttpStatus;
 
+import co.elastic.clients.elasticsearch.nodes.Http;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -17,8 +18,10 @@ public enum AuthExceptionCode implements ResponseCode {
 	INVALID_AUTHORIZATION_HEADER(false, HttpStatus.BAD_REQUEST, "유효하지 않은 Authorization 헤더"),
 	AUTH_TYPE_MISMATCH(false, HttpStatus.BAD_REQUEST, "소셜 가입 회원입니다"),
 	INVALID_REFRESH_TOKEN(false, HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않거나 없습니다"),
+	ALREADY_EXIST_USER(false, HttpStatus.BAD_REQUEST, "이미 가입된 유저입니다."),
+	NOT_EMAIL_USER(false, HttpStatus.BAD_REQUEST, "소셜 로그인 회원은 비밀번호 변경을 할 수 없습니다."),
 
-	ALREADY_EXIST_USER(false, HttpStatus.BAD_REQUEST, "이미 가입된 유저입니다.");
+	PASSWORD_IS_SAME(false, HttpStatus.BAD_REQUEST, "기존 비밀번호와 같습니다");
 
 	private final boolean success;
 	private final HttpStatus status;

--- a/src/main/java/org/ezcode/codetest/domain/user/exception/AuthExceptionCode.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/exception/AuthExceptionCode.java
@@ -2,8 +2,6 @@ package org.ezcode.codetest.domain.user.exception;
 
 import org.ezcode.codetest.common.base.exception.ResponseCode;
 import org.springframework.http.HttpStatus;
-
-import co.elastic.clients.elasticsearch.nodes.Http;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -11,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum AuthExceptionCode implements ResponseCode {
 	NO_AUTH_INFO(false, HttpStatus.BAD_REQUEST, "인증 정보가 없습니다."),
-	EXIST_USER_EMAIL(false, HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
 	USER_NOT_FOUND(false, HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다"),
 	PASSWORD_NOT_MATCH(false, HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다"),
 	LOGOUT_USER(false, HttpStatus.BAD_REQUEST, "이미 로그아웃한 유저입니다."),

--- a/src/main/java/org/ezcode/codetest/domain/user/exception/AuthExceptionCode.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/exception/AuthExceptionCode.java
@@ -20,8 +20,10 @@ public enum AuthExceptionCode implements ResponseCode {
 	INVALID_REFRESH_TOKEN(false, HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않거나 없습니다"),
 	ALREADY_EXIST_USER(false, HttpStatus.BAD_REQUEST, "이미 가입된 유저입니다."),
 	NOT_EMAIL_USER(false, HttpStatus.BAD_REQUEST, "소셜 로그인 회원은 비밀번호 변경을 할 수 없습니다."),
+	PASSWORD_IS_SAME(false, HttpStatus.BAD_REQUEST, "기존 비밀번호와 같습니다. 새로운 비밀번호는 기존 비밀번호와 달라야합니다."),
+	ALREADY_WITHDRAW_USER(false, HttpStatus.NOT_FOUND, "탈퇴된 회원입니다.")
 
-	PASSWORD_IS_SAME(false, HttpStatus.BAD_REQUEST, "기존 비밀번호와 같습니다");
+	;
 
 	private final boolean success;
 	private final HttpStatus status;

--- a/src/main/java/org/ezcode/codetest/domain/user/model/entity/CustomOAuth2User.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/model/entity/CustomOAuth2User.java
@@ -2,6 +2,7 @@ package org.ezcode.codetest.domain.user.model.entity;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import org.ezcode.codetest.application.usermanagement.user.dto.OAuth2Response;
@@ -14,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CustomOAuth2User implements OAuth2User {
 	private final OAuth2Response oAuth2Response;
-	private final String userRole;
 
 	@Override
 	public Map<String, Object> getAttributes() {
@@ -23,14 +23,7 @@ public class CustomOAuth2User implements OAuth2User {
 
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
-		Collection<GrantedAuthority> authorities = new ArrayList<>();
-		authorities.add(new GrantedAuthority() {
-			@Override
-			public String getAuthority() {
-				return userRole;
-			}
-		});
-		return authorities;
+		return List.of();
 	}
 
 	@Override
@@ -44,10 +37,6 @@ public class CustomOAuth2User implements OAuth2User {
 
 	public String getProvider(){
 		return oAuth2Response.getProvider();
-	}
-
-	public UserRole getUserRole() {
-		return UserRole.from(userRole);
 	}
 
 	public String getUsername() {

--- a/src/main/java/org/ezcode/codetest/domain/user/model/entity/CustomOAuth2User.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/model/entity/CustomOAuth2User.java
@@ -1,12 +1,10 @@
 package org.ezcode.codetest.domain.user.model.entity;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.ezcode.codetest.application.usermanagement.user.dto.OAuth2Response;
-import org.ezcode.codetest.domain.user.model.enums.UserRole;
+import org.ezcode.codetest.application.usermanagement.user.dto.response.OAuth2Response;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 

--- a/src/main/java/org/ezcode/codetest/domain/user/model/entity/User.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/model/entity/User.java
@@ -149,12 +149,12 @@ public class User extends BaseEntity {
 		this.isDeleted = true;
 	}
 
-	public void setModified() {
-		this.modifiedAt = LocalDateTime.now();
-	}
-
 	public boolean shouldSkipNotification(User recipient) {
 
 		return recipient == null || this.getId().equals(recipient.getId());
+	}
+
+	public void modifyPassword(String newPassword) {
+		this.password = newPassword;
 	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/service/CustomOAuth2UserService.java
@@ -1,7 +1,7 @@
 package org.ezcode.codetest.domain.user.service;
 
-import org.ezcode.codetest.application.usermanagement.user.dto.GoogleOAuth2Response;
-import org.ezcode.codetest.application.usermanagement.user.dto.OAuth2Response;
+import org.ezcode.codetest.application.usermanagement.user.dto.response.GoogleOAuth2Response;
+import org.ezcode.codetest.application.usermanagement.user.dto.response.OAuth2Response;
 import org.ezcode.codetest.domain.user.model.entity.CustomOAuth2User;
 import org.ezcode.codetest.domain.user.model.entity.User;
 import org.ezcode.codetest.domain.user.repository.UserRepository;
@@ -64,6 +64,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 			log.info("이미 가입된 유저");
 		}
 
-		return new CustomOAuth2User(oAuth2Response, "USER"); //기본적으로 역할은 USER로 설정
+		return new CustomOAuth2User(oAuth2Response);
 	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/user/service/UserDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/service/UserDomainService.java
@@ -21,7 +21,7 @@ public class UserDomainService {
 
 	public void checkEmailUnique(String email) {
 		if (userRepository.findByEmail(email).isPresent()) {
-			throw new AuthException(AuthExceptionCode.EXIST_USER_EMAIL);
+			throw new AuthException(AuthExceptionCode.ALREADY_EXIST_USER);
 		}
 	}
 

--- a/src/main/java/org/ezcode/codetest/domain/user/service/UserDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/service/UserDomainService.java
@@ -55,4 +55,10 @@ public class UserDomainService {
 	public User getOAuthUser(String email, String provider) {
 		return userRepository.findByEmailAndProvider(email, provider);
 	}
+
+	public void passwordComparison(String newPassword, String oldPassword) {
+		if (passwordEncoder.matches(newPassword, oldPassword)) {
+			throw new AuthException(AuthExceptionCode.PASSWORD_IS_SAME);
+		}
+	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/user/service/UserDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/service/UserDomainService.java
@@ -61,4 +61,10 @@ public class UserDomainService {
 			throw new AuthException(AuthExceptionCode.PASSWORD_IS_SAME);
 		}
 	}
+
+	public void isDeletedUser(User user) {
+		if (user.isDeleted()) {
+			throw new AuthException(AuthExceptionCode.ALREADY_WITHDRAW_USER);
+		}
+	}
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/security/hander/CustomSuccessHandler.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/security/hander/CustomSuccessHandler.java
@@ -48,12 +48,9 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 		//OAuth2User
 		CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
 
-		Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
-		Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
-
 		User loginUser = userDomainService.getOAuthUser(customUserDetails.getEmail(), customUserDetails.getProvider());
 
-		String token = jwtUtil.createToken(
+		String accessToken = jwtUtil.createToken(
 			loginUser.getId(),
 			loginUser.getEmail(),
 			loginUser.getRole(),
@@ -62,7 +59,9 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 			loginUser.getTier()
 		);
 		String refreshToken = jwtUtil.createRefreshToken(loginUser.getId());
+
 		log.info("refresh token 발급 완료");
+
 		//redis에 LOGIN : {redisToken} 형식으로 저장
 		redisTemplate.opsForValue().set(
 			"RefreshToken:" + loginUser.getId(),
@@ -72,29 +71,12 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 		log.info("레디스에 저장완료");
 
 
-		//CSRF 공격 방어용
-		String encodedToken = URLEncoder.encode(token, StandardCharsets.UTF_8);
-		ResponseCookie cookie = ResponseCookie.from("Authorization", encodedToken)
-			.maxAge(Duration.ofHours(1))
-			.path("/")
-			.httpOnly(true)
-			.sameSite("Lax")
-			.build();
-		response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+		//access token, refresh token을 프론트에 어떻게 전달하쥐...?
+
+
 
 		response.sendRedirect("https://ezcode.my/");
-		log.info("------------- token : {} ------------", token);
-	}
-
-
-	private Cookie createCookie(String key, String value) {
-		Cookie cookie = new Cookie(key, value);
-		cookie.setMaxAge(60*60*60);
-		//cookie.setSecure(true);
-		cookie.setPath("/");
-		cookie.setHttpOnly(true);
-
-		return cookie;
+		log.info("------------- accessToken : {}, refreshToken : {} ------------", accessToken, refreshToken);
 	}
 
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/security/hander/CustomSuccessHandler.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/security/hander/CustomSuccessHandler.java
@@ -1,27 +1,21 @@
 package org.ezcode.codetest.infrastructure.security.hander;
 
 import java.io.IOException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 
+import org.ezcode.codetest.application.usermanagement.auth.dto.signin.OAuthResponse;
 import org.ezcode.codetest.application.usermanagement.auth.port.JwtUtil;
 import org.ezcode.codetest.domain.user.model.entity.CustomOAuth2User;
 import org.ezcode.codetest.domain.user.model.entity.User;
 import org.ezcode.codetest.domain.user.service.UserDomainService;
 import org.ezcode.codetest.infrastructure.security.jwt.JwtUtilImpl;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
-import jakarta.servlet.http.Cookie;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -33,12 +27,14 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 	private final JwtUtil jwtUtil;
 	private final UserDomainService userDomainService;
 	private final RedisTemplate<String, String> redisTemplate;
+	private final ObjectMapper objectMapper; //json직렬화
 
 	public CustomSuccessHandler(JwtUtilImpl jwtUtil, UserDomainService userDomainService,
-		RedisTemplate<String, String> redisTemplate) {
+		RedisTemplate<String, String> redisTemplate, ObjectMapper objectMapper) {
 		this.jwtUtil = jwtUtil;
 		this.userDomainService = userDomainService;
 		this.redisTemplate = redisTemplate;
+		this.objectMapper = objectMapper;
 	}
 
 	@Override
@@ -70,12 +66,11 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 			TimeUnit.MILLISECONDS);
 		log.info("레디스에 저장완료");
 
-
-		//access token, refresh token을 프론트에 어떻게 전달하쥐...?
-
-
-
-		response.sendRedirect("https://ezcode.my/");
+		//JSON 문자열로 바꿔서 클라이언트에게 응답 본문으로 전달
+		OAuthResponse oAuthResponse = new OAuthResponse(accessToken, refreshToken);
+		response.setContentType("application/json");
+		response.setCharacterEncoding("UTF-8");
+		response.getWriter().write(objectMapper.writeValueAsString(oAuthResponse));
 		log.info("------------- accessToken : {}, refreshToken : {} ------------", accessToken, refreshToken);
 	}
 

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/AuthController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/AuthController.java
@@ -6,7 +6,7 @@ import org.ezcode.codetest.application.usermanagement.auth.dto.signin.SigninResp
 import org.ezcode.codetest.application.usermanagement.auth.dto.signup.SignupRequest;
 import org.ezcode.codetest.application.usermanagement.auth.dto.signup.SignupResponse;
 import org.ezcode.codetest.application.usermanagement.auth.service.AuthService;
-import org.ezcode.codetest.application.usermanagement.user.dto.LogoutResponse;
+import org.ezcode.codetest.application.usermanagement.user.dto.response.LogoutResponse;
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
@@ -1,9 +1,10 @@
 package org.ezcode.codetest.presentation.usermanagement;
 
-import org.ezcode.codetest.application.usermanagement.user.dto.ModifyUserInfoRequest;
-import org.ezcode.codetest.application.usermanagement.user.dto.UserInfoResponse;
+import org.ezcode.codetest.application.usermanagement.user.dto.request.ModifyUserInfoRequest;
+import org.ezcode.codetest.application.usermanagement.user.dto.request.ChangeUserPasswordRequest;
+import org.ezcode.codetest.application.usermanagement.user.dto.response.ChangeUserPasswordResponse;
+import org.ezcode.codetest.application.usermanagement.user.dto.response.UserInfoResponse;
 import org.ezcode.codetest.application.usermanagement.user.service.UserService;
-import org.ezcode.codetest.common.annotation.Auth;
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -34,5 +35,13 @@ public class UserController {
 		@RequestBody ModifyUserInfoRequest modifyUserInfoRequest
 	){
 		return ResponseEntity.status(HttpStatus.OK).body(userService.modifyUserInfo(authUser, modifyUserInfoRequest));
+	}
+
+	@PutMapping("/users/password")
+	public ResponseEntity<ChangeUserPasswordResponse> modifyUserPassword(
+		@AuthenticationPrincipal AuthUser authUser,
+		@RequestBody ChangeUserPasswordRequest changeUserPasswordRequest
+	){
+		return ResponseEntity.status(HttpStatus.OK).body(userService.modifyUserPassword(authUser, changeUserPasswordRequest));
 	}
 }

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -42,7 +43,7 @@ public class UserController {
 	@PutMapping("/users/password")
 	public ResponseEntity<ChangeUserPasswordResponse> modifyUserPassword(
 		@AuthenticationPrincipal AuthUser authUser,
-		@RequestBody ChangeUserPasswordRequest changeUserPasswordRequest
+		@Valid @RequestBody ChangeUserPasswordRequest changeUserPasswordRequest
 	){
 		return ResponseEntity.status(HttpStatus.OK).body(userService.modifyUserPassword(authUser, changeUserPasswordRequest));
 	}

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
@@ -4,11 +4,13 @@ import org.ezcode.codetest.application.usermanagement.user.dto.request.ModifyUse
 import org.ezcode.codetest.application.usermanagement.user.dto.request.ChangeUserPasswordRequest;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.ChangeUserPasswordResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.UserInfoResponse;
+import org.ezcode.codetest.application.usermanagement.user.dto.response.WithdrawUserResponse;
 import org.ezcode.codetest.application.usermanagement.user.service.UserService;
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -43,5 +45,13 @@ public class UserController {
 		@RequestBody ChangeUserPasswordRequest changeUserPasswordRequest
 	){
 		return ResponseEntity.status(HttpStatus.OK).body(userService.modifyUserPassword(authUser, changeUserPasswordRequest));
+	}
+
+	@DeleteMapping("/users/withdraw")
+	public ResponseEntity<WithdrawUserResponse> withdraw(
+		@AuthenticationPrincipal AuthUser authUser
+	){
+		return ResponseEntity.status(HttpStatus.OK).body(userService.withdrawUser(authUser));
+
 	}
 }


### PR DESCRIPTION

## 작업 내용

- 유저 탈퇴 기능 추가
- 비밀번호 변경 추가
- oauth 리다이렉션 url 삭제 및 토큰 반환
    - cookie 저장 삭제
---

## 변경 사항
**1. UserService**
- modifyUserPassword 메서드 추가 (비번 변경)
- withdrawUser 메서드 추가 (탈퇴)

**2. UserDomainService**
- passwordComparison : 기존 비번과 새로운 비번이 같으면 에러 -> 바꾸는 비번은 기존과 달라야함
- isDeletedUser : 이미 탈퇴된 회원이면 로그인 불가

**3. CustomSuccessHandler**(OAuth 성공 후 어떻게 처리할지 결정하는 클래스)
- 메인페이지로 리다이렉션하는 것에서, json으로 토큰 반환하는 것으로 변경


---

## 해결해야 할 문제

- 중복 로그인 문제 해결해야함
- token 저장 시간 결정해야함 (지금은 테스트단계라서 길게 설정)

---

## 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 비밀번호 변경 및 회원 탈퇴 API가 추가되었습니다. 이제 사용자는 비밀번호를 변경하거나 회원 탈퇴를 요청할 수 있습니다.
    - OAuth 인증 시 액세스 토큰과 리프레시 토큰이 JSON 형태로 반환됩니다.

- **버그 수정**
    - 일부 응답 메시지가 한글로 개선되었습니다.

- **리팩터**
    - DTO 및 응답 객체의 패키지 구조가 정리되었습니다.
    - 소셜 로그인 관련 사용자 정보 처리 방식이 단순화되었습니다.

- **기타**
    - 비밀번호 변경 시 기존 비밀번호와 동일할 경우 오류 메시지가 제공됩니다.
    - 탈퇴된 회원에 대한 처리가 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->