### PR TITLE
refactor : refresh토큰 Swagger 전달 이슈 해결

### DIFF
--- a/src/main/java/org/ezcode/codetest/infrastructure/swagger/config/SwaggerConfig.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/swagger/config/SwaggerConfig.java
@@ -3,6 +3,7 @@ package org.ezcode.codetest.infrastructure.swagger.config;
 import org.springframework.context.annotation.Configuration;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -16,6 +17,13 @@ import io.swagger.v3.oas.annotations.security.SecurityScheme;
 @SecurityScheme(
 	name = "JWT",
 	type = SecuritySchemeType.HTTP,
+	scheme = "bearer",
+	bearerFormat = "JWT"
+)
+@SecurityScheme(
+	name = "JWT_REFRESH", // refreshToken용
+	type = SecuritySchemeType.APIKEY,
+	in = SecuritySchemeIn.HEADER,
 	scheme = "bearer",
 	bearerFormat = "JWT"
 )

--- a/src/main/java/org/ezcode/codetest/infrastructure/swagger/config/SwaggerConfig.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/swagger/config/SwaggerConfig.java
@@ -23,9 +23,7 @@ import io.swagger.v3.oas.annotations.security.SecurityScheme;
 @SecurityScheme(
 	name = "JWT_REFRESH", // refreshToken용
 	type = SecuritySchemeType.APIKEY,
-	in = SecuritySchemeIn.HEADER,
-	scheme = "bearer",
-	bearerFormat = "JWT"
+	in = SecuritySchemeIn.HEADER
 )
 public class SwaggerConfig {
 }

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/AuthController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/AuthController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -62,13 +62,12 @@ public class AuthController {
 	}
 
 	@Operation(summary = "토큰 재발급", description = "리프레시 토큰을 이용하여 새로운 액세스 토큰을 발급합니다.",
-	parameters = {
-		@Parameter(name = "Authorization", description = "Bearer {refreshToken}", required = true)
-	})
+		security = @SecurityRequirement(name = "JWT_REFRESH")
+	)
 	@PostMapping("/auth/refresh")
 	public ResponseEntity<RefreshTokenResponse> refresh(HttpServletRequest request) {
 
-		String token = Optional.ofNullable(request.getHeader("Authorization"))
+		String token = Optional.ofNullable(request.getHeader("JWT_REFRESH"))
 			.map(h -> h.replace("Bearer ", ""))
 			.orElseThrow(()-> new AuthException(AuthExceptionCode.INVALID_AUTHORIZATION_HEADER));
 


### PR DESCRIPTION
## 작업 내용

- swaggerConfig에 JWT_REFRESH 추가
- refresh api수정


## 참고 사항

- swagger에 refreshToken 등록하여 사용하실 수 있습니다
---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - Swagger 문서에 리프레시 토큰을 위한 별도의 보안 스키마(JWT_REFRESH)가 추가되어, API 문서에서 리프레시 토큰 인증 방식을 명확하게 구분할 수 있습니다.

- **버그 수정**
  - 리프레시 토큰 요청 시 HTTP 헤더 키가 "Authorization"에서 "JWT_REFRESH"로 변경되어, 보다 명확한 토큰 구분이 가능합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->