### PR TITLE
refactor : 메서드 이름 가독성 좋게끔 변경, 하드코딩 된 메시지 제거

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/chatting/port/event/ChatEventService.java
+++ b/src/main/java/org/ezcode/codetest/application/chatting/port/event/ChatEventService.java
@@ -2,13 +2,13 @@ package org.ezcode.codetest.application.chatting.port.event;
 
 public interface ChatEventService {
 
-	<T> void publishEnterEvent(T roomData, String principalName, String sessionId);
+	<T> void publishChatRoomListLoadEvent(T roomData, String principalName, String sessionId);
 
-	<T> void publishRoomEnterEvent(T chatData, String principalName, String sessionId);
+	<T> void publishChatRoomHistoryLoadEvent(T chatData, String principalName, String sessionId);
 
-	<T> void publishBroadCastChatEvent(T chatData, Long roomId);
+	<T> void publishChatMessageBroadcastEvent(T chatData, Long roomId);
 
-	<T> void publishRoomEnterAndLeftEvent(T messageData, Long roomId);
+	<T> void publishChatRoomEntryExitMessageEvent(T messageData, Long roomId);
 
-	<T> void publishRoomChangeEvent(T roomData);
+	<T> void publishChatRoomParticipantCountChangeEvent(T roomData);
 }

