### PR TITLE
feat : 내 랭킹 조회, 타겟 랭킹 조회 구현

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/ranking/dto/TargetRankingResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/ranking/dto/TargetRankingResponse.java
@@ -1,0 +1,9 @@
+package org.ezcode.codetest.application.ranking.dto;
+
+public record TargetRankingResponse(
+        Long userId,
+        String nickname,
+        int ranks,
+        int score,
+        boolean isMe // 프론트에서 이걸보고 누가 특정 사람인지 파악(ex, 색 더 진하게)
+) {}

--- a/src/main/java/org/ezcode/codetest/application/ranking/service/RankingFacadeService.java
+++ b/src/main/java/org/ezcode/codetest/application/ranking/service/RankingFacadeService.java
@@ -2,6 +2,7 @@ package org.ezcode.codetest.application.ranking.service;
 
 import lombok.RequiredArgsConstructor;
 import org.ezcode.codetest.application.ranking.dto.RankingResponse;
+import org.ezcode.codetest.application.ranking.dto.TargetRankingResponse;
 import org.ezcode.codetest.infrastructure.ranking.redis.RedisRankingService;
 import org.springframework.stereotype.Service;
 
@@ -28,4 +29,18 @@ public class RankingFacadeService {
     public List<RankingResponse> getAllTimeRanking() {
         return redisRankingService.getTopRankings("ranking:all", 10);
     }
+
+    //랭킹 조회
+    public List<TargetRankingResponse> getRanking(String period, Long userId) {
+        LocalDate baseMonday = LocalDate.now().with(DayOfWeek.MONDAY);
+        String key = switch (period) {
+            case "weekly" -> "ranking:weekly:" + baseMonday;
+            case "last-week" -> "ranking:weekly:" + baseMonday.minusWeeks(1);
+            case "all-time" -> "ranking:all";
+            default -> throw new IllegalArgumentException("기간은 weekly, last-week, all-time 만 가능합니다.");
+        };
+
+        return redisRankingService.getRanking(key, userId);
+    }
+
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/ranking/redis/RedisRankingService.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/ranking/redis/RedisRankingService.java
@@ -3,6 +3,7 @@ package org.ezcode.codetest.infrastructure.ranking.redis;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.ezcode.codetest.application.ranking.dto.RankingResponse;
+import org.ezcode.codetest.application.ranking.dto.TargetRankingResponse;
 import org.ezcode.codetest.infrastructure.persistence.repository.user.UserJpaRepository;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
@@ -63,6 +64,40 @@ public class RedisRankingService {
                     .score(tuple.getScore().intValue())
                     .build();
         }).collect(Collectors.toList());
+    }
+
+    public List<TargetRankingResponse> getRanking(String key, Long userId) {
+        Long myRank = redisTemplate.opsForZSet().reverseRank(key, userId.toString());
+        if (myRank == null) return List.of();
+
+        long start = Math.max(0, myRank - 1);
+        long end = myRank + 1;
+
+        Set<ZSetOperations.TypedTuple<String>> range = redisTemplate.opsForZSet()
+                .reverseRangeWithScores(key, start, end);
+
+        if (range == null || range.isEmpty()) return List.of();
+
+        List<String> ids = range.stream().map(ZSetOperations.TypedTuple::getValue).toList();
+        Map<Long, String> nicknameMap = userJpaRepository.findAllById(
+                ids.stream().map(Long::parseLong).toList()
+        ).stream().collect(Collectors.toMap(
+                u -> u.getId(),
+                u -> u.getNickname()
+        ));
+
+        return range.stream().map(tuple -> {
+            Long id = Long.parseLong(tuple.getValue());
+            Long rank = redisTemplate.opsForZSet().reverseRank(key, tuple.getValue());
+
+            return new TargetRankingResponse(
+                    id,
+                    nicknameMap.getOrDefault(id, "알 수 없음"),
+                    rank != null ? rank.intValue() + 1 : -1,
+                    tuple.getScore() != null ? tuple.getScore().intValue() : 0,
+                    id.equals(userId)
+            );
+        }).sorted(Comparator.comparingInt(TargetRankingResponse::ranks)).toList();
     }
 
 }

--- a/src/main/java/org/ezcode/codetest/presentation/ranking/RankingController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/ranking/RankingController.java
@@ -3,13 +3,13 @@ package org.ezcode.codetest.presentation.ranking;
 import lombok.RequiredArgsConstructor;
 import org.ezcode.codetest.application.ranking.dto.PointResponse;
 import org.ezcode.codetest.application.ranking.dto.RankingResponse;
+import org.ezcode.codetest.application.ranking.dto.TargetRankingResponse;
 import org.ezcode.codetest.application.ranking.service.RankingFacadeService;
+import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.ezcode.codetest.infrastructure.ranking.scheduler.RankingSyncScheduler;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -41,4 +41,24 @@ public class RankingController {
     public void forceRefreshRankings() {
         rankingSyncScheduler.syncRankingsToRedis();
     }
+
+    // 내 랭킹 조회
+    // weekly, last-week, all-time 3개 가능 뭘 표시할지 의논해서 쓰면 될듯
+    @GetMapping("/me/around")
+    public List<TargetRankingResponse> getMyRanking(
+            @RequestParam("period") String period,
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+        return rankingService.getRanking(period, authUser.getId());
+    }
+
+    @GetMapping("/{userId}/around")
+    public List<TargetRankingResponse> getTargetAroundRanking(
+            @RequestParam("period") String period,
+            @PathVariable Long userId
+    ) {
+        return rankingService.getRanking(period, userId);
+    }
+
+
 }


### PR DESCRIPTION

---

## 작업 내용

- 내 랭킹조회, 타겟 랭킹 조회 구현
---

## 변경 사항

- ranking쪽 controller, service에 메서드 추가
- TargetRankingResponse Dto 추가
---

## 트러블 슈팅

- 
---

## 해결해야 할 문제

- 
---

## 참고 사항

- 기간은 일단 requestParam으로 해서 weekly, last-week, all-time 조회 가능하게 만들어 두었습니다. 원하시는거 가져다가 쓰면 될거같아요.
- isMe도 True or False로 반환해 줘서 프론트가 볼때 누가 Main인지 알기 쉽게 해두었습니다.
- http://localhost:8080/api/rankings/me/around?period=all-time ( 내 랭킹 조회)
- http://localhost:8080/api/rankings/3/around?period=all-time (특정 랭킹 조회)
---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 사용자의 랭킹 주변 정보를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다. (본인 기준 및 특정 사용자 기준)
    - 랭킹 응답에 본인 여부를 구분할 수 있는 필드가 포함되어, 본인 랭킹을 시각적으로 구분할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->