### PR TITLE
feat : 유저 본인 신고 내역 조회, 운영자가 처리시 메세지 입력 가능

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/report/dto/ReportMyResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/report/dto/ReportMyResponse.java
@@ -1,0 +1,29 @@
+package org.ezcode.codetest.application.report.dto;
+
+import org.ezcode.codetest.domain.report.model.Report;
+
+public record ReportMyResponse(
+        Long id,
+        Long targetId,
+        String targetType,
+        String reportType,
+        String reportStatus,
+        String message,
+        String imageUrl,
+        String resultMessage,
+        String createdAt
+) {
+    public static ReportMyResponse from(Report r) {
+        return new ReportMyResponse(
+                r.getId(),
+                r.getTargetId(),
+                r.getTargetType().name(),
+                r.getReportType().name(),
+                r.getReportStatus().name(),
+                r.getMessage(),
+                r.getImageUrl(),
+                r.getResultMessage(),
+                r.getCreatedAt().toString()
+        );
+    }
+}

--- a/src/main/java/org/ezcode/codetest/application/report/dto/ReportStatusUpdateRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/report/dto/ReportStatusUpdateRequest.java
@@ -5,7 +5,8 @@ import org.ezcode.codetest.domain.report.model.ReportStatus;
 
 public record ReportStatusUpdateRequest(
         @NotBlank
-        String newStatus   // 예시 RESOLVED(해결됨), REJECTED(거절)
+        String newStatus,   // 예시 RESOLVED(해결됨), REJECTED(거절)
+        String resultMessage
 ) {
         public ReportStatus toEnum() {
                 return ReportStatus.from(newStatus);

--- a/src/main/java/org/ezcode/codetest/application/report/service/ReportService.java
+++ b/src/main/java/org/ezcode/codetest/application/report/service/ReportService.java
@@ -11,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class ReportService {
@@ -92,6 +94,14 @@ public class ReportService {
                 .orElseThrow(() -> new IllegalArgumentException("신고가 존재하지 않습니다."));
 
         ReportStatus newStatus = req.toEnum();
-        report.updateStatus(newStatus);
+        report.updateStatus(newStatus, req.resultMessage());
     }
+
+    @Transactional(readOnly = true)
+    public List<ReportMyResponse> getMyReports(Long userId) {
+        return reportRepository.findByReporterIdOrderByCreatedAtDesc(userId).stream()
+                .map(ReportMyResponse::from)
+                .toList();
+    }
+
 }

--- a/src/main/java/org/ezcode/codetest/domain/report/model/Report.java
+++ b/src/main/java/org/ezcode/codetest/domain/report/model/Report.java
@@ -36,6 +36,10 @@ public class Report extends BaseEntity {
 	@Column(nullable = false, length = 50)
 	private ReportType reportType;
 
+	@Column(length = 255)
+	private String resultMessage; // 운영자가 남긴 처리 메시지
+
+
 	@Column(nullable = false, length = 50)
 	@Enumerated(EnumType.STRING)
 	private ReportStatus reportStatus;
@@ -51,8 +55,9 @@ public class Report extends BaseEntity {
 		this.reportStatus = ReportStatus.PENDING;
 	}
 
-	public void updateStatus(ReportStatus newStatus) {
+	public void updateStatus(ReportStatus newStatus, String resultMessage) {
 		this.reportStatus = newStatus;
+		this.resultMessage = resultMessage;
 	}
 
 }

--- a/src/main/java/org/ezcode/codetest/domain/report/repository/ReportRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/report/repository/ReportRepository.java
@@ -3,5 +3,8 @@ package org.ezcode.codetest.domain.report.repository;
 import org.ezcode.codetest.domain.report.model.Report;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReportRepository extends JpaRepository<Report, Long> {
+    List<Report> findByReporterIdOrderByCreatedAtDesc(Long reporterId);
 }

--- a/src/main/java/org/ezcode/codetest/presentation/ranking/RankingController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/ranking/RankingController.java
@@ -1,7 +1,6 @@
 package org.ezcode.codetest.presentation.ranking;
 
 import lombok.RequiredArgsConstructor;
-import org.ezcode.codetest.application.ranking.dto.PointResponse;
 import org.ezcode.codetest.application.ranking.dto.RankingResponse;
 import org.ezcode.codetest.application.ranking.dto.TargetRankingResponse;
 import org.ezcode.codetest.application.ranking.service.RankingFacadeService;

--- a/src/main/java/org/ezcode/codetest/presentation/report/ReportController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/report/ReportController.java
@@ -3,6 +3,7 @@ package org.ezcode.codetest.presentation.report;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.ezcode.codetest.application.report.dto.ReportMyResponse;
 import org.ezcode.codetest.application.report.dto.ReportRequest;
 import org.ezcode.codetest.application.report.dto.ReportResponse;
 import org.ezcode.codetest.application.report.service.ReportService;
@@ -13,6 +14,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -29,5 +32,13 @@ public class ReportController {
     ) {
         return ResponseEntity.ok(reportService.submitReport(authUser.getId(), request));
     }
+
+    @GetMapping("/my")
+    public ResponseEntity<List<ReportMyResponse>> myReports(
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+        return ResponseEntity.ok(reportService.getMyReports(authUser.getId()));
+    }
+
 
 }


### PR DESCRIPTION
---

## 작업 내용

- 유저가 본인이 신고한 내역 조회 및 운영자가 처리시 남긴 메세지 확인 가능

---

## 변경 사항

- 
---

## 트러블 슈팅

- 
---

## 해결해야 할 문제

- 
---

## 참고 사항

- 
---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 인증된 사용자가 자신의 신고 내역을 조회할 수 있는 새로운 API 엔드포인트(`/api/reports/my`)가 추가되었습니다.

- **기능 개선**
    - 신고 상태 변경 시 처리 메시지(resultMessage)를 함께 입력 및 저장할 수 있습니다.
    - 사용자별 신고 내역을 최신순으로 조회할 수 있습니다.

- **버그 수정**
    - 불필요한 import가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->