### PR TITLE
feat : 스킬 전략패턴 추가, 랜덤 인카운터 요소 추가

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/game/dto/request/EncounterChoiceDeleteRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/game/dto/request/EncounterChoiceDeleteRequest.java
@@ -1,0 +1,11 @@
+package org.ezcode.codetest.application.game.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record EncounterChoiceDeleteRequest(
+
+	@NotBlank(message = "삭제할 이름을 입력해주세요.")
+	String name
+
+) {
+}

--- a/src/main/java/org/ezcode/codetest/application/game/dto/request/EncounterChoiceSaveRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/game/dto/request/EncounterChoiceSaveRequest.java
@@ -1,0 +1,46 @@
+package org.ezcode.codetest.application.game.dto.request;
+
+import org.ezcode.codetest.domain.game.model.entity.EncounterChoice;
+import org.ezcode.codetest.domain.game.model.entity.RandomEncounter;
+import org.ezcode.codetest.domain.game.model.enums.RandomEncounterEffect;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record EncounterChoiceSaveRequest(
+
+	@NotBlank(message = "인카운터 이름은 필수값입니다.")
+	String encounterName,
+
+	@NotBlank(message = "인카운터 선택 이름은 필수값입니다.")
+	String choiceName,
+
+	@NotBlank(message = "인카운터 선택 결과값은 필수값입니다.")
+	String resultText,
+
+	@NotBlank(message = "인카운터 이펙트는 필수값입니다.")
+	@Pattern(
+		regexp = "^(RANDOM_BATTLE"
+			+ "|MERCHANT_GOOD_DEAL|MERCHANT_BAD_DEAL"
+			+ "|STAT_INCREASE|STAT_DECREASE"
+			+ "|AMBUSH_BANDITS_WIN|AMBUSH_BANDITS_LOSE"
+			+ "|WILD_BEASTS_ESCAPE|WILD_BEASTS_ATTACK"
+			+ "|ANCIENT_RUINS_TREASURE|ANCIENT_RUINS_TRAP"
+			+ "|TREASURE_CACHE_FOUND|TREASURE_CACHE_EMPTY)$",
+		message = "effect 는 RandomEncounterEffect 의 유효한 값이어야 합니다."
+	)
+	String randomEncounterEffect
+
+) {
+
+	public EncounterChoice toEncounterChoice(RandomEncounter encounter) {
+
+		return EncounterChoice.builder()
+			.encounter(encounter)
+			.encounterEffect(RandomEncounterEffect.valueOf(randomEncounterEffect.trim().toUpperCase()))
+			.resultText(resultText)
+			.name(choiceName)
+			.build();
+	}
+
+}

--- a/src/main/java/org/ezcode/codetest/application/game/dto/request/RandomEncounterDeleteRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/game/dto/request/RandomEncounterDeleteRequest.java
@@ -1,0 +1,11 @@
+package org.ezcode.codetest.application.game.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RandomEncounterDeleteRequest(
+
+	@NotBlank(message = "삭제할 이름을 입력해주세요.")
+	String name
+
+	) {
+}

--- a/src/main/java/org/ezcode/codetest/application/game/dto/request/RandomEncounterSaveRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/game/dto/request/RandomEncounterSaveRequest.java
@@ -1,0 +1,39 @@
+package org.ezcode.codetest.application.game.dto.request;
+
+import org.ezcode.codetest.domain.game.model.entity.RandomEncounter;
+import org.ezcode.codetest.domain.game.model.enums.EncounterCategory;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record RandomEncounterSaveRequest(
+
+	@NotBlank(message = "인카운터 카테고리는 필수입니다.")
+	@Pattern(
+		regexp = "^(BATTLE|MERCHANT|EVENT|EXPLORATION)$",
+		message = "인카운터 카테고리는 BATTLE, MERCHANT, EVENT, EXPLORATION 중 하나여야 합니다."
+	)
+	String encounterCategory,
+
+	@NotBlank(message = "이름은 필수입니다.")
+	String name,
+
+	@NotBlank(message = "설명란은 필수입니다.")
+	String encounterText,
+
+	@NotNull(message = "가중치 입력은 필수입니다.")
+	Integer weight
+) {
+
+	public RandomEncounter toRandomEncounter() {
+
+		return RandomEncounter.builder()
+			.encounterCategory(EncounterCategory.valueOf(encounterCategory.trim().toUpperCase()))
+			.activated(true)
+			.name(name)
+			.weight(weight)
+			.encounterText(encounterText)
+			.build();
+	}
+}

--- a/src/main/java/org/ezcode/codetest/application/game/management/GameAdminUseCase.java
+++ b/src/main/java/org/ezcode/codetest/application/game/management/GameAdminUseCase.java
@@ -1,9 +1,14 @@
 package org.ezcode.codetest.application.game.management;
 
+import org.ezcode.codetest.application.game.dto.request.EncounterChoiceDeleteRequest;
+import org.ezcode.codetest.application.game.dto.request.EncounterChoiceSaveRequest;
 import org.ezcode.codetest.application.game.dto.request.ItemDeleteRequest;
 import org.ezcode.codetest.application.game.dto.request.ItemSaveRequest;
