### PR TITLE
docs : Swagger 어노테이션 추가 - 커뮤니티 및 알림 controller/dto 

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/community/dto/request/DiscussionCreateRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/community/dto/request/DiscussionCreateRequest.java
@@ -1,25 +1,30 @@
 package org.ezcode.codetest.application.community.dto.request;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
 import org.ezcode.codetest.domain.community.model.Discussion;
 import org.ezcode.codetest.domain.language.model.entity.Language;
 import org.ezcode.codetest.domain.problem.model.entity.Problem;
 import org.ezcode.codetest.domain.user.model.entity.User;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+@Schema(name = "DiscussionCreateRequest", description = "새로운 Discussion 생성 요청 DTO")
 public record DiscussionCreateRequest(
 
+	@Schema(description = "문제에 사용할 언어 ID", example = "1", requiredMode = REQUIRED)
 	@NotNull(message = "languageId는 필수값입니다.")
 	Long languageId,
 
+	@Schema(description = "토론 내용", example = "이 문제에 대해 이렇게 생각했습니다...", maxLength = 2000, requiredMode = REQUIRED)
 	@NotBlank(message = "내용을 입력해야 합니다.")
 	@Size(max = 2000, message = "내용은 최대 2000자까지 허용됩니다.")
 	String content
 
 ) {
-
 	public static Discussion toEntity(
 		User user,
 		Problem problem,
@@ -33,5 +38,4 @@ public record DiscussionCreateRequest(
 			.content(request.content())
 			.build();
 	}
-
 }

--- a/src/main/java/org/ezcode/codetest/application/community/dto/request/DiscussionModifyRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/community/dto/request/DiscussionModifyRequest.java
@@ -1,14 +1,20 @@
 package org.ezcode.codetest.application.community.dto.request;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+@Schema(name = "DiscussionModifyRequest", description = "기존 Discussion 수정 요청 DTO")
 public record DiscussionModifyRequest(
 
+	@Schema(description = "문제에 사용할 언어 ID", example = "1", requiredMode = REQUIRED)
 	@NotNull(message = "languageId는 필수값입니다.")
 	Long languageId,
 
+	@Schema(description = "수정할 토론 내용", example = "내용을 이렇게 바꿨습니다...", maxLength = 2000, requiredMode = REQUIRED)
 	@NotBlank(message = "내용을 입력해야 합니다.")
 	@Size(max = 2000, message = "내용은 최대 2000자까지 허용됩니다.")
 	String content

--- a/src/main/java/org/ezcode/codetest/application/community/dto/request/ReplyCreateRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/community/dto/request/ReplyCreateRequest.java
@@ -1,17 +1,22 @@
 package org.ezcode.codetest.application.community.dto.request;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
 import org.ezcode.codetest.domain.community.model.Discussion;
 import org.ezcode.codetest.domain.community.model.Reply;
 import org.ezcode.codetest.domain.user.model.entity.User;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(name = "ReplyCreateRequest", description = "새로운 Reply 생성 요청 DTO")
 public record ReplyCreateRequest(
 
-	// nullable
+	@Schema(description = "부모 Reply ID (대댓글인 경우)", example = "5", nullable = true)
 	Long parentReplyId,
 
+	@Schema(description = "댓글 내용", example = "좋은 의견입니다!", maxLength = 2000, requiredMode = REQUIRED)
 	@NotBlank(message = "내용을 입력해야 합니다.")
 	@Size(max = 2000, message = "내용은 최대 2000자까지 허용됩니다.")
 	String content
@@ -28,7 +33,7 @@ public record ReplyCreateRequest(
 			.discussion(discussion)
 			.user(user)
 			.parent(parent)
-			.content(request.content)
+			.content(request.content())
 			.build();
 	}
 }

--- a/src/main/java/org/ezcode/codetest/application/community/dto/request/ReplyModifyRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/community/dto/request/ReplyModifyRequest.java
@@ -1,10 +1,15 @@
 package org.ezcode.codetest.application.community.dto.request;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(name = "ReplyModifyRequest", description = "기존 Reply 수정 요청 DTO")
 public record ReplyModifyRequest(
 
+	@Schema(description = "수정할 댓글 내용", example = "내용을 이렇게 변경합니다.", maxLength = 2000, requiredMode = REQUIRED)
 	@NotBlank(message = "내용을 입력해야 합니다.")
 	@Size(max = 2000, message = "내용은 최대 2000자까지 허용됩니다.")
 	String content

--- a/src/main/java/org/ezcode/codetest/application/community/dto/response/DiscussionResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/community/dto/response/DiscussionResponse.java
@@ -1,20 +1,28 @@
 package org.ezcode.codetest.application.community.dto.response;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
 import org.ezcode.codetest.application.usermanagement.user.dto.response.SimpleUserInfoResponse;
 import org.ezcode.codetest.domain.community.model.Discussion;
 
-public record DiscussionResponse(
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(name = "DiscussionResponse", description = "Discussion 조회 응답 DTO")
+public record DiscussionResponse(
+	@Schema(description = "Discussion 고유 ID", example = "123", requiredMode = REQUIRED)
 	Long discussionId,
 
+	@Schema(description = "작성자 정보", requiredMode = REQUIRED)
 	SimpleUserInfoResponse userInfo,
 
+	@Schema(description = "관련 문제 ID", example = "45", requiredMode = REQUIRED)
 	Long problemId,
 
+	@Schema(description = "사용 언어명", example = "Java 17", requiredMode = REQUIRED)
 	String languages,
 
+	@Schema(description = "토론 내용", example = "이 문제는 이렇게 풀 수 있습니다...", requiredMode = REQUIRED)
 	String content
-
 ) {
 
 	public static DiscussionResponse fromEntity(Discussion discussion) {
@@ -26,5 +34,4 @@ public record DiscussionResponse(
 			discussion.getContent()
 		);
 	}
-
 }

--- a/src/main/java/org/ezcode/codetest/application/community/dto/response/ReplyResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/community/dto/response/ReplyResponse.java
@@ -1,27 +1,34 @@
 package org.ezcode.codetest.application.community.dto.response;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
 import org.ezcode.codetest.application.usermanagement.user.dto.response.SimpleUserInfoResponse;
 import org.ezcode.codetest.domain.community.model.Reply;
 
-public record ReplyResponse(
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(name = "ReplyResponse", description = "Reply 조회 응답 DTO")
+public record ReplyResponse(
+	@Schema(description = "Reply 고유 ID", example = "456", requiredMode = REQUIRED)
 	Long replyId,
 
+	@Schema(description = "부모 Reply ID (없으면 null)", example = "123", nullable = true, requiredMode = NOT_REQUIRED)
 	Long parentId,
 
+	@Schema(description = "소속 Discussion ID", example = "123", requiredMode = REQUIRED)
 	Long discussionId,
 
+	@Schema(description = "작성자 정보", requiredMode = REQUIRED)
 	SimpleUserInfoResponse userInfo,
 
+	@Schema(description = "댓글 내용", example = "동의합니다!", requiredMode = REQUIRED)
 	String content
-
 ) {
 
 	public static ReplyResponse fromEntity(Reply reply) {
 		Long parentId = (reply.getParent() != null)
 			? reply.getParent().getId()
 			: null;
-
 		return new ReplyResponse(
 			reply.getId(),
 			parentId,

--- a/src/main/java/org/ezcode/codetest/application/community/dto/response/VoteResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/community/dto/response/VoteResponse.java
@@ -1,9 +1,16 @@
 package org.ezcode.codetest.application.community.dto.response;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.*;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "VoteResponse", description = "추천 상태 응답 DTO")
 public record VoteResponse(
-
-	// 추천 등록되면 true, 취소되면 false
+	@Schema(
+		description = "추천 상태 (추천되어 있으면 true, 취소되면 false)",
+		example = "true",
+		requiredMode = REQUIRED
+	)
 	boolean voteStatus
-
 ) {
 }

--- a/src/main/java/org/ezcode/codetest/presentation/community/DiscussionController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/community/DiscussionController.java
@@ -5,6 +5,7 @@ import org.ezcode.codetest.application.community.dto.request.DiscussionModifyReq
 import org.ezcode.codetest.application.community.dto.response.DiscussionResponse;
 import org.ezcode.codetest.application.community.service.DiscussionService;
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -65,7 +66,7 @@ public class DiscussionController {
 	@GetMapping
 	public ResponseEntity<Page<DiscussionResponse>> getDiscussions(
 		@PathVariable Long problemId,
-		@PageableDefault Pageable pageable
+		@ParameterObject @PageableDefault Pageable pageable
 	) {
 
 		Page<DiscussionResponse> page = discussionService.getDiscussions(problemId, pageable);

--- a/src/main/java/org/ezcode/codetest/presentation/community/DiscussionController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/community/DiscussionController.java
@@ -20,37 +20,67 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/problems/{problemId}/discussions")
+@Tag(name = "Discussions", description = "문제별 토론 관리 API")
 @RequiredArgsConstructor
 public class DiscussionController {
 
 	private final DiscussionService discussionService;
 
+	@Operation(
+		summary = "토론 생성",
+		description = "주어진 문제(problemId)에 새로운 토론을 생성합니다.",
+		parameters = {
+			@Parameter(name = "problemId", description = "문제 ID", required = true)
+		}
+	)
+	@ApiResponse(responseCode = "201", description = "생성된 Discussion 반환")
 	@PostMapping
 	public ResponseEntity<DiscussionResponse> createDiscussion(
 		@PathVariable Long problemId,
 		@RequestBody @Valid DiscussionCreateRequest request,
 		@AuthenticationPrincipal AuthUser authUser
 	) {
-		return ResponseEntity
-			.status(HttpStatus.CREATED)
-			.body(discussionService.createDiscussion(problemId, request, authUser.getId()));
+
+		DiscussionResponse dto = discussionService.createDiscussion(problemId, request, authUser.getId());
+		return ResponseEntity.status(HttpStatus.CREATED).body(dto);
 	}
 
+	@Operation(
+		summary = "토론 목록 조회",
+		description = "해당 문제의 토론 목록을 페이징하여 조회합니다.",
+		parameters = {
+			@Parameter(name = "problemId", description = "문제 ID", required = true)
+		}
+	)
+	@ApiResponse(responseCode = "200", description = "토론 목록 조회 성공")
 	@GetMapping
 	public ResponseEntity<Page<DiscussionResponse>> getDiscussions(
 		@PathVariable Long problemId,
 		@PageableDefault Pageable pageable
 	) {
-		return ResponseEntity
-			.ok()
-			.body(discussionService.getDiscussions(problemId, pageable));
+
+		Page<DiscussionResponse> page = discussionService.getDiscussions(problemId, pageable);
+		return ResponseEntity.ok(page);
 	}
 
+	@Operation(
+		summary = "토론 수정",
+		description = "특정 토론(discussionId)을 수정합니다.",
+		parameters = {
+			@Parameter(name = "problemId", description = "문제 ID", required = true),
+			@Parameter(name = "discussionId", description = "토론 ID", required = true)
+		}
+	)
+	@ApiResponse(responseCode = "200", description = "수정된 Discussion 반환")
 	@PutMapping("/{discussionId}")
 	public ResponseEntity<DiscussionResponse> modifyDiscussion(
 		@PathVariable Long problemId,
@@ -58,17 +88,27 @@ public class DiscussionController {
 		@RequestBody @Valid DiscussionModifyRequest request,
 		@AuthenticationPrincipal AuthUser authUser
 	) {
-		return ResponseEntity
-			.ok()
-			.body(discussionService.modifyDiscussion(problemId, discussionId, request, authUser.getId()));
+
+		DiscussionResponse dto = discussionService.modifyDiscussion(problemId, discussionId, request, authUser.getId());
+		return ResponseEntity.ok(dto);
 	}
 
+	@Operation(
+		summary = "토론 삭제",
+		description = "특정 토론(discussionId)을 삭제합니다.",
+		parameters = {
+			@Parameter(name = "problemId", description = "문제 ID", required = true),
+			@Parameter(name = "discussionId", description = "토론 ID", required = true)
+		}
+	)
+	@ApiResponse(responseCode = "200", description = "삭제 성공")
 	@DeleteMapping("/{discussionId}")
 	public ResponseEntity<Void> removeDiscussion(
 		@PathVariable Long problemId,
 		@PathVariable Long discussionId,
 		@AuthenticationPrincipal AuthUser authUser
 	) {
+
 		discussionService.removeDiscussion(problemId, discussionId, authUser.getId());
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/org/ezcode/codetest/presentation/community/DiscussionVoteController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/community/DiscussionVoteController.java
@@ -12,38 +12,59 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/problems/{problemId}/discussions/{discussionId}/votes")
+@Tag(name = "DiscussionVotes", description = "토론 추천(Vote) 관리 API")
 @RequiredArgsConstructor
 public class DiscussionVoteController {
 
 	private final DiscussionVoteService discussionVoteService;
 
+	@Operation(
+		summary = "토론 추천 토글",
+		description = "토론에 대한 추천을 생성하거나 취소합니다. 이 부분은 추후 추천/비추천 기능으로 변경될 수 있습니다.",
+		parameters = {
+			@Parameter(name = "problemId", description = "문제 ID", required = true),
+			@Parameter(name = "discussionId", description = "토론 ID", required = true)
+		}
+	)
+	@ApiResponse(responseCode = "201", description = "추천 생성됨 (voteStatus=true)")
+	@ApiResponse(responseCode = "200", description = "추천 취소됨 (voteStatus=false)")
 	@PostMapping
 	public ResponseEntity<VoteResponse> toggleVote(
 		@PathVariable Long problemId,
 		@PathVariable Long discussionId,
 		@AuthenticationPrincipal AuthUser authUser
 	) {
+
 		VoteResponse response = discussionVoteService.validateAndToggleVote(problemId, discussionId, authUser.getId());
 		HttpStatus status = response.voteStatus() ? HttpStatus.CREATED : HttpStatus.OK;
-
-		return ResponseEntity
-			.status(status)
-			.body(response);
+		return ResponseEntity.status(status).body(response);
 	}
 
+	@Operation(
+		summary = "토론 추천 상태 조회",
+		description = "현재 사용자가 해당 토론에 추천했는지 여부를 반환합니다.",
+		parameters = {
+			@Parameter(name = "problemId", description = "문제 ID", required = true),
+			@Parameter(name = "discussionId", description = "토론 ID", required = true)
+		}
+	)
+	@ApiResponse(responseCode = "200", description = "VoteResponse 반환")
 	@GetMapping
 	public ResponseEntity<VoteResponse> getVoteStatus(
 		@PathVariable Long problemId,
 		@PathVariable Long discussionId,
 		@AuthenticationPrincipal AuthUser authUser
 	) {
+
 		VoteResponse response = discussionVoteService.getVoteStatus(authUser.getId(), discussionId);
-		return ResponseEntity
-			.ok()
-			.body(response);
+		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/org/ezcode/codetest/presentation/community/ReplyController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/community/ReplyController.java
@@ -20,16 +20,30 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/problems/{problemId}/discussions/{discussionId}/replies")
+@Tag(name = "Replies", description = "토론 댓글(Reply) 관리 API")
 @RequiredArgsConstructor
 public class ReplyController {
 
 	private final ReplyService replyService;
 
+	@Operation(
+		summary = "댓글 생성",
+		description = "주어진 토론에 댓글을 추가합니다.",
+		parameters = {
+			@Parameter(name = "problemId", description = "문제 ID", required = true),
+			@Parameter(name = "discussionId", description = "토론 ID", required = true)
+		}
+	)
+	@ApiResponse(responseCode = "201", description = "생성된 Reply 반환")
 	@PostMapping
 	public ResponseEntity<ReplyResponse> createReply(
 		@PathVariable Long problemId,
@@ -37,24 +51,41 @@ public class ReplyController {
 		@RequestBody @Valid ReplyCreateRequest request,
 		@AuthenticationPrincipal AuthUser authUser
 	) {
-		return ResponseEntity
-			.status(HttpStatus.CREATED)
-			.body(replyService.createReply(problemId, discussionId, request, authUser.getId()));
+
+		ReplyResponse dto = replyService.createReply(problemId, discussionId, request, authUser.getId());
+		return ResponseEntity.status(HttpStatus.CREATED).body(dto);
 	}
 
-	// 댓글 목록 조회
+	@Operation(
+		summary = "댓글 목록 조회",
+		description = "해당 토론의 최상위 댓글 목록을 페이징하여 조회합니다.",
+		parameters = {
+			@Parameter(name = "problemId", description = "문제 ID", required = true),
+			@Parameter(name = "discussionId", description = "토론 ID", required = true)
+		}
+	)
+	@ApiResponse(responseCode = "200", description = "댓글 목록 조회 성공")
 	@GetMapping
 	public ResponseEntity<Page<ReplyResponse>> getReplies(
 		@PathVariable Long problemId,
 		@PathVariable Long discussionId,
 		@PageableDefault Pageable pageable
 	) {
-		return ResponseEntity
-			.ok()
-			.body(replyService.getReplies(problemId, discussionId, pageable));
+
+		Page<ReplyResponse> page = replyService.getReplies(problemId, discussionId, pageable);
+		return ResponseEntity.ok(page);
 	}
 
-	// 대댓글 목록 조회
+	@Operation(
+		summary = "대댓글 목록 조회",
+		description = "특정 부모 댓글(parentReplyId)의 하위 댓글을 페이징하여 조회합니다.",
+		parameters = {
+			@Parameter(name = "problemId", description = "문제 ID", required = true),
+			@Parameter(name = "discussionId", description = "토론 ID", required = true),
+			@Parameter(name = "parentReplyId", description = "부모 댓글 ID", required = true)
+		}
+	)
+	@ApiResponse(responseCode = "200", description = "대댓글 목록 조회 성공")
 	@GetMapping("/{parentReplyId}")
 	public ResponseEntity<Page<ReplyResponse>> getReplies(
 		@PathVariable Long problemId,
@@ -62,11 +93,21 @@ public class ReplyController {
 		@PathVariable Long parentReplyId,
 		@PageableDefault Pageable pageable
 	) {
-		return ResponseEntity
-			.ok()
-			.body(replyService.getChildReplies(problemId, discussionId, parentReplyId, pageable));
+
+		Page<ReplyResponse> page = replyService.getChildReplies(problemId, discussionId, parentReplyId, pageable);
+		return ResponseEntity.ok(page);
 	}
 
+	@Operation(
+		summary = "댓글 수정",
+		description = "특정 댓글(replyId)을 수정합니다.",
+		parameters = {
+			@Parameter(name = "problemId", description = "문제 ID", required = true),
+			@Parameter(name = "discussionId", description = "토론 ID", required = true),
+			@Parameter(name = "replyId", description = "댓글 ID", required = true)
+		}
+	)
+	@ApiResponse(responseCode = "200", description = "수정된 Reply 반환")
 	@PutMapping("/{replyId}")
 	public ResponseEntity<ReplyResponse> modifyReply(
 		@PathVariable Long problemId,
@@ -75,11 +116,21 @@ public class ReplyController {
 		@RequestBody @Valid ReplyModifyRequest request,
 		@AuthenticationPrincipal AuthUser authUser
 	) {
-		return ResponseEntity
-			.ok()
-			.body(replyService.modifyReply(problemId, discussionId, replyId, request, authUser.getId()));
+
+		ReplyResponse dto = replyService.modifyReply(problemId, discussionId, replyId, request, authUser.getId());
+		return ResponseEntity.ok(dto);
 	}
 
+	@Operation(
+		summary = "댓글 삭제",
+		description = "특정 댓글(replyId)을 삭제합니다.",
+		parameters = {
+			@Parameter(name = "problemId", description = "문제 ID", required = true),
+			@Parameter(name = "discussionId", description = "토론 ID", required = true),
+			@Parameter(name = "replyId", description = "댓글 ID", required = true)
+		}
+	)
+	@ApiResponse(responseCode = "200", description = "삭제 성공")
 	@DeleteMapping("/{replyId}")
 	public ResponseEntity<Void> removeReply(
 		@PathVariable Long problemId,
@@ -87,6 +138,7 @@ public class ReplyController {
 		@PathVariable Long replyId,
 		@AuthenticationPrincipal AuthUser authUser
 	) {
+
 		replyService.removeReply(problemId, discussionId, replyId, authUser.getId());
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/org/ezcode/codetest/presentation/community/ReplyController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/community/ReplyController.java
@@ -5,6 +5,7 @@ import org.ezcode.codetest.application.community.dto.request.ReplyModifyRequest;
 import org.ezcode.codetest.application.community.dto.response.ReplyResponse;
 import org.ezcode.codetest.application.community.service.ReplyService;
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -69,7 +70,7 @@ public class ReplyController {
 	public ResponseEntity<Page<ReplyResponse>> getReplies(
 		@PathVariable Long problemId,
 		@PathVariable Long discussionId,
-		@PageableDefault Pageable pageable
+		@ParameterObject @PageableDefault Pageable pageable
 	) {
 
 		Page<ReplyResponse> page = replyService.getReplies(problemId, discussionId, pageable);
@@ -91,7 +92,7 @@ public class ReplyController {
 		@PathVariable Long problemId,
 		@PathVariable Long discussionId,
 		@PathVariable Long parentReplyId,
-		@PageableDefault Pageable pageable
+		@ParameterObject @PageableDefault Pageable pageable
 	) {
 
 		Page<ReplyResponse> page = replyService.getChildReplies(problemId, discussionId, parentReplyId, pageable);

--- a/src/main/java/org/ezcode/codetest/presentation/community/ReplyVoteController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/community/ReplyVoteController.java
@@ -12,15 +12,31 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/problems/{problemId}/discussions/{discussionId}/replies/{replyId}/votes")
+@Tag(name = "ReplyVotes", description = "댓글 추천(Vote) 관리 API")
 @RequiredArgsConstructor
 public class ReplyVoteController {
 
 	private final ReplyVoteService replyVoteService;
 
+	@Operation(
+		summary = "댓글 추천 토글",
+		description = "댓글에 대한 추천을 생성하거나 취소합니다.",
+		parameters = {
+			@Parameter(name = "problemId", description = "문제 ID", required = true),
+			@Parameter(name = "discussionId", description = "토론 ID", required = true),
+			@Parameter(name = "replyId", description = "댓글 ID", required = true)
+		}
+	)
+	@ApiResponse(responseCode = "201", description = "추천 생성됨 (voteStatus=true)")
+	@ApiResponse(responseCode = "200", description = "추천 취소됨 (voteStatus=false)")
 	@PostMapping
 	public ResponseEntity<VoteResponse> toggleVote(
 		@PathVariable Long problemId,
@@ -28,14 +44,23 @@ public class ReplyVoteController {
 		@PathVariable Long replyId,
 		@AuthenticationPrincipal AuthUser authUser
 	) {
+
 		VoteResponse response = replyVoteService.validateAndToggleVote(problemId, discussionId, replyId, authUser.getId());
 		HttpStatus status = response.voteStatus() ? HttpStatus.CREATED : HttpStatus.OK;
 
-		return ResponseEntity
-			.status(status)
-			.body(response);
+		return ResponseEntity.status(status).body(response);
 	}
 
+	@Operation(
+		summary = "댓글 추천 상태 조회",
+		description = "현재 사용자가 해당 댓글에 추천했는지 여부를 반환합니다.",
+		parameters = {
+			@Parameter(name = "problemId", description = "문제 ID", required = true),
+			@Parameter(name = "discussionId", description = "토론 ID", required = true),
+			@Parameter(name = "replyId", description = "댓글 ID", required = true)
+		}
+	)
+	@ApiResponse(responseCode = "200", description = "VoteResponse 반환")
 	@GetMapping
 	public ResponseEntity<VoteResponse> getVoteStatus(
 		@PathVariable Long problemId,
@@ -43,9 +68,8 @@ public class ReplyVoteController {
 		@PathVariable Long replyId,
 		@AuthenticationPrincipal AuthUser authUser
 	) {
+
 		VoteResponse response = replyVoteService.getVoteStatus(authUser.getId(), replyId);
-		return ResponseEntity
-			.ok()
-			.body(response);
+		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/org/ezcode/codetest/presentation/notification/NotificationController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/notification/NotificationController.java
@@ -3,6 +3,7 @@ package org.ezcode.codetest.presentation.notification;
 import org.ezcode.codetest.application.notification.service.NotificationUseCase;
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.ezcode.codetest.presentation.advice.ResponseMessage;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -11,34 +12,55 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @Controller
 @RequestMapping("/notifications")
+@Tag(name = "Notifications", description = "알림 조회 및 읽음 처리 API")
 @RequiredArgsConstructor
 public class NotificationController {
 
 	private final NotificationUseCase useCase;
 
+	@Operation(
+		summary = "알림 목록 조회",
+		description = "현재 사용자(authUser)의 알림을 페이징하여 조회 요청을 보냅니다.",
+		parameters = {
+			@Parameter(name = "pageable", description = "페이징 정보 (page, size, sort)")
+		}
+	)
+	@ApiResponse(responseCode = "200", description = "알림 목록 조회 요청 완료")
 	@GetMapping
 	@ResponseMessage("알림 목록 조회 요청 완료")
 	public ResponseEntity<Void> getNotificationList(
 		@AuthenticationPrincipal AuthUser authUser,
-		@PageableDefault Pageable pageable
+		@ParameterObject @PageableDefault Pageable pageable
 	) {
 
 		useCase.getNotificationList(authUser.getEmail(), pageable);
 		return ResponseEntity.ok().build();
 	}
-	
+
+	@Operation(
+		summary = "알림 읽음 처리",
+		description = "해당 notificationId의 알림을 읽음 처리(mark as read) 합니다.",
+		parameters = {
+			@Parameter(name = "notificationId", description = "읽음 처리할 알림 ID", required = true)
+		}
+	)
+	@ApiResponse(responseCode = "200", description = "알림 읽음 처리 완료")
 	@PatchMapping("/{notificationId}")
 	@ResponseMessage("알림 읽음 처리 완료")
 	public ResponseEntity<Void> modifyNotificationMarksRead(
 		@PathVariable String notificationId,
-		@AuthenticationPrincipal AuthUser authUser) {
+		@AuthenticationPrincipal AuthUser authUser
+	) {
 
 		useCase.modifyNotificationMarksRead(authUser.getEmail(), notificationId);
 		return ResponseEntity.ok().build();

--- a/src/main/java/org/ezcode/codetest/presentation/notification/NotificationController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/notification/NotificationController.java
@@ -35,7 +35,7 @@ public class NotificationController {
 			@Parameter(name = "pageable", description = "페이징 정보 (page, size, sort)")
 		}
 	)
-	@ApiResponse(responseCode = "200", description = "알림 목록 조회 요청 완료")
+	@ApiResponse(responseCode = "200", description = "알림 목록 조회 요청 완료. 데이터는 웹소켓으로 전달됨")
 	@GetMapping
 	@ResponseMessage("알림 목록 조회 요청 완료")
 	public ResponseEntity<Void> getNotificationList(


### PR DESCRIPTION
## 작업 내용

- 커뮤니티 및 알림 도메인의 controller와 dto에 Swagger 어노테이션 적용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **문서화**
    - 커뮤니티 관련 API(DTO, 컨트롤러, 응답 객체)에 Swagger/OpenAPI 어노테이션이 추가되어 API 문서가 더욱 상세하고 명확하게 개선되었습니다.
    - 각 필드와 엔드포인트에 설명, 예시, 필수 여부 등이 문서화되어 API 사용성이 향상되었습니다.
    - 알림, 토론, 댓글, 추천(투표) 관련 API 문서도 동일하게 개선되었습니다.

- **신규 기능**
    - 댓글 추천 상태를 조회하는 API 엔드포인트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->