### PR TITLE
Refactor : html(google oauth)로 리다이렉팅되는 문제 해결

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/usermanagement/auth/service/AuthService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/auth/service/AuthService.java
@@ -115,14 +115,7 @@ public class AuthService {
 		return SigninResponse.from(bearToken, refreshToken);
 	}
 
-	public LogoutResponse logout(Long userId, HttpServletRequest request) {
-		String bearerToken = request.getHeader("Authorization");
-
-		if (bearerToken == null || !bearerToken.startsWith("Bearer ")) {
-			throw new AuthException(AuthExceptionCode.INVALID_AUTHORIZATION_HEADER);
-		}
-
-		String token = jwtUtil.substringToken(bearerToken);
+	public LogoutResponse logout(Long userId, String token) {
 
 		Long expiration = jwtUtil.getRemainingTime(token);
 

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/auth/service/AuthService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/auth/service/AuthService.java
@@ -17,7 +17,7 @@ import org.ezcode.codetest.common.security.util.JwtUtil;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
-import jakarta.servlet.http.HttpServletRequest;
+
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -137,28 +137,21 @@ public class AuthService {
 	}
 
 	//토큰 재발급
-	public RefreshTokenResponse refreshToken(HttpServletRequest request) {
-		String bearToken = request.getHeader("Authorization");
+	public RefreshTokenResponse refreshToken(String token) {
+		log.info("서비스 입장");
 
-		if (bearToken == null || !bearToken.startsWith("Bearer ")) {
-			throw new AuthException(AuthExceptionCode.INVALID_AUTHORIZATION_HEADER);
-		}
-		String refreshToken = jwtUtil.substringToken(bearToken);
+		Long userId = jwtUtil.getUserId(token);
 
-		if (!jwtUtil.validateToken(refreshToken)){
-			throw new AuthException(AuthExceptionCode.INVALID_REFRESH_TOKEN);
-		}
-
-		Long userId = jwtUtil.getUserId(refreshToken);
-
+		log.info("유저 아이디 가져옴");
 		String savedToken = redisTemplate.opsForValue().get("RefreshToken:" + userId);
-
-		if (savedToken==null || !savedToken.equals(refreshToken)){
+		log.info("저장된 토큰 가져옴");
+		if (savedToken==null || !savedToken.equals(token)){
+			log.error("저장된 토큰 없음");
 			throw new AuthException(AuthExceptionCode.INVALID_REFRESH_TOKEN);
 		}
 
 		User user = userDomainService.getUserById(userId);
-
+		log.info("유저 도메인서비스에서 유저 아이디로 유저 찾아옴");
 		String newAccessToken = jwtUtil.createToken(
 			user.getId(),
 			user.getEmail(),

--- a/src/main/java/org/ezcode/codetest/common/security/config/SecurityConfig.java
+++ b/src/main/java/org/ezcode/codetest/common/security/config/SecurityConfig.java
@@ -14,9 +14,12 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -40,14 +43,19 @@ public class SecurityConfig {
 			.formLogin(AbstractHttpConfigurer::disable)
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.logout(AbstractHttpConfigurer::disable)
-			// .oauth2Login((outh2)-> outh2
-			// 	.userInfoEndpoint((userInfoEndpointConfig ->
-			// 		userInfoEndpointConfig.userService(customOAuth2UserService)))
-			// 	.successHandler(customSuccessHandler))
+			.oauth2Login((outh2)-> outh2
+				.userInfoEndpoint((userInfoEndpointConfig ->
+					userInfoEndpointConfig.userService(customOAuth2UserService)))
+				.successHandler(customSuccessHandler)
+				.loginPage("/login"))
 			// JWT 사용을 위해 세션을 STATELESS로 설정 (세션 정보 저장 x)
 			.sessionManagement(session -> session
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			)
+			//에러 처리 체인 추가
+			.exceptionHandling(except -> except
+				.authenticationEntryPoint(customAuthenticationEntryPoint())
+				.accessDeniedHandler(customAccessDeniedHandler()))
 
 			//인증 URL 범위 설정
 			.authorizeHttpRequests(authorizeRequests ->
@@ -83,12 +91,53 @@ public class SecurityConfig {
 			.build();
 	}
 
+	// 인증 실패 시 JSON 응답 반환 (HTML 리다이렉트 방지)
 	@Bean
-	public FilterRegistrationBean<JwtFilter> jwtFilter() {
-		FilterRegistrationBean<JwtFilter> registrationBean = new FilterRegistrationBean<>();
-		registrationBean.setFilter(new JwtFilter(jwtUtil, redisTemplate));
-		registrationBean.addUrlPatterns("/*");
+	public AuthenticationEntryPoint customAuthenticationEntryPoint() {
+		return (request, response, authException) -> {
+			response.setContentType("application/json");
+			response.setCharacterEncoding("UTF-8");
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 
-		return registrationBean;
+			String jsonResponse = """
+                {
+                    "error": "Unauthorized",
+                    "message": "토큰이 필요합니다",
+                    "timestamp": "%s",
+                    "path": "%s"
+                }
+                """.formatted(
+				java.time.LocalDateTime.now().toString(),
+				request.getRequestURI()
+			);
+
+			response.getWriter().write(jsonResponse);
+		};
 	}
+
+	// 접근 권한 없을 때 JSON 응답 반환
+	@Bean
+	public AccessDeniedHandler customAccessDeniedHandler() {
+		return (request, response, accessDeniedException) -> {
+			response.setContentType("application/json");
+			response.setCharacterEncoding("UTF-8");
+			response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+			String jsonResponse = """
+                {
+                    "error": "Forbidden",
+                    "message": "접근 권한이 없습니다",
+                    "timestamp": "%s",
+                    "path": "%s"
+                }
+                """.formatted(
+				java.time.LocalDateTime.now().toString(),
+				request.getRequestURI()
+			);
+
+			response.getWriter().write(jsonResponse);
+		};
+	}
+
+
 }

--- a/src/main/java/org/ezcode/codetest/common/security/config/SecurityConfig.java
+++ b/src/main/java/org/ezcode/codetest/common/security/config/SecurityConfig.java
@@ -40,10 +40,10 @@ public class SecurityConfig {
 			.formLogin(AbstractHttpConfigurer::disable)
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.logout(AbstractHttpConfigurer::disable)
-			.oauth2Login((outh2)-> outh2
-				.userInfoEndpoint((userInfoEndpointConfig ->
-					userInfoEndpointConfig.userService(customOAuth2UserService)))
-				.successHandler(customSuccessHandler))
+			// .oauth2Login((outh2)-> outh2
+			// 	.userInfoEndpoint((userInfoEndpointConfig ->
+			// 		userInfoEndpointConfig.userService(customOAuth2UserService)))
+			// 	.successHandler(customSuccessHandler))
 			// JWT 사용을 위해 세션을 STATELESS로 설정 (세션 정보 저장 x)
 			.sessionManagement(session -> session
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
@@ -54,7 +54,6 @@ public class SecurityConfig {
 				authorizeRequests
 					.requestMatchers(
 						"/auth/**",
-						"/refresh",
 						"/signup",
 						"/login",
 						"/ezlogin",

--- a/src/main/java/org/ezcode/codetest/common/security/util/JwtFilter.java
+++ b/src/main/java/org/ezcode/codetest/common/security/util/JwtFilter.java
@@ -1,6 +1,7 @@
 package org.ezcode.codetest.common.security.util;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -31,9 +32,27 @@ public class JwtFilter extends OncePerRequestFilter {
 	private final JwtUtil jwtUtil;
 	private final RedisTemplate<String, String> redisTemplate;
 
+	// 토큰 검증을 건너뛸 경로들
+	private static final String[] WHITE_LIST = {
+		"/auth/signin",
+		"/auth/signup",
+		"/auth/refresh",
+		"/swagger-ui",
+		"/v3/api-docs",
+	};
+
+
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 									FilterChain filterChain) throws ServletException, IOException {
+
+		String requestURI = request.getRequestURI();
+
+		//whiteList 등록
+		if (shouldSkipFilter(requestURI)) {
+			filterChain.doFilter(request, response);
+			return;
+		}
 
 		String bearerToken = request.getHeader("Authorization");
 
@@ -86,4 +105,9 @@ public class JwtFilter extends OncePerRequestFilter {
 		filterChain.doFilter(request, response);
 		}
 
+	private boolean shouldSkipFilter(String requestURI){
+		return Arrays.stream(WHITE_LIST).anyMatch(requestURI::startsWith);
 	}
+
+	}
+

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/AuthController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/AuthController.java
@@ -17,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.netty.handler.codec.http2.Http2Headers;
@@ -30,6 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 @Tag(name = "인증/인가", description = "회원가입, 로그인, 로그아웃, 토큰 재발급 관련 API")
 public class AuthController {
 	private final AuthService authService;

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/AuthController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/AuthController.java
@@ -62,6 +62,12 @@ public class AuthController {
 	@Operation(summary = "토큰 재발급", description = "리프레시 토큰을 이용하여 새로운 액세스 토큰을 발급합니다.")
 	@PostMapping("/auth/refresh")
 	public ResponseEntity<RefreshTokenResponse> refresh(HttpServletRequest request) {
-		return ResponseEntity.status(HttpStatus.OK).body(authService.refreshToken(request));
+
+		String token = Optional.ofNullable(request.getHeader("Authorization"))
+			.map(h -> h.replace("Bearer ", ""))
+			.orElseThrow(()-> new AuthException(AuthExceptionCode.INVALID_AUTHORIZATION_HEADER));
+
+		log.info("Refresh token 추출 : {}", token);
+		return ResponseEntity.status(HttpStatus.OK).body(authService.refreshToken(token));
 	}
 }

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/AuthController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/AuthController.java
@@ -1,5 +1,7 @@
 package org.ezcode.codetest.presentation.usermanagement;
 
+import java.util.Optional;
+
 import org.ezcode.codetest.application.usermanagement.auth.dto.response.RefreshTokenResponse;
 import org.ezcode.codetest.application.usermanagement.auth.dto.request.SigninRequest;
 import org.ezcode.codetest.application.usermanagement.auth.dto.response.SigninResponse;
@@ -7,6 +9,8 @@ import org.ezcode.codetest.application.usermanagement.auth.dto.request.SignupReq
 import org.ezcode.codetest.application.usermanagement.auth.dto.response.SignupResponse;
 import org.ezcode.codetest.application.usermanagement.auth.service.AuthService;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.LogoutResponse;
+import org.ezcode.codetest.domain.user.exception.AuthException;
+import org.ezcode.codetest.domain.user.exception.AuthExceptionCode;
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.netty.handler.codec.http2.Http2Headers;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
@@ -46,7 +51,12 @@ public class AuthController {
 	public ResponseEntity<LogoutResponse> logout(
 			@AuthenticationPrincipal AuthUser authUser,
 			HttpServletRequest request) {
-		return ResponseEntity.status(HttpStatus.OK).body(authService.logout(authUser.getId(), request));
+
+		String token = Optional.ofNullable(request.getHeader("Authorization"))
+			.map(h -> h.replace("Bearer ", ""))
+			.orElseThrow(()-> new AuthException(AuthExceptionCode.INVALID_AUTHORIZATION_HEADER));
+
+		return ResponseEntity.status(HttpStatus.OK).body(authService.logout(authUser.getId(), token));
 	}
 
 	@Operation(summary = "토큰 재발급", description = "리프레시 토큰을 이용하여 새로운 액세스 토큰을 발급합니다.")

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 @Tag(name = "사용자 기본 기능", description = "사용자 정보 조회, 수정, 비밀번호 변경, 회원 탈퇴 API")
 public class UserController {
 	private final UserService userService;


### PR DESCRIPTION
## 작업 내용

- Spring Security에서 API 인증 실패 시 HTML 응답 대신 JSON 응답 반환하도록 수정함
- api 호출 시 Google OAuth 리다이렉트 방지 및 JSON 에러 응답 구현함
- JWT 필터 화이트리스트 기능 추가하여 특정 경로 인증 제외 처리함
 
---

## 변경 사항
- SecurityConfig.exceptionHandling() 설정 추가하여 커스텀 예외 처리 핸들러 등록함
- customAuthenticationEntryPoint() 빈 추가하여 인증 실패 시 JSON 응답 반환함
- customAccessDeniedHandler() 빈 추가하여 권한 부족 시 JSON 응답 반환함
- JwtFilter.shouldNotFilter() 메서드 추가하여 화이트리스트 경로 필터링 제외 처리함
- 화이트리스트 경로: /auth/**, /login/**, /oauth2/** 등 인증 불필요 경로 설정함

---

## 트러블 슈팅
**1. JwtFilter**
문제: 인증이 필요없는 경로에서도  JWT 필터가 동작하여 인증 검사 수행함
->   화이트리스트 경로는 JWT 검증 생략함

**2. HTML 반환 오류**
문제: OAuth2 설정으로 인해 인증되지 않은 요청이 자동으로 Google 로그인으로 리다이렉트됨
-> AuthenticationEntryPoint와 AccessDeniedHandler 설정으로 JSON 응답 우선 처리함

---

## 해결해야 할 문제

- 화이트리스트 경로가 SecurityConfig와 JwtFilter에 중복 정의됨 => 설정 통합 고려 필요함

---

## 참고 사항

- 에러 잘 뜹니당 이제ㅠㅠ
<img width="691" alt="image" src="https://github.com/user-attachments/assets/a7c4fce1-d3fb-41b8-a5aa-61e91683e2fa" />
 

---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 인증 및 인가 실패 시 JSON 형식의 에러 응답을 제공합니다.
- **버그 수정**
	- 인증 및 토큰 관련 엔드포인트에서 Authorization 헤더가 누락되었거나 잘못된 경우 명확한 에러 메시지를 반환합니다.
- **리팩터**
	- 토큰 처리 방식이 개선되어 서비스 레이어에서 직접 토큰 문자열을 사용하도록 변경되었습니다.
	- JWT 인증 필터에 화이트리스트 경로가 추가되어 일부 엔드포인트에서 토큰 검증이 생략됩니다.
	- API 엔드포인트에 공통 경로 `/api`가 추가되어 URL 구조가 일관되게 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->