--- a/src/main/java/org/ezcode/codetest/application/chatting/port/session/ChatLimitService.java
+++ b/src/main/java/org/ezcode/codetest/application/chatting/port/session/ChatLimitService.java
@@ -4,7 +4,7 @@ public interface ChatLimitService {
 
 	Long increaseChatCount(String email);
 
-	void applyChatBlock(String email);
+	void applyChatSpamPenalty(String email);
 
 	Boolean isBlocked(String email);
 

--- a/src/main/java/org/ezcode/codetest/application/chatting/port/session/ChatSessionService.java
+++ b/src/main/java/org/ezcode/codetest/application/chatting/port/session/ChatSessionService.java
@@ -1,12 +1,10 @@
 package org.ezcode.codetest.application.chatting.port.session;
 
-import java.util.Map;
-
 public interface ChatSessionService {
 
 	Long addSessionCount(String sessionId, Long roomId);
 
-	Map<String, Long> removeSessionCount(String sessionId);
+	RoomSessionInfo removeSessionCount(String sessionId);
 
 	Long viewSessionCount(Long roomId);
 

--- a/src/main/java/org/ezcode/codetest/application/chatting/port/session/RoomSessionInfo.java
+++ b/src/main/java/org/ezcode/codetest/application/chatting/port/session/RoomSessionInfo.java
@@ -1,0 +1,12 @@
+package org.ezcode.codetest.application.chatting.port.session;
+
+import lombok.Builder;
+
+@Builder
+public record RoomSessionInfo(
+
+	Long roomId,
+
+	Long headCount
+) {
+}

--- a/src/main/java/org/ezcode/codetest/application/chatting/service/ChatMessageTemplate.java
+++ b/src/main/java/org/ezcode/codetest/application/chatting/service/ChatMessageTemplate.java
@@ -1,0 +1,18 @@
+package org.ezcode.codetest.application.chatting.service;
+
+public enum ChatMessageTemplate {
+
+	SPAM_BLOCK("%s 님께서 지나친 도배로 %d초 동안 차단되었습니다."),
+	CHAT_ROOM_LEFT("%s 님께서 채팅방을 나가셨습니다~!"),
+	CHAT_ROOM_ENTER("%s 님께서 채팅방에 들어오셨습니다~!");
+
+	private final String template;
+
+	ChatMessageTemplate(String template) {
+		this.template = template;
+	}
+
+	public String format(Object... args) {
+		return String.format(template, args);
+	}
+}

--- a/src/main/java/org/ezcode/codetest/application/chatting/service/ChatSpamPreventionService.java
+++ b/src/main/java/org/ezcode/codetest/application/chatting/service/ChatSpamPreventionService.java
@@ -20,9 +20,9 @@ public class ChatSpamPreventionService {
 
 	public void applyChatBlock(String email, String nickName, Long roomId) {
 
-		limitService.applyChatBlock(email);
+		limitService.applyChatSpamPenalty(email);
 
-		eventService.publishBroadCastChatEvent(nickName + " 님께서 지나친 도배로 30초 동안 차단되었습니다.", roomId);
+		eventService.publishChatMessageBroadcastEvent(ChatMessageTemplate.SPAM_BLOCK.format(nickName, 30), roomId);
 	}
 
 	public Long countChatsInLast10Seconds(String email) {

--- a/src/main/java/org/ezcode/codetest/application/chatting/service/ChattingUseCase.java
+++ b/src/main/java/org/ezcode/codetest/application/chatting/service/ChattingUseCase.java
@@ -1,7 +1,6 @@
 package org.ezcode.codetest.application.chatting.service;
 
 import java.util.List;
-import java.util.Map;
 
 import org.ezcode.codetest.application.chatting.dto.request.ChatRoomDeleteRequest;
 import org.ezcode.codetest.application.chatting.dto.request.ChatRoomSaveRequest;

--- a/src/main/java/org/ezcode/codetest/application/chatting/service/ChattingUseCase.java
+++ b/src/main/java/org/ezcode/codetest/application/chatting/service/ChattingUseCase.java
@@ -12,6 +12,7 @@ import org.ezcode.codetest.application.chatting.port.cache.ChatRoomCacheService;
 import org.ezcode.codetest.application.chatting.port.event.ChatEventService;
 import org.ezcode.codetest.application.chatting.port.session.ChatSessionService;
 import org.ezcode.codetest.application.chatting.port.cache.ChatRoomCache;
+import org.ezcode.codetest.application.chatting.port.session.RoomSessionInfo;
 import org.ezcode.codetest.domain.chat.model.Chat;
 import org.ezcode.codetest.domain.chat.model.ChatRoom;
 import org.ezcode.codetest.domain.chat.service.ChattingDomainService;
@@ -46,7 +47,7 @@ public class ChattingUseCase {
 
 		cacheService.addChatRoomToCache(ChatRoomCache.from(savedRoom));
 
-		eventService.publishRoomChangeEvent(RoomChangedResponse.from(savedRoom, EVENT_TYPE_CREATE));
+		eventService.publishChatRoomParticipantCountChangeEvent(RoomChangedResponse.from(savedRoom, EVENT_TYPE_CREATE));
 	}
 
 	@Transactional
@@ -64,7 +65,8 @@ public class ChattingUseCase {
 
 		sessionService.removeRoomSession(request.roomId());
 
-		eventService.publishRoomChangeEvent(RoomChangedResponse.from(removedRoom, EVENT_TYPE_DELETE));
+		eventService.publishChatRoomParticipantCountChangeEvent(
+			RoomChangedResponse.from(removedRoom, EVENT_TYPE_DELETE));
 	}
 
 	@Transactional
@@ -91,7 +93,7 @@ public class ChattingUseCase {
 			)
 			.toList();
 
-		eventService.publishEnterEvent(roomLists, principalName, sessionId);
+		eventService.publishChatRoomListLoadEvent(roomLists, principalName, sessionId);
 	}
 
 	@Transactional
@@ -103,7 +105,7 @@ public class ChattingUseCase {
 
 		Chat chat = chattingDomainService.createChatting(request.toEntity(user, chatRoom));
 
-		eventService.publishBroadCastChatEvent(ChatResponse.from(chat), roomId);
+		eventService.publishChatMessageBroadcastEvent(ChatResponse.from(chat), roomId);
 	}
 
 	@Transactional
@@ -121,11 +123,12 @@ public class ChattingUseCase {
 
 		Long headCount = sessionService.addSessionCount(sessionId, roomId);
 
-		eventService.publishRoomEnterEvent(chatLists, principalName, sessionId);
+		eventService.publishChatRoomHistoryLoadEvent(chatLists, principalName, sessionId);
 
-		eventService.publishRoomEnterAndLeftEvent(user.getNickname() + " 님이 입장했어요~!", roomId);
+		eventService.publishChatRoomEntryExitMessageEvent(
+			ChatMessageTemplate.CHAT_ROOM_ENTER.format(user.getNickname()), roomId);
 
-		eventService.publishRoomChangeEvent(RoomChangedResponse.from(
+		eventService.publishChatRoomParticipantCountChangeEvent(RoomChangedResponse.from(
 				chatRoom,
 				EVENT_TYPE_UPDATE,
 				headCount
@@ -140,14 +143,15 @@ public class ChattingUseCase {
 
 		ChatRoom chatRoom = chattingDomainService.getChatRoom(roomId);
 
-		Map<String, Long> roomData = sessionService.removeSessionCount(sessionId);
+		RoomSessionInfo roomData = sessionService.removeSessionCount(sessionId);
 
-		eventService.publishRoomEnterAndLeftEvent(user.getNickname() + " 님이 나가셨습니다~", roomId);
+		eventService.publishChatRoomEntryExitMessageEvent(
+			ChatMessageTemplate.CHAT_ROOM_LEFT.format(user.getNickname()), roomId);
 
-		eventService.publishRoomChangeEvent(RoomChangedResponse.from(
+		eventService.publishChatRoomParticipantCountChangeEvent(RoomChangedResponse.from(
 				chatRoom,
 				EVENT_TYPE_UPDATE,
-				roomData.get("headCount")
+				roomData.headCount()
 			)
 		);
 	}

--- a/src/main/java/org/ezcode/codetest/infrastructure/event/listener/ChatEventListener.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/event/listener/ChatEventListener.java
@@ -21,20 +21,20 @@ public class ChatEventListener {
 	private final StompMessageService messageService;
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	public void handleEnterEvent(EnterEvent<?> event) {
+	public void handleChatRoomListLoad(EnterEvent<?> event) {
 
 		try {
-			messageService.handleEnter(event.roomData(), event.principalName(), event.sessionId());
+			messageService.handleChatRoomListLoad(event.roomData(), event.principalName(), event.sessionId());
 		} catch (Exception e) {
 			log.warn("사용자 입장 후, 채팅룸 전달 중 오류 발생", e);
 		}
 	}
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	public void handleRoomEnterEvent(RoomEnterEvent<?> event) {
+	public void handleChatRoomHistoryLoad(RoomEnterEvent<?> event) {
 
 		try {
-			messageService.handleRoomEnter(event.chatData(), event.principalName(), event.sessionId());
+			messageService.handleChatRoomHistoryLoad(event.chatData(), event.principalName(), event.sessionId());
 		} catch (Exception e) {
 			log.warn("사용자 채팅방 입장 후, 채팅내역 전달 중 오류 발생", e);
 		}
@@ -44,30 +44,30 @@ public class ChatEventListener {
 		phase = TransactionPhase.AFTER_COMMIT,
 		fallbackExecution = true
 	)
-	public void handleBroadCastChatEvent(BroadCastChatEvent<?> event) {
+	public void handleChatMessageBroadcast(BroadCastChatEvent<?> event) {
 
 		try {
-			messageService.handleBroadCastChat(event.chatData(), event.roomId());
+			messageService.handleChatMessageBroadcast(event.chatData(), event.roomId());
 		} catch (Exception e) {
 			log.warn("사용자 채팅 메시지 전달 중 오류 발생", e);
 		}
 	}
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	public void handleRoomEnterAndLeftEvent(RoomEnterAndLeftEvent<?> event) {
+	public void handleChatRoomEntryExitMessage(RoomEnterAndLeftEvent<?> event) {
 
 		try {
-			messageService.handleRoomEnterAndLeftEvent(event.messageData(), event.roomId());
+			messageService.handleChatRoomEntryExitMessage(event.messageData(), event.roomId());
 		} catch (Exception e) {
 			log.warn("사용자 입장/퇴장 메시지 전달 중 오류 발생", e);
 		}
 	}
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	public void handleRoomChangeEvent(RoomChangeEvent<?> event) {
+	public void handleChatRoomParticipantCountChange(RoomChangeEvent<?> event) {
 
 		try {
-			messageService.handleRoomChangeEvent(event.roomData());
+			messageService.handleChatRoomParticipantCountChange(event.roomData());
 		} catch (Exception e) {
 			log.warn("채팅룸 상태 변화 전달 중 오류 발생", e);
 		}

--- a/src/main/java/org/ezcode/codetest/infrastructure/event/listener/WebSocketEventListener.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/event/listener/WebSocketEventListener.java
@@ -3,8 +3,11 @@ package org.ezcode.codetest.infrastructure.event.listener;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.ezcode.codetest.application.chatting.port.session.RoomSessionInfo;
+import org.ezcode.codetest.application.chatting.service.ChatMessageTemplate;
 import org.ezcode.codetest.domain.chat.model.ChatRoom;
 import org.ezcode.codetest.domain.chat.service.ChattingDomainService;
+import org.ezcode.codetest.domain.user.service.UserDomainService;
 import org.ezcode.codetest.infrastructure.event.service.StompMessageService;
 import org.ezcode.codetest.infrastructure.session.service.RedisSessionCountService;
 import org.springframework.context.ApplicationListener;
@@ -21,6 +24,7 @@ public class WebSocketEventListener implements ApplicationListener<SessionDiscon
 	private final StompMessageService messageService;
 	private final RedisSessionCountService sessionService;
 	private final ChattingDomainService chattingDomainService;
+	private final UserDomainService userDomainService;
 
 	@Override
 	public void onApplicationEvent(SessionDisconnectEvent event) {
@@ -28,16 +32,20 @@ public class WebSocketEventListener implements ApplicationListener<SessionDiscon
 		StompHeaderAccessor h = StompHeaderAccessor.wrap(event.getMessage());
 		String sessionId = h.getSessionId();
 
-		Map<String, Long> roomData = sessionService.removeSessionCount(sessionId);
+		String email = h.getUser().getName();
+		String nickName = userDomainService.getUser(email).getNickname();
 
-		ChatRoom chatRoom = chattingDomainService.getChatRoom(roomData.get("roomId"));
+		RoomSessionInfo roomData = sessionService.removeSessionCount(sessionId);
+		ChatRoom chatRoom = chattingDomainService.getChatRoom(roomData.roomId());
 
 		Map<String, Object> payload = new HashMap<>();
 		payload.put("roomId", chatRoom.getId());
 		payload.put("title", chatRoom.getTitle());
-		payload.put("headCount", roomData.get("headCount"));
+		payload.put("headCount", roomData.headCount());
+		payload.put("eventType", "UPDATE");
 
-		messageService.handleRoomChangeEvent(payload);
-
+		messageService.handleChatRoomParticipantCountChange(payload);
+		messageService.handleChatRoomEntryExitMessage(ChatMessageTemplate.CHAT_ROOM_LEFT.format(nickName),
+			chatRoom.getId());
 	}
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/event/service/ChatEventPublisher.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/event/service/ChatEventPublisher.java
@@ -17,27 +17,27 @@ public class ChatEventPublisher implements ChatEventService {
 
 	private final ApplicationEventPublisher publisher;
 
-	public <T> void publishEnterEvent(T roomData, String principalName, String sessionId) {
+	public <T> void publishChatRoomListLoadEvent(T roomData, String principalName, String sessionId) {
 
 		publisher.publishEvent(new EnterEvent<>(roomData, principalName, sessionId));
 	}
 
-	public <T> void publishRoomEnterEvent(T chatData, String principalName, String sessionId) {
+	public <T> void publishChatRoomHistoryLoadEvent(T chatData, String principalName, String sessionId) {
 
 		publisher.publishEvent(new RoomEnterEvent<>(chatData, principalName, sessionId));
 	}
 
-	public <T> void publishBroadCastChatEvent(T chatData, Long roomId) {
+	public <T> void publishChatMessageBroadcastEvent(T chatData, Long roomId) {
 
 		publisher.publishEvent(new BroadCastChatEvent<>(chatData, roomId));
 	}
 
-	public <T> void publishRoomEnterAndLeftEvent(T messageData, Long roomId) {
+	public <T> void publishChatRoomEntryExitMessageEvent(T messageData, Long roomId) {
 
 		publisher.publishEvent(new RoomEnterAndLeftEvent<>(messageData, roomId));
 	}
 
-	public <T> void publishRoomChangeEvent(T roomData) {
+	public <T> void publishChatRoomParticipantCountChangeEvent(T roomData) {
 
 		publisher.publishEvent(new RoomChangeEvent<>(roomData));
 	}

--- a/src/main/java/org/ezcode/codetest/infrastructure/event/service/StompMessageService.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/event/service/StompMessageService.java
@@ -18,7 +18,7 @@ public class StompMessageService {
 
 	private final SimpMessagingTemplate messagingTemplate;
 
-	public <T> void handleEnter(T roomData, String principalName, String sessionId) {
+	public <T> void handleChatRoomListLoad(T roomData, String principalName, String sessionId) {
 
 		SimpMessageHeaderAccessor accessor =
 			SimpMessageHeaderAccessor.create(SimpMessageType.MESSAGE);
@@ -34,7 +34,7 @@ public class StompMessageService {
 		);
 	}
 
-	public <T> void handleRoomEnter(T chatData, String principalName, String sessionId) {
+	public <T> void handleChatRoomHistoryLoad(T chatData, String principalName, String sessionId) {
 
 		SimpMessageHeaderAccessor accessor =
 			SimpMessageHeaderAccessor.create(SimpMessageType.MESSAGE);
@@ -68,17 +68,17 @@ public class StompMessageService {
 		);
 	}
 
-	public <T> void handleBroadCastChat(T data, Long roomId) {
+	public <T> void handleChatMessageBroadcast(T data, Long roomId) {
 
 		messagingTemplate.convertAndSend("/topic/chat/" + roomId, data);
 	}
 
-	public <T> void handleRoomEnterAndLeftEvent(T messageData, Long roomId) {
+	public <T> void handleChatRoomEntryExitMessage(T messageData, Long roomId) {
 
 		messagingTemplate.convertAndSend("/topic/chat/" + roomId, messageData);
 	}
 
-	public <T> void handleRoomChangeEvent(T roomData) {
+	public <T> void handleChatRoomParticipantCountChange(T roomData) {
 
 		messagingTemplate.convertAndSend("/topic/chatrooms", roomData);
 	}

--- a/src/main/java/org/ezcode/codetest/infrastructure/session/config/RedisSessionConfig.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/session/config/RedisSessionConfig.java
@@ -8,7 +8,7 @@ import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
-public class SessionRedisConfig {
+public class RedisSessionConfig {
 
 	@Bean
 	public RedisTemplate<String, Long> redisTemplate(RedisConnectionFactory factory) {

--- a/src/main/java/org/ezcode/codetest/infrastructure/session/service/RedisChatLimitService.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/session/service/RedisChatLimitService.java
@@ -20,13 +20,14 @@ public class RedisChatLimitService implements ChatLimitService {
 
 	private final RedisScript<Long> incrWithTtlScript =
 		new DefaultRedisScript<>(
-			"local current = redis.call('INCR', KEYS[1])\n" +
-				"if tonumber(current) == 1 then\n" +
-				"  redis.call('EXPIRE', KEYS[1], tonumber(ARGV[1]))\n" +
-				"end\n" +
-				"return tonumber(current)",
-			Long.class
-		);
+			"""
+				local current = redis.call('INCR', KEYS[1])
+				if tonumber(current) == 1 then
+				  redis.call('EXPIRE', KEYS[1], tonumber(ARGV[1]))
+				end
+				return tonumber(current)
+				"""
+			, Long.class);
 
 	@Override
 	public Long increaseChatCount(String email) {
@@ -40,7 +41,7 @@ public class RedisChatLimitService implements ChatLimitService {
 		);
 	}
 
-	public void applyChatBlock(String email) {
+	public void applyChatSpamPenalty(String email) {
 
 		String sessionKey = RedisKeyConstants.BLOCKED_SESSION_KEY_PREFIX + email;
 

--- a/src/main/java/org/ezcode/codetest/infrastructure/session/service/RedisSessionCountService.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/session/service/RedisSessionCountService.java
@@ -81,12 +81,12 @@ public class RedisSessionCountService implements ChatSessionService {
 		String roomCountKey = RedisKeyConstants.ROOM_COUNT_KEY_PREFIX + roomId;
 
 		List<String> keys = Arrays.asList(roomKey, sessionKey, roomCountKey);
-		Object[] args = new Object[] {sessionId, roomId.toString()};
 
 		return redisTemplate.execute(
 			addSessionScript,
 			keys,
-			args
+			sessionId,
+			roomId.toString()
 		);
 	}
 

--- a/src/main/java/org/ezcode/codetest/infrastructure/session/service/RedisSessionCountService.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/session/service/RedisSessionCountService.java
@@ -2,12 +2,11 @@ package org.ezcode.codetest.infrastructure.session.service;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import org.ezcode.codetest.application.chatting.port.session.ChatSessionService;
+import org.ezcode.codetest.application.chatting.port.session.RoomSessionInfo;
 import org.ezcode.codetest.domain.chat.exception.ChattingException;
 import org.ezcode.codetest.domain.chat.exception.ChattingExceptionCode;
 import org.ezcode.codetest.infrastructure.session.constant.RedisKeyConstants;
@@ -26,50 +25,53 @@ public class RedisSessionCountService implements ChatSessionService {
 
 	private final RedisScript<Long> addSessionScript =
 		new DefaultRedisScript<>(
-		"local roomId = ARGV[2]\n" +
-			"redis.call('SET', KEYS[2], roomId)\n" +
-			"local added = redis.call('SADD', KEYS[1], ARGV[1])\n" +
-			"if added == 1 then\n" +
-			"  redis.call('INCR', KEYS[3])\n" +
-			"end\n" +
-			"local cnt = redis.call('GET', KEYS[3])\n" +
-			"return tonumber(cnt)\n",
-		Long.class
-	);
+			"""
+				local roomId = ARGV[2]
+				redis.call('SET', KEYS[2], roomId)
+				local added = redis.call('SADD', KEYS[1], ARGV[1])
+				if added == 1 then
+				  redis.call('INCR', KEYS[3])
+				end
+				local cnt = redis.call('GET', KEYS[3])
+				return tonumber(cnt)
+				"""
+			, Long.class);
 
 	private final RedisScript<List<Long>> removeSessionScript =
 		new DefaultRedisScript<>(
-		"local roomId = redis.call('GET', KEYS[1])\n" +
-			"if not roomId then\n" +
-			"  return {-1, 0}\n" +
-			"end\n" +
-			"local roomKey = 'chatroom:' .. roomId\n" +
-			"local roomCountKey = 'roomCount:' .. roomId\n" +
-			"local removed = redis.call('SREM', roomKey, ARGV[1])\n" +
-			"if removed == 1 then\n" +
-			"  redis.call('DECR', roomCountKey)\n" +
-			"end\n" +
-			"redis.call('DEL', KEYS[1])\n" +
-			"local cnt = redis.call('GET', roomCountKey)\n" +
-			"if not cnt then\n" +
-			"  cnt = \"0\"\n" +
-			"end\n" +
-			"return { tonumber(roomId), tonumber(cnt) }\n",
-		(Class<List<Long>>)(Class<?>)List.class
-	);
+			"""
+				local roomId = redis.call('GET', KEYS[1])
+				if not roomId then
+				  return {-1, 0}
+				end
+				local roomKey = 'chatroom:' .. roomId
+				local roomCountKey = 'roomCount:' .. roomId
+				local removed = redis.call('SREM', roomKey, ARGV[1])
+				if removed == 1 then
+				  redis.call('DECR', roomCountKey)
+				end
+				redis.call('DEL', KEYS[1])
+				local cnt = redis.call('GET', roomCountKey)
+				if not cnt then
+				  cnt = "0"
+				end
+				return { tonumber(roomId), tonumber(cnt) }
+				"""
+			, (Class<List<Long>>)(Class<?>)List.class);
 
 	private final RedisScript<Long> removeRoomScript =
 		new DefaultRedisScript<>(
-		"local sessions = redis.call('SMEMBERS', KEYS[1])\n" +
-			"for i=1,#sessions do\n" +
-			"  local sessionKey = 'session:' .. sessions[i]\n" +
-			"  redis.call('DEL', sessionKey)\n" +
-			"end\n" +
-			"redis.call('DEL', KEYS[1])\n" +
-			"redis.call('DEL', KEYS[2])\n" +
-			"return #sessions\n",
-		Long.class
-	);
+			"""
+				local sessions = redis.call('SMEMBERS', KEYS[1])
+				for i=1,#sessions do
+				  local sessionKey = 'session:' .. sessions[i]
+				  redis.call('DEL', sessionKey)
+				end
+				redis.call('DEL', KEYS[1])
+				redis.call('DEL', KEYS[2])
+				return #sessions
+				"""
+			, Long.class);
 
 	@Override
 	public Long addSessionCount(String sessionId, Long roomId) {
@@ -81,12 +83,11 @@ public class RedisSessionCountService implements ChatSessionService {
 		List<String> keys = Arrays.asList(roomKey, sessionKey, roomCountKey);
 		Object[] args = new Object[] {sessionId, roomId.toString()};
 
-		Long headCount = redisTemplate.execute(
+		return redisTemplate.execute(
 			addSessionScript,
 			keys,
 			args
 		);
-		return (headCount != null ? headCount : 0L);
 	}
 
 	public void removeRoomSession(Long roomId) {
@@ -98,12 +99,12 @@ public class RedisSessionCountService implements ChatSessionService {
 		redisTemplate.execute(
 			removeRoomScript,
 			keys,
-			new Object[]{}
+			new Object[] {}
 		);
 	}
 
 	@Override
-	public Map<String, Long> removeSessionCount(String sessionId) {
+	public RoomSessionInfo removeSessionCount(String sessionId) {
 
 		String sessionKey = RedisKeyConstants.SESSION_KEY_PREFIX + sessionId;
 
@@ -113,7 +114,7 @@ public class RedisSessionCountService implements ChatSessionService {
 			sessionId
 		);
 
-		if (result == null || result.size() < 2) {
+		if (result.size() < 2) {
 			throw new ChattingException(ChattingExceptionCode.INVALID_CHATTING_SESSION);
 		}
 
@@ -124,11 +125,10 @@ public class RedisSessionCountService implements ChatSessionService {
 			throw new ChattingException(ChattingExceptionCode.INVALID_CHATTING_SESSION);
 		}
 
-		Map<String, Long> roomData = new HashMap<>();
-		roomData.put("roomId", roomId);
-		roomData.put("headCount", headCount);
-
-		return roomData;
+		return RoomSessionInfo.builder()
+			.roomId(roomId)
+			.headCount(headCount)
+			.build();
 	}
 
 	@Override

--- a/src/test/java/org/ezcode/codetest/application/chatting/service/ChatSpamPreventionServiceTest.java
+++ b/src/test/java/org/ezcode/codetest/application/chatting/service/ChatSpamPreventionServiceTest.java
@@ -62,8 +62,9 @@ class ChatSpamPreventionServiceTest {
 			chatSpamPreventionService.applyChatBlock(TEMP_TEST_EMAIL, TEMP_TEST_NICKNAME, TEMP_ROOM_ID);
 
 			//then
-			verify(limitService).applyChatBlock(TEMP_TEST_EMAIL);
-			verify(eventService).publishBroadCastChatEvent(TEMP_TEST_NICKNAME + " 님께서 지나친 도배로 30초 동안 차단되었습니다.",
+			verify(limitService).applyChatSpamPenalty(TEMP_TEST_EMAIL);
+			verify(eventService).publishChatMessageBroadcastEvent(
+				ChatMessageTemplate.SPAM_BLOCK.format(TEMP_TEST_NICKNAME, 30),
 				TEMP_ROOM_ID);
 		}
 
@@ -78,8 +79,6 @@ class ChatSpamPreventionServiceTest {
 			verify(limitService).increaseChatCount(TEMP_TEST_EMAIL);
 		}
 
-
 	}
-
 
 }

--- a/src/test/java/org/ezcode/codetest/application/chatting/service/ChattingUseCaseTest.java
+++ b/src/test/java/org/ezcode/codetest/application/chatting/service/ChattingUseCaseTest.java
@@ -18,6 +18,7 @@ import org.ezcode.codetest.application.chatting.port.cache.ChatRoomCache;
 import org.ezcode.codetest.application.chatting.port.cache.ChatRoomCacheService;
 import org.ezcode.codetest.application.chatting.port.event.ChatEventService;
 import org.ezcode.codetest.application.chatting.port.session.ChatSessionService;
+import org.ezcode.codetest.application.chatting.port.session.RoomSessionInfo;
 import org.ezcode.codetest.domain.chat.model.Chat;
 import org.ezcode.codetest.domain.chat.model.ChatRoom;
 import org.ezcode.codetest.domain.chat.service.ChattingDomainService;
@@ -43,35 +44,35 @@ class ChattingUseCaseTest {
 	private ChattingUseCase chattingUseCase;
 
 	@Mock
-	private UserDomainService     userDomainService;
+	private UserDomainService userDomainService;
 	@Mock
 	private ChattingDomainService chattingDomainService;
 	@Mock
-	private ChatEventService      eventService;
+	private ChatEventService eventService;
 	@Mock
-	private ChatSessionService    sessionService;
+	private ChatSessionService sessionService;
 	@Mock
-	private ChatRoomCacheService  cacheService;
+	private ChatRoomCacheService cacheService;
 
-	private User                user;
-	private Chat                chat1;
-	private ChatRoom            chatRoom1;
+	private User user;
+	private Chat chat1;
+	private ChatRoom chatRoom1;
 	private List<ChatRoomCache> cacheChatRooms;
-	private List<ChatRoom>      chatRooms;
-	private List<Chat>          chats;
+	private List<ChatRoom> chatRooms;
+	private List<Chat> chats;
 
-	private static final String TEST_EMAIL      = "test@unknow.com";
-	private static final String TEST_PRINCIPAL  = "익명 Principal";
+	private static final String TEST_EMAIL = "test@unknow.com";
+	private static final String TEST_PRINCIPAL = "익명 Principal";
 	private static final String TEST_SESSION_ID = "임시 세션 ID";
-	private static final Long   TEST_ROOM_ID    = 1L;
-	private static final String TEMP_TITLE_1    = "임시 방 제목1";
-	private static final String TEMP_TITLE_2    = "임시 방 제목2";
-	private static final String TEMP_MESSAGE_1  = "임시 채팅 메시지";
-	private static final String TEMP_MESSAGE_2  = "임시 채팅 메시지2";
-	private static final String EVENT_CREATE    = "CREATE";
-	private static final String EVENT_DELETE    = "DELETE";
-	private static final String EVENT_GET       = "GET";
-	private static final String EVENT_UPDATE    = "UPDATE";
+	private static final Long TEST_ROOM_ID = 1L;
+	private static final String TEMP_TITLE_1 = "임시 방 제목1";
+	private static final String TEMP_TITLE_2 = "임시 방 제목2";
+	private static final String TEMP_MESSAGE_1 = "임시 채팅 메시지";
+	private static final String TEMP_MESSAGE_2 = "임시 채팅 메시지2";
+	private static final String EVENT_CREATE = "CREATE";
+	private static final String EVENT_DELETE = "DELETE";
+	private static final String EVENT_GET = "GET";
+	private static final String EVENT_UPDATE = "UPDATE";
 
 	@BeforeEach
 	void setUp() {
@@ -146,7 +147,7 @@ class ChattingUseCaseTest {
 			);
 
 			verify(cacheService).addChatRoomToCache(ChatRoomCache.from(chatRoom1));
-			verify(eventService).publishRoomChangeEvent(
+			verify(eventService).publishChatRoomParticipantCountChangeEvent(
 				RoomChangedResponse.from(chatRoom1, EVENT_CREATE)
 			);
 		}
@@ -181,7 +182,7 @@ class ChattingUseCaseTest {
 			verify(sessionService).removeRoomSession(TEST_ROOM_ID);
 
 			ArgumentCaptor<RoomChangedResponse> responseCaptor = ArgumentCaptor.forClass(RoomChangedResponse.class);
-			verify(eventService).publishRoomChangeEvent(responseCaptor.capture());
+			verify(eventService).publishChatRoomParticipantCountChangeEvent(responseCaptor.capture());
 			RoomChangedResponse response = responseCaptor.getValue();
 			assertAll(
 				() -> assertEquals(TEST_ROOM_ID, response.roomId()),
@@ -210,7 +211,8 @@ class ChattingUseCaseTest {
 			ArgumentCaptor<List<RoomChangedResponse>> captor =
 				(ArgumentCaptor<List<RoomChangedResponse>>)(Object)
 					ArgumentCaptor.forClass(List.class);
-			verify(eventService).publishEnterEvent(captor.capture(), eq(TEST_PRINCIPAL), eq(TEST_SESSION_ID));
+			verify(eventService).publishChatRoomListLoadEvent(captor.capture(), eq(TEST_PRINCIPAL),
+				eq(TEST_SESSION_ID));
 
 			List<RoomChangedResponse> published = captor.getValue();
 			assertEquals(cacheChatRooms.size(), published.size());
@@ -251,7 +253,8 @@ class ChattingUseCaseTest {
 			ArgumentCaptor<List<RoomChangedResponse>> responseCaptor =
 				(ArgumentCaptor<List<RoomChangedResponse>>)(Object)
 					ArgumentCaptor.forClass(List.class);
-			verify(eventService).publishEnterEvent(responseCaptor.capture(), eq(TEST_PRINCIPAL), eq(TEST_SESSION_ID));
+			verify(eventService).publishChatRoomListLoadEvent(responseCaptor.capture(), eq(TEST_PRINCIPAL),
+				eq(TEST_SESSION_ID));
 
 			List<RoomChangedResponse> published = responseCaptor.getValue();
 			assertEquals(capturedRooms.size(), published.size());
@@ -289,7 +292,7 @@ class ChattingUseCaseTest {
 			);
 
 			ArgumentCaptor<ChatResponse> responseCaptor = ArgumentCaptor.forClass(ChatResponse.class);
-			verify(eventService).publishBroadCastChatEvent(responseCaptor.capture(), eq(TEST_ROOM_ID));
+			verify(eventService).publishChatMessageBroadcastEvent(responseCaptor.capture(), eq(TEST_ROOM_ID));
 			ChatResponse passedResponse = responseCaptor.getValue();
 			assertAll(
 				() -> assertEquals(passedResponse.message(), passedChat.getMessage()),
@@ -320,17 +323,20 @@ class ChattingUseCaseTest {
 			ArgumentCaptor<List<ChatResponse>> chatResponseCaptor =
 				(ArgumentCaptor<List<ChatResponse>>)(Object)
 					ArgumentCaptor.forClass(List.class);
-			verify(eventService).publishRoomEnterEvent(chatResponseCaptor.capture(), eq(TEST_PRINCIPAL), eq(TEST_SESSION_ID));
+			verify(eventService).publishChatRoomHistoryLoadEvent(chatResponseCaptor.capture(), eq(TEST_PRINCIPAL),
+				eq(TEST_SESSION_ID));
 
 			List<ChatResponse> passedChatResponse = chatResponseCaptor.getValue();
 			passedChatResponse.forEach(chatResponse ->
 				assertEquals(chatResponse.name(), user.getNickname())
 			);
 
-			verify(eventService).publishRoomEnterAndLeftEvent(user.getNickname() + " 님이 입장했어요~!", TEST_ROOM_ID);
+			verify(eventService).publishChatRoomEntryExitMessageEvent(
+				ChatMessageTemplate.CHAT_ROOM_ENTER.format(user.getNickname()), TEST_ROOM_ID);
 
-			ArgumentCaptor<RoomChangedResponse> roomChangedResponseCaptor = ArgumentCaptor.forClass(RoomChangedResponse.class);
-			verify(eventService).publishRoomChangeEvent(roomChangedResponseCaptor.capture());
+			ArgumentCaptor<RoomChangedResponse> roomChangedResponseCaptor = ArgumentCaptor.forClass(
+				RoomChangedResponse.class);
+			verify(eventService).publishChatRoomParticipantCountChangeEvent(roomChangedResponseCaptor.capture());
 			RoomChangedResponse passedRoomChangedResponse = roomChangedResponseCaptor.getValue();
 			assertAll(
 				() -> assertEquals(EVENT_UPDATE, passedRoomChangedResponse.eventType()),
@@ -348,7 +354,10 @@ class ChattingUseCaseTest {
 			given(userDomainService.getUser(anyString())).willReturn(user);
 			given(chattingDomainService.getChatRoom(anyLong())).willReturn(chatRoom1);
 			given(sessionService.removeSessionCount(TEST_SESSION_ID))
-				.willReturn(Map.of("roomId", TEST_ROOM_ID, "headCount", 1L));
+				.willReturn(RoomSessionInfo.builder()
+					.roomId(TEST_ROOM_ID)
+					.headCount(1L)
+					.build());
 
 			// when
 			chattingUseCase.leftChatRoom(TEST_SESSION_ID, TEST_EMAIL, TEST_ROOM_ID);
@@ -357,10 +366,11 @@ class ChattingUseCaseTest {
 			verify(userDomainService).getUser(TEST_EMAIL);
 			verify(chattingDomainService).getChatRoom(TEST_ROOM_ID);
 
-			verify(eventService).publishRoomEnterAndLeftEvent(user.getNickname() + " 님이 나가셨습니다~", TEST_ROOM_ID);
+			verify(eventService).publishChatRoomEntryExitMessageEvent(
+				ChatMessageTemplate.CHAT_ROOM_LEFT.format(user.getNickname()), TEST_ROOM_ID);
 
 			ArgumentCaptor<RoomChangedResponse> responseCaptor = ArgumentCaptor.forClass(RoomChangedResponse.class);
-			verify(eventService).publishRoomChangeEvent(responseCaptor.capture());
+			verify(eventService).publishChatRoomParticipantCountChangeEvent(responseCaptor.capture());
 			RoomChangedResponse passed = responseCaptor.getValue();
 			assertAll(
 				() -> assertEquals(TEST_ROOM_ID, passed.roomId()),


### PR DESCRIPTION

---

## 작업 내용

- 메서드 이름 가독성 좋게끔 변경, 하드코딩된 메시지 제거, 필요없는 null 체크 제거

---

## 해결해야 할 문제

- 네이밍 문제는 지속적으로 좀 더 괜찮은 게 있는지 확인해보면서 계속 변경해보겠습니다.

---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 채팅방 세션 정보(방 ID, 인원수)를 담는 RoomSessionInfo 타입이 추가되었습니다.
    - 채팅 이벤트 메시지 템플릿(enum) 및 메시지 포맷 기능이 도입되었습니다.

- **리팩터**
    - 채팅 이벤트 관련 서비스, 리스너, 메시지 서비스의 메서드 명칭이 보다 명확하고 구체적으로 변경되었습니다.
    - 채팅 스팸 제재 관련 메서드 명칭이 일관성 있게 변경되었습니다.
    - 세션 카운트 반환 타입이 Map에서 RoomSessionInfo로 개선되었습니다.
    - Redis Lua 스크립트가 가독성 향상을 위해 멀티라인 텍스트 블록으로 변경되었습니다.
    - 일부 클래스 및 메서드 명칭이 직관적으로 변경되었습니다.

- **테스트**
    - 변경된 메서드 명칭 및 데이터 타입에 맞춰 테스트 코드가 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->