### PR TITLE
Refactor : 이메일 인증 및 비밀번호 재설정 링크 구조 개선 및 redirectUrl 적용

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/usermanagement/auth/dto/request/ResetPasswordRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/auth/dto/request/ResetPasswordRequest.java
@@ -1,13 +1,12 @@
 package org.ezcode.codetest.application.usermanagement.auth.dto.request;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-@Schema(description = "비밀번호 찾기 요청")
-public class FindPasswordRequest {
+public class ResetPasswordRequest {
     private String email;
-    private String redirectUrl;
+    private String newPassword;
+    private String token;
 }

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/auth/dto/request/SendEmailRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/auth/dto/request/SendEmailRequest.java
@@ -1,10 +1,13 @@
 package org.ezcode.codetest.application.usermanagement.auth.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Schema(description = "이메일 전송 요청")
 public class SendEmailRequest {
+    @Schema(description = "인증 완료 후 리다이렉트할 URL")
     private String redirectUrl;
 }

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/auth/dto/request/SendEmailRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/auth/dto/request/SendEmailRequest.java
@@ -1,13 +1,10 @@
 package org.ezcode.codetest.application.usermanagement.auth.dto.request;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-@Schema(description = "비밀번호 찾기 요청")
-public class FindPasswordRequest {
-    private String email;
+public class SendEmailRequest {
     private String redirectUrl;
 }

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/auth/dto/response/SendEmailResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/auth/dto/response/SendEmailResponse.java
@@ -3,11 +3,11 @@ package org.ezcode.codetest.application.usermanagement.auth.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "인증코드 전송 성공")
-public record SendEmailCodeResponse(
+public record SendEmailResponse(
     @Schema(description = "인증코드 전송 성공 메세지")
     String message
 ) {
-    public static SendEmailCodeResponse from(String message) {
-        return new SendEmailCodeResponse(message);
+    public static SendEmailResponse from(String message) {
+        return new SendEmailResponse(message);
     }
 }

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/auth/service/AuthService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/auth/service/AuthService.java
@@ -4,11 +4,11 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.ezcode.codetest.application.usermanagement.auth.dto.request.FindPasswordRequest;
-import org.ezcode.codetest.application.usermanagement.auth.dto.request.VerifyEmailCodeRequest;
+import org.ezcode.codetest.application.usermanagement.auth.dto.request.ResetPasswordRequest;
 import org.ezcode.codetest.application.usermanagement.auth.dto.response.FindPasswordResponse;
 import org.ezcode.codetest.application.usermanagement.auth.dto.response.RefreshTokenResponse;
 import org.ezcode.codetest.application.usermanagement.auth.dto.request.SigninRequest;
-import org.ezcode.codetest.application.usermanagement.auth.dto.response.SendEmailCodeResponse;
+import org.ezcode.codetest.application.usermanagement.auth.dto.response.SendEmailResponse;
 import org.ezcode.codetest.application.usermanagement.auth.dto.response.SigninResponse;
 import org.ezcode.codetest.application.usermanagement.auth.dto.request.SignupRequest;
 import org.ezcode.codetest.application.usermanagement.auth.dto.response.SignupResponse;
@@ -100,9 +100,9 @@ public class AuthService {
 	}
 
 	@Transactional
-	public SendEmailCodeResponse sendEmailCode(Long userId, String email) {
-		mailService.sendButtonMail(userId, email);
-		return SendEmailCodeResponse.from("인증 코드를 전송했습니다.");
+	public SendEmailResponse sendEmailCode(Long userId, String email, String redirectUrl) {
+		mailService.sendButtonMail(userId, email, redirectUrl);
+		return SendEmailResponse.from("인증 코드를 전송했습니다.");
 	}
 
 	@Transactional
@@ -226,20 +226,22 @@ public class AuthService {
 			throw new AuthException(AuthExceptionCode.USER_NOT_FOUND);
 		}
 
-		mailService.sendPasswordMail(user.getId(), request.getEmail());
+		mailService.sendPasswordMail(user.getId(), request.getEmail(), request.getRedirectUrl());
 
 		return FindPasswordResponse.from("이메일로 전송되었습니다.");
 	}
 
 	//메일로 받은 링크를 통해 비번 변경
-	public FindPasswordResponse changePasswordByEmail(String email, String key) {
+	public FindPasswordResponse resetPassword(ResetPasswordRequest request) {
 
-		User user = userDomainService.getUserByEmail(email);
+		User user = userDomainService.getUserByEmail(request.getEmail());
 
-		boolean isMatch = mailService.verifyCode(user.getId(), key);
+		boolean isMatch = mailService.verifyPasswordCode(user.getId(), request.getToken());
 
 		if (isMatch){
-			return FindPasswordResponse.from("인증되었습니다");
+			String encodedPassword = userDomainService.encodePassword(request.getNewPassword());
+			user.modifyPassword(encodedPassword);
+			return FindPasswordResponse.from("비밀번호가 변경되었습니다.");
 		} else {
 			throw new UserException(UserExceptionCode.NOT_MATCH_CODE);
 		}

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
@@ -4,9 +4,6 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
-import org.ezcode.codetest.application.usermanagement.auth.dto.request.VerifyEmailCodeRequest;
-import org.ezcode.codetest.application.usermanagement.auth.dto.response.SendEmailCodeResponse;
-import org.ezcode.codetest.application.usermanagement.auth.dto.response.VerifyEmailCodeResponse;
 import org.ezcode.codetest.application.usermanagement.user.model.UsersByWeek;
 import org.ezcode.codetest.domain.submission.dto.WeeklySolveCount;
 import org.ezcode.codetest.application.usermanagement.user.dto.request.ChangeUserPasswordRequest;
@@ -16,9 +13,7 @@ import org.ezcode.codetest.application.usermanagement.user.dto.response.UserInfo
 import org.ezcode.codetest.application.usermanagement.user.dto.response.WithdrawUserResponse;
 import org.ezcode.codetest.domain.submission.service.SubmissionDomainService;
 import org.ezcode.codetest.domain.user.exception.AuthException;
-import org.ezcode.codetest.domain.user.exception.UserException;
 import org.ezcode.codetest.domain.user.exception.code.AuthExceptionCode;
-import org.ezcode.codetest.domain.user.exception.code.UserExceptionCode;
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.ezcode.codetest.domain.user.model.entity.User;
 import org.ezcode.codetest.domain.user.model.enums.AuthType;
@@ -29,7 +24,6 @@ import org.springframework.stereotype.Service;
 
 import org.springframework.transaction.annotation.Transactional;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/org/ezcode/codetest/common/security/config/SecurityConfig.java
+++ b/src/main/java/org/ezcode/codetest/common/security/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -71,6 +72,10 @@ public class SecurityConfig {
 					.requestMatchers(new DispatcherTypeRequestMatcher(DispatcherType.ASYNC)).permitAll()
 					.requestMatchers(
 						SecurityPath.PUBLIC_PATH).permitAll()
+					.requestMatchers(HttpMethod.GET,
+						"/api/problems/*/discussions",
+						"/api/problems/{problemId}/discussions/{discussionId}/replies",
+						"/api/problems/{problemId}/discussions/{discussionId}/replies/**").permitAll()
 					.requestMatchers("/admin/**").hasRole("ADMIN") //어드민 권한 필요 (문제 생성, 관리 등)
 					.anyRequest().authenticated() //나머지는 일반 인증
 			)

--- a/src/main/java/org/ezcode/codetest/domain/user/service/MailService.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/service/MailService.java
@@ -30,17 +30,17 @@ public class MailService {
 		javaMailSender.send(message);
 	}
 
-	public void sendButtonMail(Long userId, String email) {
-		MimeMessage message = CreateButtonMail(userId, email);
+	public void sendButtonMail(Long userId, String email, String redirectUrl) {
+		MimeMessage message = CreateButtonMail(userId, email, redirectUrl);
 		javaMailSender.send(message);
 	}
 
-	public void sendPasswordMail(Long userId, String email) {
-		MimeMessage message = CreatePasswordMail(userId, email);
+	public void sendPasswordMail(Long userId, String email, String redirectUrl) {
+		MimeMessage message = CreatePasswordMail(userId, email, redirectUrl);
 		javaMailSender.send(message);
 	}
 
-	public MimeMessage CreateButtonMail(Long userId, String email) {
+	public MimeMessage CreateButtonMail(Long userId, String email, String redirectUrl) {
 		MimeMessage message = javaMailSender.createMimeMessage();
 		String key = createNumber(userId); //radis에 유저id&코드로 저장 (10분)
 
@@ -51,7 +51,7 @@ public class MailService {
 			String body = "";
 			body += "<h3>" + "아래 버튼을 클릭하여 이메일 인증을 완료해 주세요" + "</h3>";
 			// 이메일 버튼
-			body += "<a href='http://localhost:8080/api/auth/verify?email="+ email + "&key=" + key + "' target='_blenk'>이메일 인증 확인</a>";
+			body += "<a href='" + redirectUrl + "/api/auth/verify?email="+ email + "&key=" + key + "' target='_blenk'>이메일 인증 확인</a>";
 			body += "<h3>" + "감사합니다." + "</h3>";
 			message.setText(body,"UTF-8", "html");
 		} catch (MessagingException e) {
@@ -61,7 +61,7 @@ public class MailService {
 		return message;
     }
 
-	public MimeMessage CreatePasswordMail(Long userId, String email){
+	public MimeMessage CreatePasswordMail(Long userId, String email, String redirectUrl){
 		MimeMessage message = javaMailSender.createMimeMessage();
 
 		String redisKey = "PASSWORD_KEY:" + userId;
@@ -81,7 +81,7 @@ public class MailService {
 			String body = "";
 			body += "<h3>" + "아래 버튼을 클릭하여 비밀번호 변경을 완료해 주세요" + "</h3>";
 			// 이메일 버튼
-			body += "<a href='http://localhost:8080/api/auth/password?email="+ email + "&key=" + verificationCode + "' target='_blenk'>비밀번호 변경하기</a>";
+			body += "<a href='"+redirectUrl+"/api/auth/reset-password?email="+ email + "&key=" + verificationCode + "' target='_blenk'>비밀번호 변경하기</a>";
 			body += "<h3>" + "감사합니다." + "</h3>";
 			message.setText(body,"UTF-8", "html");
 		} catch (MessagingException e) {
@@ -153,6 +153,24 @@ public class MailService {
 			redisTemplate.delete(key);
 		}
         return isMatch;
+	}
+
+	// 비밀번호 검증
+	public boolean verifyPasswordCode(Long userId, String inputCode) {
+		String key = "PASSWORD_KEY:" + userId;
+		String storedCode = redisTemplate.opsForValue().get(key);
+
+		if (storedCode == null) {
+			log.warn("비밀번호 재설정 코드가 없음 : {}", userId);
+			return false;
+		}
+
+		boolean isMatch = inputCode != null && inputCode.trim().equals(storedCode);
+
+		if (isMatch) {
+			redisTemplate.delete(key);
+		}
+		return isMatch;
 	}
 
 }

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/AuthController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/AuthController.java
@@ -102,7 +102,7 @@ public class AuthController {
 		return ResponseEntity.status(HttpStatus.OK).body(authService.verifyEmailCode(email, key));
 	}
 
-
+	//미완성 -> 메일 전송까지는 성공
 	@PostMapping("/auth/find-password")
 	public ResponseEntity<FindPasswordResponse> findPassword(
 		@RequestBody FindPasswordRequest request

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/AuthController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/AuthController.java
@@ -3,11 +3,12 @@ package org.ezcode.codetest.presentation.usermanagement;
 import java.util.Optional;
 
 import org.ezcode.codetest.application.usermanagement.auth.dto.request.FindPasswordRequest;
-import org.ezcode.codetest.application.usermanagement.auth.dto.request.VerifyEmailCodeRequest;
+import org.ezcode.codetest.application.usermanagement.auth.dto.request.ResetPasswordRequest;
+import org.ezcode.codetest.application.usermanagement.auth.dto.request.SendEmailRequest;
 import org.ezcode.codetest.application.usermanagement.auth.dto.response.FindPasswordResponse;
 import org.ezcode.codetest.application.usermanagement.auth.dto.response.RefreshTokenResponse;
 import org.ezcode.codetest.application.usermanagement.auth.dto.request.SigninRequest;
-import org.ezcode.codetest.application.usermanagement.auth.dto.response.SendEmailCodeResponse;
+import org.ezcode.codetest.application.usermanagement.auth.dto.response.SendEmailResponse;
 import org.ezcode.codetest.application.usermanagement.auth.dto.response.SigninResponse;
 import org.ezcode.codetest.application.usermanagement.auth.dto.request.SignupRequest;
 import org.ezcode.codetest.application.usermanagement.auth.dto.response.SignupResponse;
@@ -22,11 +23,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -86,10 +85,11 @@ public class AuthController {
 
 	@Operation(summary = "이메일 인증 코드 전송", description = "현재 로그인된 회원의 이메일로 인증 코드를 전송합니다.")
 	@PostMapping("/email/send")
-	public ResponseEntity<SendEmailCodeResponse> sendMailCode(
-		@AuthenticationPrincipal AuthUser authUser
+	public ResponseEntity<SendEmailResponse> sendMailCode(
+		@AuthenticationPrincipal AuthUser authUser,
+		@RequestBody SendEmailRequest request
 	){
-		return ResponseEntity.status(HttpStatus.CREATED).body(authService.sendEmailCode(authUser.getId(), authUser.getEmail()));
+		return ResponseEntity.status(HttpStatus.CREATED).body(authService.sendEmailCode(authUser.getId(), authUser.getEmail(), request.getRedirectUrl()));
 	}
 
 	//이메일에서 버튼 클릭하면 자동으로 연결
@@ -110,11 +110,10 @@ public class AuthController {
 		return ResponseEntity.status(HttpStatus.OK).body(authService.findPassword(request));
 	}
 
-	@GetMapping("/auth/verify-password-code")
-	public ResponseEntity<FindPasswordResponse> changePasswordByEmail(
-		@RequestParam String email,
-		@RequestParam String key
+	@PostMapping("/auth/reset-password")
+	public ResponseEntity<FindPasswordResponse> resetPassword(
+		@RequestBody ResetPasswordRequest request
 	){
-		return ResponseEntity.status(HttpStatus.OK).body(authService.changePasswordByEmail(email, key));
+		return ResponseEntity.status(HttpStatus.OK).body(authService.resetPassword(request));
 	}
 }

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
@@ -1,8 +1,5 @@
 package org.ezcode.codetest.presentation.usermanagement;
 
-import org.ezcode.codetest.application.usermanagement.auth.dto.request.VerifyEmailCodeRequest;
-import org.ezcode.codetest.application.usermanagement.auth.dto.response.SendEmailCodeResponse;
-import org.ezcode.codetest.application.usermanagement.auth.dto.response.VerifyEmailCodeResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.request.ModifyUserInfoRequest;
 import org.ezcode.codetest.application.usermanagement.user.dto.request.ChangeUserPasswordRequest;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.ChangeUserPasswordResponse;
@@ -15,7 +12,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;


### PR DESCRIPTION
## 작업 내용
- 이메일 인증 및 비밀번호 재설정 메일 전송 방식을 개선
- 프론트엔드에서 redirectUrl을 포함해 요청보내면, 백엔드에서 해당 URL에 토큰을 붙여 메일을 발송할 수 있도록 변경

---

## 변경 사항
- 기존 하드코딩된 인증 URL(localhost:8080) 제거 → 프론트에서 전달한 redirectUrl 사용

- 이메일 본문 링크 생성 방식 변경
`http://localhost:8080/api/auth/verify?email=...&key=...`
→ `redirectUrl + "?token=" + key`
    - 이메일 인증 요청 및 비밀번호 재설정 요청에 redirectUrl 필드 추가
    - FindPasswordRequest에 redirectUrl 필드 추가

- 인증 플로우 개선
    - 이메일 인증과 비밀번호 재설정 요청을 분리하여 설계
    - 토큰 검증 후 실제 작업(비밀번호 업데이트) 수행 방식으로 변경

- SecurityConfig에 인증 관련 GET 요청 허용 경로 추가

---

## 트러블 슈팅

- 비밀번호 재설정을 위한 인증 로직(토큰 검증 후 비밀번호 변경)은 아직 미완성 상태입니다.
    - `/auth/reset-password` ap 준비되어 있긴하지만 UI와 실제 연동은 미구현

---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 비밀번호 재설정 요청 및 처리 기능이 추가되었습니다.
  - 이메일 발송 시 리다이렉트 URL을 지정할 수 있게 되었습니다.
  - 비밀번호 재설정 토큰 검증 기능이 추가되었습니다.

- **기능 개선**
  - 이메일 인증 및 비밀번호 재설정 플로우가 쿼리 파라미터 기반 GET 요청에서 요청 본문 기반 POST 요청으로 변경되었습니다.
  - 이메일 및 비밀번호 재설정 관련 응답 구조가 개선되었습니다.
  - 이메일 본문 내 링크가 동적으로 리다이렉트 URL을 반영하도록 개선되었습니다.

- **버그 수정**
  - 불필요한 import 구문이 제거되어 코드가 정리되었습니다.

- **보안**
  - 특정 문제 토론 및 답글 조회 API에 대한 비인증 GET 요청이 허용되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->