### PR TITLE
feat : 방어 전투 로그 조회할 수 있는 기능 추가, 성능 개선

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/game/dto/response/encounter/DefenceBattleHistoryResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/game/dto/response/encounter/DefenceBattleHistoryResponse.java
@@ -1,0 +1,39 @@
+package org.ezcode.codetest.application.game.dto.response.encounter;
+
+import java.time.LocalDateTime;
+
+import org.ezcode.codetest.domain.game.model.encounter.BattleHistory;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "캐릭터 방어 전투 결과 응답")
+public record DefenceBattleHistoryResponse(
+
+	@Schema(description = "공격자 캐릭터 닉네임")
+	String attackerNickName,
+
+	@Schema(description = "플레이어 캐릭터 닉네임")
+	String PlayerNickName,
+
+	@Schema(description = "전투 로그")
+	String battleLog,
+
+	@Schema(description = "플레이어 승패 여부(이겼을시 true, 패배시 false)")
+	boolean isDefenderWin,
+
+	@Schema(description = "PVP 가 일어난 시점")
+	LocalDateTime battleCreatedAt
+
+) {
+	public static DefenceBattleHistoryResponse from(BattleHistory history) {
+		return DefenceBattleHistoryResponse.builder()
+			.attackerNickName(history.getAttacker().getName())
+			.PlayerNickName(history.getDefender().getName())
+			.battleLog(history.getBattleLog())
+			.isDefenderWin(!history.getIsAttackerWin())
+			.battleCreatedAt(history.getCreatedAt())
+			.build();
+	}
+}

--- a/src/main/java/org/ezcode/codetest/application/game/play/GamePlayUseCase.java
+++ b/src/main/java/org/ezcode/codetest/application/game/play/GamePlayUseCase.java
@@ -9,6 +9,7 @@ import org.ezcode.codetest.application.game.dto.request.skill.SkillEquipRequest;
 import org.ezcode.codetest.application.game.dto.request.skill.SkillUnEquipRequest;
 import org.ezcode.codetest.application.game.dto.response.character.CharacterStatusResponse;
 import org.ezcode.codetest.application.game.dto.response.encounter.BattleHistoryResponse;
+import org.ezcode.codetest.application.game.dto.response.encounter.DefenceBattleHistoryResponse;
 import org.ezcode.codetest.application.game.dto.response.encounter.EncounterResultResponse;
 import org.ezcode.codetest.application.game.dto.response.encounter.MatchingBattleResponse;
 import org.ezcode.codetest.application.game.dto.response.encounter.MatchingEncounterResponse;
@@ -18,6 +19,7 @@ import org.ezcode.codetest.application.game.dto.response.skill.SkillGamblingResp
 import org.ezcode.codetest.application.game.dto.response.skill.SkillResponse;
 import org.ezcode.codetest.common.security.util.JwtUtil;
 import org.ezcode.codetest.domain.game.model.character.GameCharacter;
+import org.ezcode.codetest.domain.game.model.encounter.BattleHistory;
 import org.ezcode.codetest.domain.game.model.encounter.EncounterHistory;
 import org.ezcode.codetest.domain.game.model.encounter.EncounterLog;
 import org.ezcode.codetest.domain.game.model.encounter.MatchMessageTemplate;
@@ -161,25 +163,6 @@ public class GamePlayUseCase {
 	}
 
 	@Transactional
-	public BattleHistoryResponse randomBattle(Long userId) {
-
-		GameCharacter player = characterService.getGameCharacter(userId);
-
-		GameCharacter enemy = encounterDomainService.getRandomEnemyCharacter(userId, player.getId());
-
-		BattleLog log = encounterDomainService.battle(player, enemy);
-
-		encounterDomainService.createBattleHistory(player, enemy, log);
-
-		return BattleHistoryResponse.of(
-			player.getName(),
-			enemy.getName(),
-			log.getMessages(),
-			log.getPlayerWin()
-		);
-	}
-
-	@Transactional
 	public MatchingBattleResponse randomBattleMatching(Long userId) {
 
 		GameCharacter player = characterService.getGameCharacter(userId);
@@ -220,6 +203,16 @@ public class GamePlayUseCase {
 		EncounterHistory history = encounterDomainService.createEncounterHistory(player, resultLog);
 
 		return EncounterResultResponse.from(history);
+	}
+
+	@Transactional
+	public List<DefenceBattleHistoryResponse> getPlayerDefenceHistory(Long userId) {
+
+		GameCharacter playerCharacter = characterService.getGameCharacter(userId);
+
+		List<BattleHistory> history = encounterDomainService.getCharacterBattleHistory(playerCharacter);
+
+		return history.stream().map(DefenceBattleHistoryResponse::from).toList();
 	}
 
 }