+import org.ezcode.codetest.application.game.dto.request.RandomEncounterDeleteRequest;
+import org.ezcode.codetest.application.game.dto.request.RandomEncounterSaveRequest;
 import org.ezcode.codetest.application.game.dto.request.SkillDeleteRequest;
 import org.ezcode.codetest.application.game.dto.request.SkillSaveRequest;
+import org.ezcode.codetest.domain.game.model.entity.RandomEncounter;
 import org.ezcode.codetest.domain.game.service.GameManagementDomainService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +31,32 @@ public class GameAdminUseCase {
 	public void deleteItem(ItemDeleteRequest request) {
 
 		managementService.deleteItem(request.name());
+	}
+
+	@Transactional
+	public void createRandomEncounter(RandomEncounterSaveRequest request) {
+
+		managementService.createRandomEncounter(request.toRandomEncounter());
+	}
+
+	@Transactional
+	public void deleteRandomEncounter(RandomEncounterDeleteRequest request) {
+
+		managementService.deleteRandomEncounter(request.name());
+	}
+
+	@Transactional
+	public void createEncounterChoice(EncounterChoiceSaveRequest request) {
+
+		RandomEncounter encounter = managementService.findRandomEncounter(request.encounterName());
+
+		managementService.createEncounterChoice(request.toEncounterChoice(encounter));
+	}
+
+	@Transactional
+	public void deleteEncounterChoice(EncounterChoiceDeleteRequest request) {
+
+		managementService.deleteRandomEncounter(request.name());
 	}
 
 	@Transactional

--- a/src/main/java/org/ezcode/codetest/common/base/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/ezcode/codetest/common/base/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package org.ezcode.codetest.common.base.exception;
 
 import org.ezcode.codetest.common.dto.CommonResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -8,7 +9,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -34,5 +37,15 @@ public class GlobalExceptionHandler {
 		return ResponseEntity
 			.status(e.getHttpStatus())
 			.body(CommonResponse.from(e.getResponseCode()));
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<CommonResponse<String>> handleAllException(Exception e
+	) {
+		log.error("Unhandled exception caught", e);
+
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(CommonResponse.of(false, e.getMessage(), 400, null));
 	}
 }

--- a/src/main/java/org/ezcode/codetest/common/security/config/SecurityConfig.java
+++ b/src/main/java/org/ezcode/codetest/common/security/config/SecurityConfig.java
@@ -19,6 +19,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import jakarta.servlet.DispatcherType;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -43,23 +44,25 @@ public class SecurityConfig {
 			.formLogin(AbstractHttpConfigurer::disable)
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.logout(AbstractHttpConfigurer::disable)
-			.oauth2Login((outh2)-> outh2
-				.userInfoEndpoint((userInfoEndpointConfig ->
-					userInfoEndpointConfig.userService(customOAuth2UserService)))
+			.oauth2Login(outh2 -> outh2
+				.userInfoEndpoint(userInfoEndpointConfig ->
+					userInfoEndpointConfig.userService(customOAuth2UserService))
 				.successHandler(customSuccessHandler)
-				.loginPage("/login"))
-			// JWT 사용을 위해 세션을 STATELESS로 설정 (세션 정보 저장 x)
+				.loginPage("/login")
+			)
+			// JWT 사용을 위해 세션을 STATELESS로 설정
 			.sessionManagement(session -> session
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			)
-			//에러 처리 체인 추가
+			// 에러 처리 체인 추가
 			.exceptionHandling(except -> except
 				.authenticationEntryPoint(customAuthenticationEntryPoint())
 				.accessDeniedHandler(customAccessDeniedHandler()))
-
-			//인증 URL 범위 설정
+			// 인증 URL 범위 설정
 			.authorizeHttpRequests(authorizeRequests ->
 				authorizeRequests
+					// cleanup(Async dispatch) 요청만 무조건 허용
+					.requestMatchers(request -> request.getDispatcherType() == DispatcherType.ASYNC).permitAll()
 					.requestMatchers(
 						"/api/auth/**",
 						"/login",
@@ -67,7 +70,7 @@ public class SecurityConfig {
 						"/login/**",
 						"/oauth2/**",
 						"/login/oauth",
-						"/login/oauth2/**", //OAuth로그인 접근
+						"/login/oauth2/**",
 						"/actuator/**",
 						"/chatting",
 						"/submit-test",
@@ -79,14 +82,14 @@ public class SecurityConfig {
 						"/v3/**",
 						"/webjars/**",
 						"/searching",
-						"/css/**", //html 화면 구성 접근
-						"/images/**").permitAll()
-					.requestMatchers("/admin/**").hasRole("ADMIN") //어드민 권한 필요 (문제 생성, 관리 등)
-					.anyRequest().authenticated() //나머지는 일반 인증
+						"/css/**",
+						"/images/**"
+					).permitAll()
+					.requestMatchers("/admin/**").hasRole("ADMIN")
+					.anyRequest().authenticated()
 			)
 			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
 			.addFilterBefore(exceptionFilter, JwtFilter.class)
-
 			.build();
 	}
 

--- a/src/main/java/org/ezcode/codetest/domain/game/exception/GameExceptionCode.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/exception/GameExceptionCode.java
@@ -21,7 +21,11 @@ public enum GameExceptionCode implements ResponseCode {
 	SKILL_ALREADY_EQUIPPED(false, HttpStatus.BAD_REQUEST, "해당 스킬을 이미 장착중입니다."),
 	SKILL_SLOT_FULL(false, HttpStatus.BAD_REQUEST, "스킬 슬롯이 꽉차있습니다."),
 	SKILL_ALREADY_EXISTS(false, HttpStatus.BAD_REQUEST, "이미 존재하는 스킬입니다."),
-	ITEM_ALREADY_EXISTS(false, HttpStatus.BAD_REQUEST, "이미 존재하는 아이템입니다.");
+	ITEM_ALREADY_EXISTS(false, HttpStatus.BAD_REQUEST, "이미 존재하는 아이템입니다."),
+	RANDOM_ENCOUNTER_ALREADY_EXISTS(false, HttpStatus.BAD_REQUEST, "이미 존재하는 랜덤 인카운터입니다."),
+	RANDOM_ENCOUNTER_NOT_EXISTS(false, HttpStatus.BAD_REQUEST, "해당 랜덤 인카운터가 존재하지 않습니다."),
+	ENCOUNTER_CHOICE_ALREADY_EXISTS(false, HttpStatus.BAD_REQUEST, "이미 존재하는 인카운터 선택지입니다."),
+	ENCOUNTER_CHOICE_NOT_EXISTS(false, HttpStatus.BAD_REQUEST, "해당 인카운터 선택지가 존재하지 않습니다.");
 
 	private final boolean success;
 	private final HttpStatus status;

--- a/src/main/java/org/ezcode/codetest/domain/game/model/entity/CharacterRealStat.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/model/entity/CharacterRealStat.java
@@ -3,7 +3,6 @@ package org.ezcode.codetest.domain.game.model.entity;
 import java.util.List;
 import java.util.Map;
 
-import org.ezcode.codetest.domain.game.model.enums.ItemCategory;
 import org.ezcode.codetest.domain.game.model.enums.Stat;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;

--- a/src/main/java/org/ezcode/codetest/domain/game/model/entity/EncounterChoice.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/model/entity/EncounterChoice.java
@@ -3,6 +3,7 @@ package org.ezcode.codetest.domain.game.model.entity;
 import org.ezcode.codetest.common.base.entity.BaseEntity;
 import org.ezcode.codetest.domain.game.model.enums.RandomEncounterEffect;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -30,6 +31,10 @@ public class EncounterChoice extends BaseEntity {
 	@JoinColumn(name = "random_encounter_id", nullable = false)
 	private RandomEncounter encounter;
 
+	@Column(nullable = false, unique = true)
+	private String name;
+
+	@Column(nullable = false)
 	private String resultText;
 
 	@Enumerated(EnumType.STRING)
@@ -38,10 +43,12 @@ public class EncounterChoice extends BaseEntity {
 	@Builder
 	public EncounterChoice(
 		RandomEncounter encounter,
+		String name,
 		String resultText,
 		RandomEncounterEffect encounterEffect
 	) {
 		this.encounter = encounter;
+		this.name = name;
 		this.resultText = resultText;
 		this.encounterEffect = encounterEffect;
 	}

--- a/src/main/java/org/ezcode/codetest/domain/game/model/entity/EncounterChoice.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/model/entity/EncounterChoice.java
@@ -1,6 +1,7 @@
 package org.ezcode.codetest.domain.game.model.entity;
 
-import org.ezcode.codetest.domain.game.model.enums.EncounterHandlerKey;
+import org.ezcode.codetest.common.base.entity.BaseEntity;
+import org.ezcode.codetest.domain.game.model.enums.RandomEncounterEffect;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class EncounterChoice {
+public class EncounterChoice extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,5 +32,5 @@ public class EncounterChoice {
 	private String resultText;
 
 	@Enumerated(EnumType.STRING)
-	private EncounterHandlerKey handlerKey;
+	private RandomEncounterEffect encounterEffect;
 }

--- a/src/main/java/org/ezcode/codetest/domain/game/model/entity/EncounterChoice.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/model/entity/EncounterChoice.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -33,4 +34,15 @@ public class EncounterChoice extends BaseEntity {
 
 	@Enumerated(EnumType.STRING)
 	private RandomEncounterEffect encounterEffect;
+
+	@Builder
+	public EncounterChoice(
+		RandomEncounter encounter,
+		String resultText,
+		RandomEncounterEffect encounterEffect
+	) {
+		this.encounter = encounter;
+		this.resultText = resultText;
+		this.encounterEffect = encounterEffect;
+	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/game/model/entity/RandomEncounter.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/model/entity/RandomEncounter.java
@@ -1,6 +1,12 @@
 package org.ezcode.codetest.domain.game.model.entity;
 
+import org.ezcode.codetest.common.base.entity.BaseEntity;
+import org.ezcode.codetest.domain.game.model.enums.EncounterCategory;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -8,11 +14,24 @@ import lombok.Getter;
 
 @Entity
 @Getter
-public class RandomEncounter {
+public class RandomEncounter extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Enumerated(EnumType.STRING)
+	private EncounterCategory encounterCategory;
+
+	@Column(nullable = false, unique = true)
+	private String name;
+
+	@Column(nullable = false)
 	private String encounterText;
+
+	@Column(nullable = false)
+	private Boolean isActivated;
+
+	@Column(nullable = false)
+	private Integer weight;
 }

--- a/src/main/java/org/ezcode/codetest/domain/game/model/entity/RandomEncounter.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/model/entity/RandomEncounter.java
@@ -10,10 +10,14 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RandomEncounter extends BaseEntity {
 
 	@Id
@@ -30,8 +34,23 @@ public class RandomEncounter extends BaseEntity {
 	private String encounterText;
 
 	@Column(nullable = false)
-	private Boolean isActivated;
+	private boolean isActivated;
 
 	@Column(nullable = false)
 	private Integer weight;
+
+	@Builder
+	public RandomEncounter(
+		EncounterCategory encounterCategory,
+		String name,
+		String encounterText,
+		boolean isActivated,
+		Integer weight
+	) {
+		this.encounterCategory = encounterCategory;
+		this.name = name;
+		this.encounterText = encounterText;
+		this.isActivated = isActivated;
+		this.weight = weight;
+	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/game/model/entity/RandomEncounter.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/model/entity/RandomEncounter.java
@@ -34,7 +34,7 @@ public class RandomEncounter extends BaseEntity {
 	private String encounterText;
 
 	@Column(nullable = false)
-	private boolean isActivated;
+	private boolean activated;
 
 	@Column(nullable = false)
 	private Integer weight;
@@ -44,13 +44,17 @@ public class RandomEncounter extends BaseEntity {
 		EncounterCategory encounterCategory,
 		String name,
 		String encounterText,
-		boolean isActivated,
+		boolean activated,
 		Integer weight
 	) {
 		this.encounterCategory = encounterCategory;
 		this.name = name;
 		this.encounterText = encounterText;
-		this.isActivated = isActivated;
+		this.activated = activated;
 		this.weight = weight;
+	}
+
+	public void softDelete() {
+		activated = false;
 	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/game/model/entity/Skill.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/model/entity/Skill.java
@@ -1,7 +1,6 @@
 package org.ezcode.codetest.domain.game.model.entity;
 
-import java.util.UUID;
-
+import org.ezcode.codetest.common.base.entity.BaseEntity;
 import org.ezcode.codetest.domain.game.model.enums.Grade;
 import org.ezcode.codetest.domain.game.model.enums.SkillEffect;
 
@@ -20,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Skill {
+public class Skill extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/ezcode/codetest/domain/game/model/enums/EncounterCategory.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/model/enums/EncounterCategory.java
@@ -1,0 +1,6 @@
+package org.ezcode.codetest.domain.game.model.enums;
+
+public enum EncounterCategory {
+
+	BATTLE, MERCHANT, EVENT, EXPLORATION
+}

--- a/src/main/java/org/ezcode/codetest/domain/game/model/enums/EncounterHandlerKey.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/model/enums/EncounterHandlerKey.java
@@ -1,8 +1,0 @@
-package org.ezcode.codetest.domain.game.model.enums;
-
-public enum EncounterHandlerKey {
-
-	BATTLE,
-	POSITIVE,
-	NEGATIVE
-}

--- a/src/main/java/org/ezcode/codetest/domain/game/model/enums/RandomEncounterEffect.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/model/enums/RandomEncounterEffect.java
@@ -1,0 +1,35 @@
+package org.ezcode.codetest.domain.game.model.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum RandomEncounterEffect {
+
+	RANDOM_BATTLE("무작위 전투 발생", null),
+
+	MERCHANT_GOOD_DEAL("상인과의 거래 성공", true),
+	MERCHANT_BAD_DEAL("상인과의 거래 실패", false),
+
+	STAT_INCREASE("스탯이 상승함", true),
+	STAT_DECREASE("스탯이 감소함", false),
+
+	AMBUSH_BANDITS_WIN("매복한 도적을 격퇴함", true),
+	AMBUSH_BANDITS_LOSE("매복한 도적에게 패배함", false),
+
+	WILD_BEASTS_ESCAPE("야생 동물에게서 도주 성공", true),
+	WILD_BEASTS_ATTACK("야생 동물에게 공격당함", false),
+
+	ANCIENT_RUINS_TREASURE("고대 유적에서 보물을 발견함", true),
+	ANCIENT_RUINS_TRAP("고대 유적의 함정에 걸림", false),
+
+	TREASURE_CACHE_FOUND("숨겨진 보물을 발견함", true),
+	TREASURE_CACHE_EMPTY("빈 상자를 발견함", false);
+
+	private final String description;
+	private final Boolean success;
+
+	RandomEncounterEffect(String description, Boolean success) {
+		this.description = description;
+		this.success = success;
+	}
+}

--- a/src/main/java/org/ezcode/codetest/domain/game/model/vo/BattleCtx.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/model/vo/BattleCtx.java
@@ -1,0 +1,9 @@
+package org.ezcode.codetest.domain.game.model.vo;
+
+public class BattleCtx {
+
+	private CharacterContext attacker;
+
+	private CharacterContext defender;
+
+}

--- a/src/main/java/org/ezcode/codetest/domain/game/model/vo/CharacterContext.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/model/vo/CharacterContext.java
@@ -1,0 +1,29 @@
+package org.ezcode.codetest.domain.game.model.vo;
+
+import java.util.List;
+
+import org.ezcode.codetest.domain.game.strategy.SkillStrategy;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CharacterContext {
+
+	private Double atk;
+	private Double def;
+	private Double speed;
+	private Double crit;
+	private Double stun;
+	private Double evasion;
+	private Double accuracy;
+	private Double hp;
+	private Integer ap;
+
+	private List<SkillStrategy> skillList;
+
+ }
+
+
+

--- a/src/main/java/org/ezcode/codetest/domain/game/repository/EncounterChoiceRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/repository/EncounterChoiceRepository.java
@@ -1,4 +1,23 @@
 package org.ezcode.codetest.domain.game.repository;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.ezcode.codetest.domain.game.model.entity.EncounterChoice;
+
 public interface EncounterChoiceRepository {
+
+	Optional<EncounterChoice> findById(Long id);
+
+	boolean existsByName(String name);
+
+	Optional<EncounterChoice> findByName(String name);
+
+	EncounterChoice save(EncounterChoice encounter);
+
+	void delete(EncounterChoice encounter);
+
+	void deleteByName(String name);
+
+	List<EncounterChoice> findAll();
 }

--- a/src/main/java/org/ezcode/codetest/domain/game/repository/EncounterChoiceRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/repository/EncounterChoiceRepository.java
@@ -1,4 +1,4 @@
 package org.ezcode.codetest.domain.game.repository;
 
-public interface EncounterRepository {
+public interface EncounterChoiceRepository {
 }

--- a/src/main/java/org/ezcode/codetest/domain/game/repository/EncounterRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/repository/EncounterRepository.java
@@ -1,0 +1,4 @@
+package org.ezcode.codetest.domain.game.repository;
+
+public interface EncounterRepository {
+}

--- a/src/main/java/org/ezcode/codetest/domain/game/repository/RandomEncounterRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/repository/RandomEncounterRepository.java
@@ -1,0 +1,4 @@
+package org.ezcode.codetest.domain.game.repository;
+
+public interface RandomEncounterRepository {
+}

--- a/src/main/java/org/ezcode/codetest/domain/game/repository/RandomEncounterRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/repository/RandomEncounterRepository.java
@@ -1,4 +1,24 @@
 package org.ezcode.codetest.domain.game.repository;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.ezcode.codetest.domain.game.model.entity.RandomEncounter;
+
 public interface RandomEncounterRepository {
+
+	Optional<RandomEncounter> findById(Long id);
+
+	boolean existsByName(String name);
+
+	Optional<RandomEncounter> findByName(String name);
+
+	RandomEncounter save(RandomEncounter encounter);
+
+	void delete(RandomEncounter encounter);
+
+	void deleteByName(String name);
+
+	List<RandomEncounter> findAll();
+
 }

--- a/src/main/java/org/ezcode/codetest/domain/game/service/GameManagementDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/service/GameManagementDomainService.java
@@ -4,9 +4,13 @@ import java.util.List;
 
 import org.ezcode.codetest.domain.game.exception.GameException;
 import org.ezcode.codetest.domain.game.exception.GameExceptionCode;
+import org.ezcode.codetest.domain.game.model.entity.EncounterChoice;
 import org.ezcode.codetest.domain.game.model.entity.Item;
+import org.ezcode.codetest.domain.game.model.entity.RandomEncounter;
 import org.ezcode.codetest.domain.game.model.entity.Skill;
+import org.ezcode.codetest.domain.game.repository.EncounterChoiceRepository;
 import org.ezcode.codetest.domain.game.repository.ItemRepository;
+import org.ezcode.codetest.domain.game.repository.RandomEncounterRepository;
 import org.ezcode.codetest.domain.game.repository.SkillRepository;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +22,8 @@ public class GameManagementDomainService {
 
 	private final ItemRepository itemRepository;
 	private final SkillRepository skillRepository;
+	private final RandomEncounterRepository encounterRepository;
+	private final EncounterChoiceRepository choiceRepository;
 
 	public Item createItem(Item item) {
 
@@ -58,6 +64,62 @@ public class GameManagementDomainService {
 		if(!exists) throw new GameException(GameExceptionCode.SKILL_NOT_EXISTS);
 
 		skillRepository.deleteByName(name);
+	}
+
+	public List<Skill> getAllSkillList() {
+
+		return skillRepository.findAll();
+	}
+
+	public RandomEncounter createRandomEncounter(RandomEncounter encounter) {
+
+		boolean exists = encounterRepository.existsByName(encounter.getName());
+
+		if(exists) throw new GameException(GameExceptionCode.RANDOM_ENCOUNTER_ALREADY_EXISTS);
+
+		return encounterRepository.save(encounter);
+	}
+
+	public RandomEncounter findRandomEncounter(String name) {
+
+		return encounterRepository.findByName(name)
+			.orElseThrow(() -> new GameException(GameExceptionCode.RANDOM_ENCOUNTER_NOT_EXISTS));
+	}
+
+	public void deleteRandomEncounter(String name) {
+
+		RandomEncounter encounter = encounterRepository.findByName(name)
+			.orElseThrow(() -> new GameException(GameExceptionCode.RANDOM_ENCOUNTER_NOT_EXISTS));
+
+		encounter.softDelete();
+	}
+
+	public List<RandomEncounter> getAllRandomEncounterList() {
+
+		return encounterRepository.findAll();
+	}
+
+	public EncounterChoice createEncounterChoice(EncounterChoice choice) {
+
+		boolean exists = choiceRepository.existsByName(choice.getName());
+
+		if(exists) throw new GameException(GameExceptionCode.ENCOUNTER_CHOICE_ALREADY_EXISTS);
+
+		return choiceRepository.save(choice);
+	}
+
+	public void deleteEncounterChoice(String name) {
+
+		boolean exists = choiceRepository.existsByName(name);
+
+		if(!exists) throw new GameException(GameExceptionCode.ENCOUNTER_CHOICE_NOT_EXISTS);
+
+		choiceRepository.deleteByName(name);
+	}
+
+	public List<EncounterChoice> getAllEncounterChoiceList() {
+
+		return choiceRepository.findAll();
 	}
 
 }

--- a/src/main/java/org/ezcode/codetest/domain/game/strategy/SkillStrategy.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/strategy/SkillStrategy.java
@@ -1,0 +1,11 @@
+package org.ezcode.codetest.domain.game.strategy;
+
+import org.ezcode.codetest.domain.game.model.enums.SkillEffect;
+import org.ezcode.codetest.domain.game.model.vo.CharacterContext;
+
+public interface SkillStrategy {
+
+	SkillEffect getType();
+
+	void useSkill(CharacterContext player, CharacterContext enemy);
+}

--- a/src/main/java/org/ezcode/codetest/domain/game/strategy/SkillStrategyFactory.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/strategy/SkillStrategyFactory.java
@@ -16,7 +16,7 @@ public class SkillStrategyFactory {
 	public SkillStrategyFactory(List<SkillStrategy> strategies) {
 
 		skillFactory = strategies.stream()
-			.collect(Collectors.toMap(SkillStrategy::getType, Function.identity()));
+			.collect(Collectors.toMap(SkillStrategy::getType, Function.identity(), (first, second) -> first));
 	}
 
 	public SkillStrategy getStrategy(SkillEffect effect) {

--- a/src/main/java/org/ezcode/codetest/domain/game/strategy/SkillStrategyFactory.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/strategy/SkillStrategyFactory.java
@@ -1,0 +1,26 @@
+package org.ezcode.codetest.domain.game.strategy;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.ezcode.codetest.domain.game.model.enums.SkillEffect;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SkillStrategyFactory {
+
+	private final Map<SkillEffect, SkillStrategy> skillFactory;
+
+	public SkillStrategyFactory(List<SkillStrategy> strategies) {
+
+		skillFactory = strategies.stream()
+			.collect(Collectors.toMap(SkillStrategy::getType, Function.identity()));
+	}
+
+	public SkillStrategy getStrategy(SkillEffect effect) {
+		return skillFactory.get(effect);
+	}
+
+}

--- a/src/main/java/org/ezcode/codetest/domain/game/util/StatUpdateUtil.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/util/StatUpdateUtil.java
@@ -1,4 +1,4 @@
-package org.ezcode.codetest.domain.game.Util;
+package org.ezcode.codetest.domain.game.util;
 
 import java.util.Collections;
 import java.util.EnumMap;

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/EncounterChoiceJpaRepository.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/EncounterChoiceJpaRepository.java
@@ -1,0 +1,7 @@
+package org.ezcode.codetest.infrastructure.persistence.repository.game;
+
+import org.ezcode.codetest.domain.game.model.entity.EncounterChoice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EncounterChoiceJpaRepository extends JpaRepository<EncounterChoice, Long> {
+}

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/EncounterChoiceJpaRepository.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/EncounterChoiceJpaRepository.java
@@ -1,7 +1,15 @@
 package org.ezcode.codetest.infrastructure.persistence.repository.game;
 
+import java.util.Optional;
+
 import org.ezcode.codetest.domain.game.model.entity.EncounterChoice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EncounterChoiceJpaRepository extends JpaRepository<EncounterChoice, Long> {
+
+	boolean existsByName(String name);
+
+	Optional<EncounterChoice> findByName(String name);
+
+	void deleteByName(String name);
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/EncounterChoiceRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/EncounterChoiceRepositoryImpl.java
@@ -1,13 +1,13 @@
 package org.ezcode.codetest.infrastructure.persistence.repository.game;
 
-import org.ezcode.codetest.domain.game.repository.EncounterRepository;
+import org.ezcode.codetest.domain.game.repository.EncounterChoiceRepository;
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
-public class EncounterChoiceRepositoryImpl implements EncounterRepository {
+public class EncounterChoiceRepositoryImpl implements EncounterChoiceRepository {
 
 	private final EncounterChoiceJpaRepository encounterRepository;
 

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/EncounterChoiceRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/EncounterChoiceRepositoryImpl.java
@@ -1,0 +1,14 @@
+package org.ezcode.codetest.infrastructure.persistence.repository.game;
+
+import org.ezcode.codetest.domain.game.repository.EncounterRepository;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class EncounterChoiceRepositoryImpl implements EncounterRepository {
+
+	private final EncounterChoiceJpaRepository encounterRepository;
+
+}

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/EncounterChoiceRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/EncounterChoiceRepositoryImpl.java
@@ -1,5 +1,10 @@
 package org.ezcode.codetest.infrastructure.persistence.repository.game;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.ezcode.codetest.domain.game.model.entity.EncounterChoice;
+import org.ezcode.codetest.domain.game.model.entity.RandomEncounter;
 import org.ezcode.codetest.domain.game.repository.EncounterChoiceRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,5 +15,47 @@ import lombok.RequiredArgsConstructor;
 public class EncounterChoiceRepositoryImpl implements EncounterChoiceRepository {
 
 	private final EncounterChoiceJpaRepository encounterRepository;
+
+	@Override
+	public Optional<EncounterChoice> findById(Long id) {
+
+		return encounterRepository.findById(id);
+	}
+
+	@Override
+	public boolean existsByName(String name) {
+
+		return encounterRepository.existsByName(name);
+	}
+
+	@Override
+	public Optional<EncounterChoice> findByName(String name) {
+
+		return encounterRepository.findByName(name);
+	}
+
+	@Override
+	public EncounterChoice save(EncounterChoice encounter) {
+
+		return encounterRepository.save(encounter);
+	}
+
+	@Override
+	public void delete(EncounterChoice encounter) {
+
+		encounterRepository.delete(encounter);
+	}
+
+	@Override
+	public void deleteByName(String name) {
+
+		encounterRepository.deleteByName(name);
+	}
+
+	@Override
+	public List<EncounterChoice> findAll() {
+
+		return encounterRepository.findAll();
+	}
 
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/RandomEncounterJpaRepository.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/RandomEncounterJpaRepository.java
@@ -1,0 +1,7 @@
+package org.ezcode.codetest.infrastructure.persistence.repository.game;
+
+import org.ezcode.codetest.domain.game.model.entity.RandomEncounter;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RandomEncounterJpaRepository extends JpaRepository<RandomEncounter, Long> {
+}

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/RandomEncounterJpaRepository.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/RandomEncounterJpaRepository.java
@@ -1,7 +1,15 @@
 package org.ezcode.codetest.infrastructure.persistence.repository.game;
 
+import java.util.Optional;
+
 import org.ezcode.codetest.domain.game.model.entity.RandomEncounter;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RandomEncounterJpaRepository extends JpaRepository<RandomEncounter, Long> {
+
+	boolean existsByNameAndActivated(String name, boolean isActivated);
+
+	Optional<RandomEncounter> findByNameAndActivated(String name, boolean isActivated);
+
+	void deleteByName(String name);
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/RandomEncounterRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/RandomEncounterRepositoryImpl.java
@@ -1,5 +1,9 @@
 package org.ezcode.codetest.infrastructure.persistence.repository.game;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.ezcode.codetest.domain.game.model.entity.RandomEncounter;
 import org.ezcode.codetest.domain.game.repository.RandomEncounterRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,6 +15,46 @@ public class RandomEncounterRepositoryImpl implements RandomEncounterRepository 
 
 	private final RandomEncounterJpaRepository randomEncounterRepository;
 
+	@Override
+	public Optional<RandomEncounter> findById(Long id) {
 
+		return randomEncounterRepository.findById(id);
+	}
+
+	@Override
+	public boolean existsByName(String name) {
+
+		return randomEncounterRepository.existsByNameAndActivated(name, true);
+	}
+
+	@Override
+	public Optional<RandomEncounter> findByName(String name) {
+
+		return randomEncounterRepository.findByNameAndActivated(name, true);
+	}
+
+	@Override
+	public RandomEncounter save(RandomEncounter encounter) {
+
+		return randomEncounterRepository.save(encounter);
+	}
+
+	@Override
+	public void delete(RandomEncounter encounter) {
+
+		randomEncounterRepository.delete(encounter);
+	}
+
+	@Override
+	public void deleteByName(String name) {
+
+		randomEncounterRepository.deleteByName(name);
+	}
+
+	@Override
+	public List<RandomEncounter> findAll() {
+
+		return randomEncounterRepository.findAll();
+	}
 
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/RandomEncounterRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/RandomEncounterRepositoryImpl.java
@@ -1,0 +1,16 @@
+package org.ezcode.codetest.infrastructure.persistence.repository.game;
+
+import org.ezcode.codetest.domain.game.repository.RandomEncounterRepository;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class RandomEncounterRepositoryImpl implements RandomEncounterRepository {
+
+	private final RandomEncounterJpaRepository randomEncounterRepository;
+
+
+
+}

--- a/src/main/java/org/ezcode/codetest/presentation/game/management/GameManagementController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/game/management/GameManagementController.java
@@ -1,7 +1,11 @@
 package org.ezcode.codetest.presentation.game.management;
 
+import org.ezcode.codetest.application.game.dto.request.EncounterChoiceDeleteRequest;
+import org.ezcode.codetest.application.game.dto.request.EncounterChoiceSaveRequest;
 import org.ezcode.codetest.application.game.dto.request.ItemDeleteRequest;
 import org.ezcode.codetest.application.game.dto.request.ItemSaveRequest;
+import org.ezcode.codetest.application.game.dto.request.RandomEncounterDeleteRequest;
+import org.ezcode.codetest.application.game.dto.request.RandomEncounterSaveRequest;
 import org.ezcode.codetest.application.game.dto.request.SkillDeleteRequest;
 import org.ezcode.codetest.application.game.dto.request.SkillSaveRequest;
 import org.ezcode.codetest.application.game.management.GameAdminUseCase;
@@ -18,7 +22,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/games")
-public class ItemManagementController {
+public class GameManagementController {
 
 	private final GameAdminUseCase gameAdminUseCase;
 
@@ -53,4 +57,39 @@ public class ItemManagementController {
 		gameAdminUseCase.deleteSkill(request);
 		return ResponseEntity.status(HttpStatus.OK).build();
 	}
+
+	@PostMapping("/encounters")
+	public ResponseEntity<Void> createRandomEncounter(
+		@RequestBody RandomEncounterSaveRequest request
+	) {
+		gameAdminUseCase.createRandomEncounter(request);
+		return ResponseEntity.status(HttpStatus.CREATED).build();
+	}
+
+	@DeleteMapping("/encounters")
+	public ResponseEntity<Void> deleteRandomEncounter(
+		@RequestBody RandomEncounterDeleteRequest request
+	) {
+		gameAdminUseCase.deleteRandomEncounter(request);
+		return ResponseEntity.status(HttpStatus.OK).build();
+	}
+
+	@PostMapping("/choices")
+	public ResponseEntity<Void> createEncounterChoice(
+		@RequestBody EncounterChoiceSaveRequest request
+	) {
+		gameAdminUseCase.createEncounterChoice(request);
+		return ResponseEntity.status(HttpStatus.CREATED).build();
+	}
+
+	@DeleteMapping("/choices")
+	public ResponseEntity<Void> deleteEncounterChoice(
+		@RequestBody EncounterChoiceDeleteRequest request
+	) {
+		gameAdminUseCase.deleteEncounterChoice(request);
+		return ResponseEntity.status(HttpStatus.OK).build();
+	}
+
 }
+
+


### PR DESCRIPTION

---

## 작업 내용

- 스킬 전략패턴이 추가되었습니다. 랜덤 인카운터 요소가 생성되었습니다.

---

## 변경 사항

- 추가적으로 글로벌 익셉션 핸들러에서 에러를 좀 보기 쉽게끔 Exception.class 타입으로 예외가 콘솔에 출력되도록 처리했습니다.

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 다양한 랜덤 인카운터 효과와 카테고리(enum) 도입 및 관련 엔티티 필드 확장
  - 전투 컨텍스트 및 캐릭터 속성 관리용 VO 클래스 추가
  - 스킬 전략 패턴 도입 및 전략 팩토리 클래스 추가
  - 인카운터 및 랜덤 인카운터 관련 리포지토리, JPA 인터페이스 및 도메인 서비스 메서드 추가
  - 랜덤 인카운터 및 인카운터 선택지 생성/삭제를 위한 API 및 관리용 UseCase 메서드 추가
  - 전역 예외 처리기에서 모든 예외에 대해 400 에러 및 상세 메시지 반환 기능 추가
  - 랜덤 인카운터 및 인카운터 선택지 관련 예외 코드 추가
  - 인카운터 선택지 및 랜덤 인카운터 저장/삭제 요청 DTO 추가

- **버그 수정**
  - 없음

- **리팩터링**
  - 일부 불필요한 import 제거 및 필드명/타입 정비
  - 엔티티의 상속 구조 개선
  - 패키지명 오탈자 수정

- **기타**
  - 보안 설정에 비동기 요청 허용 규칙 추가 및 OAuth2 로그인 설정 간소화
  - 관리 컨트롤러 명칭 변경 및 신규 엔드포인트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->