### PR TITLE
docs : Swagger 문서화를 위한 컨트롤러 및 DTO 어노테이션 추가

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/submission/dto/request/language/LanguageCreateRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/dto/request/language/LanguageCreateRequest.java
@@ -2,17 +2,22 @@ package org.ezcode.codetest.application.submission.dto.request.language;
 
 import org.ezcode.codetest.domain.language.model.entity.Language;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "언어 생성 요청")
 public record LanguageCreateRequest(
 
+	@Schema(description = "언어 이름", example = "Java")
 	@NotBlank(message = "언어는 필수 입력 값입니다.")
 	String name,
 
+	@Schema(description = "언어 버전", example = "17")
 	@NotBlank(message = "버전은 필수 입력 값입니다.")
 	String version,
 
+	@Schema(description = "Judge0에서 사용하는 언어 ID", example = "62")
 	@NotNull(message = "Judge0 아이디는 필수 입력 값입니다.")
 	Long judge0Id
 

--- a/src/main/java/org/ezcode/codetest/application/submission/dto/request/language/LanguageUpdateRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/dto/request/language/LanguageUpdateRequest.java
@@ -1,9 +1,12 @@
 package org.ezcode.codetest.application.submission.dto.request.language;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "언어 업데이트 요청")
 public record LanguageUpdateRequest(
 
+	@Schema(description = "Judge0에서 사용하는 언어 ID", example = "62")
 	@NotNull(message = "Judge0 아이디는 필수 입력 값입니다.")
 	Long judge0Id
 

--- a/src/main/java/org/ezcode/codetest/application/submission/dto/request/review/CodeReviewRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/dto/request/review/CodeReviewRequest.java
@@ -1,16 +1,24 @@
 package org.ezcode.codetest.application.submission.dto.request.review;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "코드 리뷰 요청 DTO")
 public record CodeReviewRequest(
 
+	@Schema(description = "언어 ID", example = "62")
 	@NotNull(message = "언어 번호는 필수 입력 값입니다.")
 	Long languageId,
 
+	@Schema(
+		description = "소스 코드",
+		example = "public class Main { public static void main(String[] args) { System.out.println(\"Hello\"); } }"
+	)
 	@NotBlank(message = "소스 코드는 필수 입력 값입니다.")
 	String sourceCode,
 
+	@Schema(description = "정답 여부", example = "true")
 	@NotNull(message = "정답 여부는 필수 입력 값입니다.")
 	Boolean isCorrect
 

--- a/src/main/java/org/ezcode/codetest/application/submission/dto/request/submission/CodeSubmitRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/dto/request/submission/CodeSubmitRequest.java
@@ -1,13 +1,20 @@
 package org.ezcode.codetest.application.submission.dto.request.submission;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "코드 제출 요청 DTO")
 public record CodeSubmitRequest(
 
+	@Schema(description = "언어 ID", example = "1")
 	@NotNull(message = "언어 번호는 필수 입력 값입니다.")
 	Long languageId,
 
+	@Schema(
+		description = "소스 코드",
+		example = "public class Main { public static void main(String[] args) { System.out.println(\"Hello World\"); } }"
+	)
 	@NotBlank(message = "소스 코드는 필수 입력 값입니다.")
 	String sourceCode
 

--- a/src/main/java/org/ezcode/codetest/application/submission/dto/response/language/LanguageResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/dto/response/language/LanguageResponse.java
@@ -2,14 +2,21 @@ package org.ezcode.codetest.application.submission.dto.response.language;
 
 import org.ezcode.codetest.domain.language.model.entity.Language;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "언어 응답 정보")
 public record LanguageResponse (
 
+	@Schema(description = "언어 ID", example = "1")
 	Long id,
 
+	@Schema(description = "언어 이름", example = "Java")
 	String name,
 
+	@Schema(description = "언어 버전", example = "17")
 	String version,
 
+	@Schema(description = "Judge0에서 사용하는 언어 ID", example = "62")
 	Long judge0Id
 
 ){

--- a/src/main/java/org/ezcode/codetest/application/submission/dto/response/review/CodeReviewResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/dto/response/review/CodeReviewResponse.java
@@ -1,7 +1,11 @@
 package org.ezcode.codetest.application.submission.dto.response.review;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "코드 리뷰 응답 DTO")
 public record CodeReviewResponse(
 
+	@Schema(description = "리뷰 내용", example = "변수명이 명확하지 않습니다. 의미 있는 이름을 사용해주세요.")
 	String reviewContent
 
 ) {

--- a/src/main/java/org/ezcode/codetest/application/submission/dto/response/submission/FinalResultResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/dto/response/submission/FinalResultResponse.java
@@ -1,16 +1,22 @@
 package org.ezcode.codetest.application.submission.dto.response.submission;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
+@Schema(description = "최종 채점 결과 응답 DTO")
 public class FinalResultResponse {
 
+	@Schema(description = "전체 테스트케이스 수", example = "5")
 	private final int totalCount;
 
+	@Schema(description = "통과한 테스트케이스 수", example = "5")
 	private final int passedCount;
 
+	@Schema(description = "전체 통과 여부", example = "true")
 	private final boolean isCorrect;
 
+	@Schema(description = "메시지", example = "Accepted")
 	private final String message;
 
 	public FinalResultResponse(int totalCount, int passedCount, String message) {

--- a/src/main/java/org/ezcode/codetest/application/submission/dto/response/submission/GroupedSubmissionResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/dto/response/submission/GroupedSubmissionResponse.java
@@ -7,16 +7,21 @@ import org.ezcode.codetest.domain.submission.model.entity.Submission;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 @JsonPropertyOrder({ "problemId", "problemDescription", "submissions" })
+@Schema(description = "문제 단위로 묶은 제출 목록 응답")
 public class GroupedSubmissionResponse {
 
+	@Schema(description = "문제 ID", example = "10")
 	private final Long problemId;
 
+	@Schema(description = "문제 설명", example = "두 수의 합을 구하는 문제입니다.")
 	private final String problemDescription;
 
+	@Schema(description = "해당 문제에 대한 제출 목록")
 	private final List<SubmissionDetailResponse> submissions;
 
 	public GroupedSubmissionResponse(Problem problem, List<Submission> submissions) {

--- a/src/main/java/org/ezcode/codetest/application/submission/dto/response/submission/JudgeResultResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/dto/response/submission/JudgeResultResponse.java
@@ -3,21 +3,29 @@ package org.ezcode.codetest.application.submission.dto.response.submission;
 import org.ezcode.codetest.application.submission.model.JudgeResult;
 import org.ezcode.codetest.domain.submission.dto.AnswerEvaluation;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "각 테스트케이스에 대한 채점 결과")
 public record JudgeResultResponse(
 
+	@Schema(description = "테스트케이스 통과 여부", example = "true")
 	boolean isPassed,
 
+	@Schema(description = "기댓값", example = "12")
 	String expectedOutput,
 
+	@Schema(description = "실제 출력값", example = "12")
 	String actualOutput,
 
+	@Schema(description = "실행 시간 (s)", example = "0.129")
 	Double executionTime,
 
+	@Schema(description = "메모리 사용량 (KB)", example = "12196")
 	Long memoryUsage,
 
+	@Schema(description = "결과 메시지", example = "Accepted")
 	String message
 
 ) {

--- a/src/main/java/org/ezcode/codetest/application/submission/dto/response/submission/SubmissionDetailResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/dto/response/submission/SubmissionDetailResponse.java
@@ -4,23 +4,31 @@ import java.time.LocalDateTime;
 
 import org.ezcode.codetest.domain.submission.model.entity.Submission;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
-@Builder
+@Schema(description = "개별 제출 결과 응답")
 public record SubmissionDetailResponse(
 
+	@Schema(description = "제출 ID", example = "101")
 	Long id,
 
+	@Schema(description = "소스 코드", example = "System.out.println(\"Hello\");")
 	String sourceCode,
 
+	@Schema(description = "정답 여부", example = "true")
 	boolean isCorrect,
 
+	@Schema(description = "결과 메시지", example = "Accepted")
 	String message,
 
+	@Schema(description = "실행 시간 (s)", example = "0.129")
 	Double executionTime,
 
+	@Schema(description = "메모리 사용량 (KB)", example = "12196")
 	Long memoryUsage,
 
+	@Schema(description = "제출 시간", example = "2025-06-11T19:00:00")
 	LocalDateTime submittedAt
 
 ) {

--- a/src/main/java/org/ezcode/codetest/application/submission/dto/response/submission/SubmissionDetailResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/dto/response/submission/SubmissionDetailResponse.java
@@ -5,7 +5,6 @@ import java.time.LocalDateTime;
 import org.ezcode.codetest.domain.submission.model.entity.Submission;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
 
 @Schema(description = "개별 제출 결과 응답")
 public record SubmissionDetailResponse(

--- a/src/main/java/org/ezcode/codetest/presentation/language/LanguageController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/language/LanguageController.java
@@ -17,24 +17,35 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/languages")
+@Tag(name = "Language", description = "프로그래밍 언어 관리 API")
 public class LanguageController {
 
 	private final LanguageService languageService;
 
 	@PostMapping
-	public ResponseEntity<LanguageResponse> createLanguage(@RequestBody @Valid LanguageCreateRequest request) {
+	@Operation(summary = "언어 생성", description = "새로운 프로그래밍 언어를 등록합니다.")
+	@ApiResponse(responseCode = "201", description = "언어 생성 성공")
+	public ResponseEntity<LanguageResponse> createLanguage(
+		@RequestBody @Valid LanguageCreateRequest request
+	) {
 		return ResponseEntity
 			.status(HttpStatus.CREATED)
 			.body(languageService.createLanguage(request));
 	}
 
 	@GetMapping
+	@Operation(summary = "언어 목록 조회", description = "등록된 모든 프로그래밍 언어 목록을 조회합니다.")
+	@ApiResponse(responseCode = "200", description = "언어 목록 조회 성공")
 	public ResponseEntity<List<LanguageResponse>> getLanguages() {
 		return ResponseEntity
 			.status(HttpStatus.OK)
@@ -42,16 +53,25 @@ public class LanguageController {
 	}
 
 	@PutMapping("/{languageId}")
+	@Operation(summary = "언어 수정", description = "기존 프로그래밍 언어 정보를 수정합니다.")
+	@ApiResponse(responseCode = "200", description = "언어 수정 성공")
 	public ResponseEntity<LanguageResponse> modifyLanguage(
+		@Parameter(description = "수정할 언어 ID", required = true)
 		@PathVariable Long languageId,
-		@RequestBody @Valid LanguageUpdateRequest request) {
+		@RequestBody @Valid LanguageUpdateRequest request
+	) {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(languageService.modifyLanguage(languageId, request));
 	}
 
 	@DeleteMapping("/{languageId}")
-	public ResponseEntity<Void> removeLanguage(@PathVariable Long languageId) {
+	@Operation(summary = "언어 삭제", description = "등록된 프로그래밍 언어를 삭제합니다.")
+	@ApiResponse(responseCode = "204", description = "언어 삭제 성공")
+	public ResponseEntity<Void> removeLanguage(
+		@Parameter(description = "삭제할 언어 ID", required = true)
+		@PathVariable Long languageId
+	) {
 		languageService.removeLanguage(languageId);
 		return ResponseEntity
 			.status(HttpStatus.NO_CONTENT)

--- a/src/main/java/org/ezcode/codetest/presentation/submission/SubmissionController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/submission/SubmissionController.java
@@ -18,23 +18,54 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Submission", description = "코드 제출 및 리뷰 관련 API")
 public class SubmissionController {
 
 	private final SubmissionService submissionService;
 
 	@PostMapping("/problems/{problemId}/submit-stream")
+	@Operation(
+		summary = "코드 제출 (SSE 응답)",
+		description = """
+        이 API는 Server-Sent Events(SSE)를 통해 테스트케이스별 채점 결과를 스트리밍으로 전송합니다.
+
+        응답 MIME 타입: `text/event-stream`
+        
+        응답 예시:
+        ```
+        data: {"isPassed":true,"expectedOutput":"7","actualOutput":"7","executionTime":0.129,"memoryUsage":12196,"message":"Accepted"}
+        ```
+        """
+	)
+	@ApiResponse(
+		responseCode = "200",
+		description = "SSE로 스트리밍 응답 전송",
+		content = @Content(mediaType = "text/event-stream")
+	)
 	public SseEmitter submitCodeStream(
-		@PathVariable Long problemId,
+		@Parameter(description = "제출할 문제 ID", required = true) @PathVariable Long problemId,
 		@RequestBody @Valid CodeSubmitRequest request,
 		@AuthenticationPrincipal AuthUser authUser) {
 		return submissionService.submitCodeStream(problemId, request, authUser);
 	}
 
+	@Operation(
+		summary = "사용자 제출 목록 조회",
+		description = "현재 로그인한 사용자의 코드 제출 기록을 조회합니다.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "제출 목록 반환")
+		}
+	)
 	@GetMapping("/submissions")
 	public ResponseEntity<List<GroupedSubmissionResponse>> getSubmissions(@AuthenticationPrincipal AuthUser authUser) {
 		return ResponseEntity
@@ -42,9 +73,16 @@ public class SubmissionController {
 			.body(submissionService.getSubmissions(authUser));
 	}
 
+	@Operation(
+		summary = "코드 리뷰 요청",
+		description = "특정 문제에 대해 사용자의 제출 코드를 리뷰 요청합니다.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "리뷰 결과 반환")
+		}
+	)
 	@PostMapping("/problems/{problemId}/review")
 	public ResponseEntity<CodeReviewResponse> getCodeReview(
-		@PathVariable Long problemId,
+		@Parameter(description = "문제 ID", required = true) @PathVariable Long problemId,
 		@RequestBody @Valid CodeReviewRequest request) {
 		return ResponseEntity
 			.status(HttpStatus.OK)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서화**
    - API 요청 및 응답 객체에 Swagger(OpenAPI) 어노테이션이 추가되어, 각 필드의 설명과 예시가 API 문서에 표시됩니다.
    - 언어, 제출, 코드 리뷰 관련 컨트롤러에 상세한 그룹, 메서드 설명, 응답 코드, 파라미터 설명 등이 추가되어 API 문서가 더욱 명확해졌습니다.  
    - 실제 서비스 동작에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->