--- a/src/main/java/org/ezcode/codetest/domain/game/model/character/CharacterRealStat.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/model/character/CharacterRealStat.java
@@ -86,12 +86,12 @@ public class CharacterRealStat {
 			case DATA_STRUCTURE:
 				this.def += rate / 10;
 				this.atk += rate / 10;
-				this.accuracy += rate / 10;
+				this.accuracy += rate / 5;
 				break;
 			case SPEED:
-				this.speed += rate / 10;
+				this.speed += rate / 5;
 				this.atk += rate / 10;
-				this.accuracy += rate / 10;
+				this.accuracy += rate / 5;
 				break;
 			case DEBUGGING:
 				this.crit += rate / 5;
@@ -101,7 +101,7 @@ public class CharacterRealStat {
 			case OPTIMIZATION:
 				this.evasion += rate / 5;
 				this.def += rate / 10;
-				this.accuracy += rate / 10;
+				this.accuracy += rate / 5;
 				break;
 			default:
 				break;

--- a/src/main/java/org/ezcode/codetest/domain/game/repository/BattleHistoryRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/repository/BattleHistoryRepository.java
@@ -20,4 +20,6 @@ public interface BattleHistoryRepository {
 	void delete(BattleHistory battleHistory);
 
 	List<BattleHistory> findAll();
+
+	List<BattleHistory> findCreatedInLast24Hours(Long playerId);
 }

--- a/src/main/java/org/ezcode/codetest/domain/game/service/GameEncounterDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/service/GameEncounterDomainService.java
@@ -40,7 +40,7 @@ import lombok.RequiredArgsConstructor;
 public class GameEncounterDomainService {
 
 	private final CharacterEquipService characterEquipService;
-	private final SkillStrategyFactory  skillStrategyFactory;
+	private final SkillStrategyFactory skillStrategyFactory;
 	private final EncounterStrategyFactory encounterFactory;
 
 	private final BattleHistoryRepository battleHistoryRepository;
@@ -65,13 +65,13 @@ public class GameEncounterDomainService {
 
 		WeaponType playerWeaponType = playerItems.stream()
 			.filter(item -> item instanceof Weapon)
-			.map(item -> (WeaponType) item.getItemType())
+			.map(item -> (WeaponType)item.getItemType())
 			.findFirst()
 			.orElse(WeaponType.NOTHING);
 
- 		WeaponType opponentWeaponType = opponentItems.stream()
+		WeaponType opponentWeaponType = opponentItems.stream()
 			.filter(item -> item instanceof Weapon)
-			.map(item -> (WeaponType) item.getItemType())
+			.map(item -> (WeaponType)item.getItemType())
 			.findFirst()
 			.orElse(WeaponType.NOTHING);
 
@@ -106,10 +106,12 @@ public class GameEncounterDomainService {
 
 				if (attacker == playerContext) {
 					player.earnGold(100L);
-					battleLog.add("전투 승리보상으로 100 골드가 지급되었습니다.");
+					battleLog.add("%s(이)가 전투 승리보상으로 100 골드가 지급되었습니다.", playerContext.getName());
 				} else {
 					player.loseGold(25L);
-					battleLog.add("패배하여 25 골드를 갈취당했습니다.");
+					opponent.earnGold(25L);
+					battleLog.add("%s님이 %s님에게 패배하여 25 골드를 갈취당했습니다.", playerContext.getName(),
+						opponentContext.getName());
 				}
 
 				return battleLog;
@@ -128,10 +130,12 @@ public class GameEncounterDomainService {
 
 				if (defender == playerContext) {
 					player.earnGold(100L);
-					battleLog.add("전투 승리보상으로 100 골드가 지급되었습니다.");
+					battleLog.add("%s님에게 전투 승리보상으로 100 골드가 지급되었습니다.", playerContext.getName());
 				} else {
 					player.loseGold(25L);
-					battleLog.add("패배하여 25 골드를 갈취당했습니다.");
+					opponent.earnGold(25L);
+					battleLog.add("%s님이 %s님에게 패배하여 25 골드를 갈취당했습니다.", playerContext.getName(),
+						opponentContext.getName());
 				}
 
 				return battleLog;
@@ -140,7 +144,7 @@ public class GameEncounterDomainService {
 			currentSkillIndex = (currentSkillIndex + 1) % 3;
 		}
 
-		battleLog.add("전투가 종료되었습니다. 양쪽 모두 살아남았습니다. 무승부입니다!");
+		battleLog.add("전투가 종료되었습니다. 양쪽 모두 살아남았습니다. 무승부입니다.");
 		battleLog.setPlayerWin(false);
 		return battleLog;
 	}
@@ -175,7 +179,7 @@ public class GameEncounterDomainService {
 
 	public GameCharacter getRandomEnemyCharacter(Long userId, Long playerId) {
 
-		GameCharacterMatchTokenBucket playerTokenBucket =  matchTokenBucketRepository.findByCharacterId(playerId)
+		GameCharacterMatchTokenBucket playerTokenBucket = matchTokenBucketRepository.findByCharacterId(playerId)
 			.orElseThrow(() -> new GameException(GameExceptionCode.PLAYER_TOKEN_BUCKET_NOT_EXISTS));
 
 		playerTokenBucket.consumeBattleToken();
@@ -186,7 +190,7 @@ public class GameEncounterDomainService {
 
 	public RandomEncounter getRandomEncounter(Long playerId) {
 
-		GameCharacterMatchTokenBucket playerTokenBucket =  matchTokenBucketRepository.findByCharacterId(playerId)
+		GameCharacterMatchTokenBucket playerTokenBucket = matchTokenBucketRepository.findByCharacterId(playerId)
 			.orElseThrow(() -> new GameException(GameExceptionCode.PLAYER_TOKEN_BUCKET_NOT_EXISTS));
 
 		playerTokenBucket.consumeEncounterToken();
@@ -217,7 +221,7 @@ public class GameEncounterDomainService {
 		CharacterContext playerContext = CharacterContext.from(player.getName(), playerStats);
 
 		Inventory playerInventory = inventoryRepository.findByGameCharacterId(player.getId())
-				.orElseThrow(() -> new GameException(GameExceptionCode.INVENTORY_NOT_FOUND));
+			.orElseThrow(() -> new GameException(GameExceptionCode.INVENTORY_NOT_FOUND));
 
 		EncounterLog resultLog = new EncounterLog();
 
@@ -233,6 +237,11 @@ public class GameEncounterDomainService {
 			.resultLog(log.asText())
 			.isPositive(log.getIsPositive())
 			.build());
+	}
+
+	public List<BattleHistory> getCharacterBattleHistory(GameCharacter player) {
+
+		return battleHistoryRepository.findCreatedInLast24Hours(player.getId());
 	}
 
 }

--- a/src/main/java/org/ezcode/codetest/domain/game/strategy/skill/skillstrategyimpl/LifeStealSkill.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/strategy/skill/skillstrategyimpl/LifeStealSkill.java
@@ -39,7 +39,7 @@ public class LifeStealSkill extends AbstractSkill {
 
 		if (RNG.nextDouble() * 100 < attacker.getStun()) {
 			defender.consumeActionPoints();
-			log.add("스턴! %s가 잠시 머리를 잃었습니다 — 행동력 1 감소 → 남은 AP %d", defender.getName(), defender.getAp());
+			log.add("스턴! %s(이)가 잠시 정신을 잃었습니다 — 행동력 1 감소 → 남은 AP %d", defender.getName(), defender.getAp());
 		}
 
 		log.add("[%s] 남은 체력: %,.1f | [%s] 남은 체력: %,.1f", attacker.getName(), attacker.getHp(), defender.getName(), defender.getHp());

--- a/src/main/java/org/ezcode/codetest/domain/game/util/StatUpdateUtil.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/util/StatUpdateUtil.java
@@ -111,7 +111,6 @@ public class StatUpdateUtil {
 	}
 
 	public Map<Stat, Double> getStatIncreasePerProblem(String categoryDescription) {
-		//TODO : 나중에 NULL 처리하기
 		return increasedStatRate.get(categoryDescription).asImmutableMap();
 	}
 

--- a/src/main/java/org/ezcode/codetest/infrastructure/cache/config/CaffeineCacheConfig.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/cache/config/CaffeineCacheConfig.java
@@ -23,6 +23,11 @@ public class CaffeineCacheConfig {
 				.expireAfterWrite(Duration.ofMinutes(1))
 				.build());
 
+		CaffeineCache historyCache = new CaffeineCache("histories",
+			Caffeine.newBuilder()
+				.expireAfterWrite(Duration.ofMinutes(1))
+				.build());
+
 		CaffeineCache skillCache = new CaffeineCache("skill",
 			Caffeine.newBuilder()
 				.expireAfterWrite(Duration.ofMinutes(10))
@@ -38,8 +43,14 @@ public class CaffeineCacheConfig {
 				.expireAfterWrite(Duration.ofMinutes(10))
 				.build());
 
+		CaffeineCache choiceCache = new CaffeineCache("choices",
+			Caffeine.newBuilder()
+				.expireAfterWrite(Duration.ofMinutes(10))
+				.build());
+
 		SimpleCacheManager manager = new SimpleCacheManager();
-		manager.setCaches(List.of(skillCache, itemsByCategoryCache, encountersCache, countCache));
+		manager.setCaches(
+			List.of(skillCache, itemsByCategoryCache, encountersCache, countCache, historyCache, choiceCache));
 		return manager;
 	}
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/event/config/CustomHandShakeHandler.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/event/config/CustomHandShakeHandler.java
@@ -31,7 +31,6 @@ public class CustomHandShakeHandler extends DefaultHandshakeHandler {
 		if (query != null && query.startsWith("token=")) {
 			tokenParam = query.substring(6);
 		}
-		//TODO : 토큰의 대한 예외처리 아직 구현 x
 
 		Claims claims = jwtUtil.extractClaims(tokenParam);
 		String email = claims.get("email", String.class);

--- a/src/main/java/org/ezcode/codetest/infrastructure/event/listener/WebSocketEventListener.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/event/listener/WebSocketEventListener.java
@@ -16,7 +16,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class WebSocketEventListener implements ApplicationListener<SessionDisconnectEvent> {
@@ -29,23 +31,27 @@ public class WebSocketEventListener implements ApplicationListener<SessionDiscon
 	@Override
 	public void onApplicationEvent(SessionDisconnectEvent event) {
 
-		StompHeaderAccessor h = StompHeaderAccessor.wrap(event.getMessage());
-		String sessionId = h.getSessionId();
+		try {
+			StompHeaderAccessor h = StompHeaderAccessor.wrap(event.getMessage());
+			String sessionId = h.getSessionId();
 
-		String email = h.getUser().getName();
-		String nickName = userDomainService.getUser(email).getNickname();
+			String email = h.getUser().getName();
+			String nickName = userDomainService.getUser(email).getNickname();
 
-		RoomSessionInfo roomData = sessionService.removeSessionCount(sessionId);
-		ChatRoom chatRoom = chattingDomainService.getChatRoom(roomData.roomId());
+			RoomSessionInfo roomData = sessionService.removeSessionCount(sessionId);
+			ChatRoom chatRoom = chattingDomainService.getChatRoom(roomData.roomId());
 
-		Map<String, Object> payload = new HashMap<>();
-		payload.put("roomId", chatRoom.getId());
-		payload.put("title", chatRoom.getTitle());
-		payload.put("headCount", roomData.headCount());
-		payload.put("eventType", "UPDATE");
+			Map<String, Object> payload = new HashMap<>();
+			payload.put("roomId", chatRoom.getId());
+			payload.put("title", chatRoom.getTitle());
+			payload.put("headCount", roomData.headCount());
+			payload.put("eventType", "UPDATE");
 
-		messageService.handleChatRoomParticipantCountChange(payload);
-		messageService.handleChatRoomEntryExitMessage(ChatMessageTemplate.CHAT_ROOM_LEFT.format(nickName),
-			chatRoom.getId());
+			messageService.handleChatRoomParticipantCountChange(payload);
+			messageService.handleChatRoomEntryExitMessage(ChatMessageTemplate.CHAT_ROOM_LEFT.format(nickName),
+				chatRoom.getId());
+		} catch (Exception e) {
+			log.warn("SessionDisconnectEvent 처리 중 예외 발생, 채팅 관련 웹소켓 세션이 아닙니다.", e);
+		}
 	}
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/mysql/character/GameCharacterRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/mysql/character/GameCharacterRepositoryImpl.java
@@ -31,7 +31,7 @@ public class GameCharacterRepositoryImpl implements GameCharacterRepository {
 	public Optional<GameCharacter> findRandomCharacter(Long userId) {
 
 		long count = characterRepository.count();
-		if (count == 0) return Optional.empty();
+		if (count == 0 || count == 1) return Optional.empty();
 
 		for (int i = 0; i < 10; i++) {
 

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/mysql/encounter/BattleHistoryJpaRepository.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/mysql/encounter/BattleHistoryJpaRepository.java
@@ -1,8 +1,10 @@
 package org.ezcode.codetest.infrastructure.persistence.repository.game.mysql.encounter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.ezcode.codetest.domain.game.model.encounter.BattleHistory;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BattleHistoryJpaRepository extends JpaRepository<BattleHistory, Long> {
@@ -12,4 +14,8 @@ public interface BattleHistoryJpaRepository extends JpaRepository<BattleHistory,
 	List<BattleHistory> findByDefenderId(Long characterId);
 
 	List<BattleHistory> findByAttackerIdOrDefenderId(Long attackerId, Long defenderId);
+
+	@EntityGraph(attributePaths = {"attacker", "defender"})
+	List<BattleHistory> findByDefenderIdAndCreatedAtAfterOrderByCreatedAtDesc(Long defenderId,
+		LocalDateTime last24Hours);
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/mysql/encounter/BattleHistoryRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/mysql/encounter/BattleHistoryRepositoryImpl.java
@@ -1,10 +1,12 @@
 package org.ezcode.codetest.infrastructure.persistence.repository.game.mysql.encounter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import org.ezcode.codetest.domain.game.model.encounter.BattleHistory;
 import org.ezcode.codetest.domain.game.repository.BattleHistoryRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
@@ -55,5 +57,13 @@ public class BattleHistoryRepositoryImpl implements BattleHistoryRepository {
 	public List<BattleHistory> findAll() {
 
 		return battleHistoryRepository.findAll();
+	}
+
+	@Override
+	@Cacheable(value = "histories", key = "#playerId")
+	public List<BattleHistory> findCreatedInLast24Hours(Long playerId) {
+
+		return battleHistoryRepository.findByDefenderIdAndCreatedAtAfterOrderByCreatedAtDesc(playerId,
+			LocalDateTime.now().minusDays(1));
 	}
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/mysql/encounter/EncounterChoiceRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/game/mysql/encounter/EncounterChoiceRepositoryImpl.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.ezcode.codetest.domain.game.model.encounter.EncounterChoice;
 import org.ezcode.codetest.domain.game.repository.EncounterChoiceRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,7 @@ public class EncounterChoiceRepositoryImpl implements EncounterChoiceRepository 
 	}
 
 	@Override
+	@Cacheable(value = "choices", key = "#encounterId + '-' + #playerDecision")
 	public List<EncounterChoice> findChoiceByPlayerDecision(Long encounterId, boolean playerDecision) {
 
 		return encounterRepository.findByEncounterIdAndPlayerDecision(encounterId, playerDecision);

--- a/src/main/java/org/ezcode/codetest/presentation/game/play/GamePlayController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/game/play/GamePlayController.java
@@ -10,6 +10,7 @@ import org.ezcode.codetest.application.game.dto.request.skill.SkillEquipRequest;
 import org.ezcode.codetest.application.game.dto.request.skill.SkillUnEquipRequest;
 import org.ezcode.codetest.application.game.dto.response.character.CharacterStatusResponse;
 import org.ezcode.codetest.application.game.dto.response.encounter.BattleHistoryResponse;
+import org.ezcode.codetest.application.game.dto.response.encounter.DefenceBattleHistoryResponse;
 import org.ezcode.codetest.application.game.dto.response.encounter.EncounterResultResponse;
 import org.ezcode.codetest.application.game.dto.response.encounter.MatchingBattleResponse;
 import org.ezcode.codetest.application.game.dto.response.encounter.MatchingEncounterResponse;
@@ -207,6 +208,22 @@ public class GamePlayController {
 	) {
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(gamePlayUseCase.battle(authUser.getId(), request));
+	}
+
+	@Operation(
+		summary = "방어 PVP 기록 조회 API",
+		description = "상대방이 자신을 대상으로 한 PVP 기록을 조회합니다.(24시간전까지만)",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "PVP 결과 반환")
+		}
+	)
+	@ResponseMessage("정상적으로 PVP 기록 조회에 성공하였습니다.")
+	@GetMapping("/characters/battles")
+	public ResponseEntity<List<DefenceBattleHistoryResponse>> getDefenceBattleHistory(
+		@AuthenticationPrincipal AuthUser authUser
+	) {
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(gamePlayUseCase.getPlayerDefenceHistory(authUser.getId()));
 	}
 
 	@Operation(

--- a/src/main/resources/templates/game-page.html
+++ b/src/main/resources/templates/game-page.html
@@ -363,7 +363,7 @@
         panel.scrollTop = 0;
         panel.innerHTML = `<img src="/images/15328_green_noisy_nobg.gif" class="vaultboy-background" alt="Vault Boy HUD">`;
 
-        // 왼쪽 패널: BATTLE, GAMBLE, ADVENTURE
+        // ← LEFT panels: BATTLE, GAMBLE, ADVENTURE
         if (!isRight) {
             const titles = {
                 battle: '⚔️ BATTLE',
@@ -372,53 +372,119 @@
             };
             panel.innerHTML += `<h2>${titles[panelId]}</h2>`;
 
-            // BATTLE 분기
+            // BATTLE panel
             if (panelId === 'battle') {
                 panel.innerHTML += `
-        <p style="color:orange; line-height:1.4; margin:16px 0;">
-          전투 매칭 시스템이 활성화되었습니다. 시스템은 유저의 능력치를 기준으로 '적절히 불공정한' 상대를 찾아드립니다.
-        </p>
-      `;
-                panel.innerHTML += `<button class="match-button" id="battle-match-btn">BATTLE MATCHING</button>`;
+<p style="color:orange; line-height:1.4; margin-bottom:16px;">
+  전투 매칭 시스템이 활성화되었습니다. 시스템은 유저의 능력치를 기준으로 '적절히 불공정한' 상대를 찾아드립니다.
+</p>
+<div style="display:flex; gap:12px; margin-bottom:16px;">
+  <button class="match-button" id="battle-match-btn">BATTLE MATCHING</button>
+  <button class="menu-button" id="defence-log-btn">DEFENCE LOG</button>
+</div>
+`;
                 document.getElementById('battle-match-btn')
                     .addEventListener('click', matchingBattle);
+
+                document.getElementById('defence-log-btn')
+                    .addEventListener('click', async () => {
+                        // 1) fetch defence history
+                        const res = await fetch('/api/games/characters/battles', {
+                            headers: {'Authorization': 'Bearer ' + savedToken}
+                        });
+                        const data = await res.json();
+                        if (!data.success) {
+                            panel.innerHTML = `<p style="color:#f00;">Failed to load defence log.</p>`;
+                            return;
+                        }
+                        const list = data.result;
+
+                        // 2) back button & count
+                        const backHtml = `
+<button id="back-to-battle" class="menu-button" style="margin-bottom:12px;">
+  ← 뒤로 가기
+</button>`;
+                        const countHtml = `
+<p style="color:#0f0; margin-bottom:12px;">
+  총 ${list.length}건의 방어 로그가 조회되었습니다.
+</p>`;
+
+                        // 3) assemble history HTML
+                        let historyHtml = `
+<h2>🛡️ Defence Battle History</h2>
+<ul style="padding-left:20px;">`;
+                        list.forEach((item, idx) => {
+                            const color = item.isDefenderWin ? '#0f0' : '#f00';
+                            const when = new Date(item.battleCreatedAt).toLocaleString();
+                            const lines = item.battleLog.split('\n');
+                            historyHtml += `
+  <li style="margin-bottom:16px;">
+    <div class="defence-item-header" data-idx="${idx}"
+         style="cursor:pointer; color:${color}; font-weight:bold; user-select:none;">
+      • ${item.attackerNickName} vs ${item.PlayerNickName}
+    </div>
+    <div style="font-size:12px; color:#999; margin:4px 0;">
+      (${when})
+    </div>
+    <div id="dtl-${idx}" style="display:none; padding-left:16px; color:#fff; margin-top:4px;">
+      <ul style="margin:0; list-style:disc; margin-left:16px;">
+        ${lines.map(line => `<li>${line}</li>`).join('')}
+      </ul>
+      <p style="color:${color}; font-weight:bold; margin-top:8px;">
+        ${item.isDefenderWin ? '방어에 성공하였습니다!' : '방어에 실패했습니다!'}
+      </p>
+    </div>
+  </li>
+  <hr style="border-color:#0f0; opacity:0.2;">
+`;
+                        });
+                        historyHtml += `</ul>`;
+
+                        // 4) render all at once
+                        panel.innerHTML = backHtml + countHtml + historyHtml;
+
+                        // 5) bind back button
+                        document.getElementById('back-to-battle')
+                            .addEventListener('click', () => showPanel('battle'));
+
+                        // 6) bind toggles
+                        document.querySelectorAll('.defence-item-header').forEach(header => {
+                            header.addEventListener('click', () => {
+                                const idx = header.dataset.idx;
+                                const detail = document.getElementById(`dtl-${idx}`);
+                                detail.style.display = detail.style.display === 'none' ? 'block' : 'none';
+                            });
+                        });
+                    });
             }
 
-            // GAMBLE 분기
+            // GAMBLE panel (unchanged)
             if (panelId === 'gamble') {
                 panel.innerHTML += `
-    <p style="color:orange; line-height:1.4; margin:16px 0;">
-      여기는 등록된 합법 도박 상점입니다. 유저의 골드를 빠르게 소각하며, 낮은 확률로 장비 혹은 스킬을 지급합니다.
-      환불, 책임, 위로는 제공되지 않습니다. 뽑기 결과는 즉시 적용됩니다. 후회는 선택사항입니다.
-      시스템은 감정을 고려하지 않으며, 통계는 당신 편이 아닙니다. 그래도 시도하시겠습니까?
-    </p>
-  `;
-                // ITEM GAMBLE 버튼만 남깁니다.
-                panel.innerHTML += `
-    <button class="menu-button" id="item-gamble-btn">GAMBLE</button>
-  `;
+<p style="color:orange; line-height:1.4; margin:16px 0;">
+  여기는 등록된 합법 도박 상점입니다. 유저의 골드를 빠르게 소각하며, 낮은 확률로 장비 혹은 스킬을 지급합니다.
+  환불, 책임, 위로는 제공되지 않습니다. 뽑기 결과는 즉시 적용됩니다. 후회는 선택사항입니다.
+  시스템은 감정을 고려하지 않으며, 통계는 당신 편이 아닙니다. 그래도 시도하시겠습니까?
+</p>
+<button class="menu-button" id="item-gamble-btn">GAMBLE</button>
+`;
                 document.getElementById('item-gamble-btn')
                     .addEventListener('click', openItemGamblePopup);
-                // 더 이상 별도 SKILL GAMBLE 버튼은 없음.
             }
 
-            // ADVENTURE 분기
+            // ADVENTURE panel (unchanged)
             if (panelId === 'adventure') {
-                // 1) 경고 문구 추가 (흰색)
                 panel.innerHTML += `
-    <p style="color:orange; line-height:1.4; margin:16px 0;">
-      무작위 인카운터는 시스템에 의해 자동으로 배정됩니다.<br/>
-      실패 확률, 부상 가능성, 트라우마는 포함되지만 사전 고지는 생략됩니다.<br/>
-      그래도 버튼을 누른 건 당신입니다—책임은 시스템이 지지 않습니다.
-      (부정적 결과 발생 시 영구적인 능력치 하락 및 골드 분실이 일어날 수 있습니다)
-    </p>
-  `;
-                // 2) 매칭 버튼
-                panel.innerHTML += `
-    <button class="match-button" id="adventure-match-btn" style="background-color:#300; border:3px solid #f00; color:#f00;">
-      ADVENTURE MATCHING
-    </button>
-  `;
+<p style="color:orange; line-height:1.4; margin:16px 0;">
+  무작위 인카운터는 시스템에 의해 자동으로 배정됩니다.<br/>
+  실패 확률, 부상 가능성, 트라우마는 포함되지만 사전 고지는 생략됩니다.<br/>
+  그래도 버튼을 누른 건 당신입니다—책임은 시스템이 지지 않습니다.
+  (부정적 결과 발생 시 영구적인 능력치 하락 및 골드 분실이 일어날 수 있습니다)
+</p>
+<button class="match-button" id="adventure-match-btn" style="background-color:#300; border:3px solid #f00; color:#f00;">
+  ADVENTURE MATCHING
+</button>
+`;
                 document.getElementById('adventure-match-btn')
                     .addEventListener('click', matchingAdventure);
             }
@@ -426,70 +492,71 @@
             return;
         }
 
-        // 오른쪽 패널: STATUS, INVENTORY, SKILLS
+        // → RIGHT panels: STATUS, INVENTORY, SKILLS
         const urlMap = {
             status: '/api/games/characters',
             inventory: '/api/games/characters/inventories',
             skills: '/api/games/characters/skills/unequipped'
         };
-        const res = await fetch(urlMap[panelId], {headers: {'Authorization': 'Bearer ' + savedToken}});
+        const res = await fetch(urlMap[panelId], {
+            headers: {'Authorization': 'Bearer ' + savedToken}
+        });
         const json = await res.json();
 
         if (panelId === 'status') {
             const r = json.result;
             panel.innerHTML += `
-      <h2>👤 ${r.name}</h2><hr>
-      <h3>🧠 Stats</h3>
-      <ul>${Object.entries(r.stats).map(([k, v]) => `<li data-key="${k}">${formatNum1(v)}</li>`).join('')}</ul>
-      <h3>⚔️ Real Stats</h3>
-      <ul>${Object.entries(r.realStat).map(([k, v]) => `<li data-key="${k}">${formatNum1(v)}</li>`).join('')}</ul>
-      <h3>💰 Gold</h3><p>${formatNum1(r.gold)}</p>
-      <h3>🎒 Items</h3>
-      ${r.items.map(item => `
-        <div style="margin-bottom:32px;">
-          <strong class="status-item-name">${item.name}</strong> [${item.grade} ${item.itemCategory}-${item.itemType}]<br>
-          <em>${item.description}</em>
-          <ul>${Object.entries(item)
+<h2>👤 ${r.name}</h2><hr>
+<h3>🧠 Stats</h3>
+<ul>${Object.entries(r.stats).map(([k, v]) => `<li data-key="${k}">${formatNum1(v)}</li>`).join('')}</ul>
+<h3>⚔️ Real Stats</h3>
+<ul>${Object.entries(r.realStat).map(([k, v]) => `<li data-key="${k}">${formatNum1(v)}</li>`).join('')}</ul>
+<h3>💰 Gold</h3><p>${formatNum1(r.gold)}</p>
+<h3>🎒 Items</h3>
+${r.items.map(item => `
+  <div style="margin-bottom:32px;">
+    <strong class="status-item-name">${item.name}</strong> [${item.grade} ${item.itemCategory}-${item.itemType}]<br>
+    <em>${item.description}</em>
+    <ul>${Object.entries(item)
                 .filter(([k]) => !['name', 'description', 'itemCategory', 'itemType', 'grade'].includes(k))
                 .map(([k, v]) => `<li data-key="${k}">${formatNum1(v)}</li>`).join('')}
-          </ul>
-        </div>
-      `).join('')}
-      <h3>📚 Skills</h3>
-      ${r.skills.map(skill => `
-        <div style="margin-bottom:32px;" data-skill="${skill.name}">
-          <strong class="skill-name" onclick="unequipSkill('${skill.name}')">${skill.name}</strong>
-          [${skill.grade}-${skill.skillEffect}]
-          <span class="slot-type">${skill.slotType}</span><br>
-          <em>${skill.skillDetails}</em>
-        </div>
-      `).join('')}
-    `;
+    </ul>
+  </div>
+`).join('')}
+<h3>📚 Skills</h3>
+${r.skills.map(skill => `
+  <div style="margin-bottom:32px;" data-skill="${skill.name}">
+    <strong class="skill-name" onclick="unequipSkill('${skill.name}')">${skill.name}</strong>
+    [${skill.grade}-${skill.skillEffect}]<span class="slot-type">${skill.slotType}</span><br>
+    <em>${skill.skillDetails}</em>
+  </div>
+`).join('')}
+`;
         } else if (panelId === 'inventory') {
             panel.innerHTML += `<h2>📦 INVENTORY</h2>`;
             (json.result || []).forEach(item => {
                 panel.innerHTML += `
-        <div style="margin-bottom:32px;">
-          <strong class="item-name" onclick="equipItem('${item.name}')">${item.name}</strong>
-          [${item.grade} ${item.itemCategory}-${item.itemType}]<br>
-          <em>${item.description}</em>
-          <ul>${Object.entries(item)
+<div style="margin-bottom:32px;">
+  <strong class="item-name" onclick="equipItem('${item.name}')">${item.name}</strong>
+  [${item.grade} ${item.itemCategory}-${item.itemType}]<br>
+  <em>${item.description}</em>
+  <ul>${Object.entries(item)
                     .filter(([k]) => !['name', 'description', 'itemCategory', 'itemType', 'grade'].includes(k))
                     .map(([k, v]) => `<li data-key="${k}">${formatNum1(v)}</li>`).join('')}
-          </ul>
-        </div>
-      `;
+  </ul>
+</div>
+`;
             });
         } else { // skills
             panel.innerHTML += `<h2>🧠 SKILLS</h2>`;
             json.result.forEach(skill => {
                 panel.innerHTML += `
-        <div style="margin-bottom:32px;" data-skill="${skill.name}">
-          <strong class="skill-name" onclick="openEquipPopup(event,'${skill.name}')">${skill.name}</strong>
-          [${skill.grade}-${skill.skillEffect}]<br>
-          <em>${skill.skillDetails}</em>
-        </div>
-      `;
+<div style="margin-bottom:32px;" data-skill="${skill.name}">
+  <strong class="skill-name" onclick="openEquipPopup(event,'${skill.name}')">${skill.name}</strong>
+  [${skill.grade}-${skill.skillEffect}]<br>
+  <em>${skill.skillDetails}</em>
+</div>
+`;
             });
         }
     }


### PR DESCRIPTION
---

## 작업 내용

![Honeycam 2025-06-23 16-58-24](https://github.com/user-attachments/assets/d4d01634-c999-4e52-adc9-6190f14fd201)

- 사용자 입장에서 공격 로그는 볼수 있는데 방어 로그는 조회가 불가능해서 pvp 기능중 방어 로그 조회 기능을 추가하였습니다.
- 추가적으로 방어 성공시에는 이제 방어자는 25골드 금액을 보상받게끔 변경되었습니다.

---


### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 전투 패널에 "방어 로그" 버튼이 추가되어 최근 24시간 내 자신의 방어(PVP) 전투 기록을 확인할 수 있습니다.
    - 방어 로그는 공격자/방어자 이름, 결과, 상세 전투 로그, 전체 기록 수와 함께 표시되며, 실패 시 오류 메시지를 안내합니다.

- **버그 수정**
    - 랜덤 캐릭터 선택 시 캐릭터가 1명뿐인 경우 잘못된 동작을 방지하도록 개선되었습니다.

- **성능 개선**
    - 방어 로그 및 선택지 조회 시 캐시가 적용되어 조회 속도가 향상되었습니다.

- **UI/UX**
    - "전투", "모험", "도박" 패널 및 우측 패널의 일부 레이아웃과 표시가 개선되었습니다.

- **기타**
    - 일부 전투 로그 메시지 및 시스템 메시지의 표현이 더 자연스럽게 변경되었습니다.
    - 서버 이벤트 처리에서 예외 발생 시 로그로 남기도록 안정성이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->