### PR TITLE
refactor : 트랜잭션 범위 내 외부 서비스 호출 처리

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
@@ -12,6 +12,8 @@ import org.ezcode.codetest.domain.user.model.entity.User;
 import org.ezcode.codetest.domain.user.service.UserDomainService;
 import org.ezcode.codetest.infrastructure.s3.S3Directory;
 import org.ezcode.codetest.infrastructure.s3.S3Uploader;
+import org.ezcode.codetest.infrastructure.s3.exception.S3Exception;
+import org.ezcode.codetest.infrastructure.s3.exception.code.S3ExceptionCode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -19,9 +21,11 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ProblemService {
 
 	private final ProblemDomainService problemDomainService;
@@ -39,8 +43,8 @@ public class ProblemService {
 
 		// 문제 이미지 있다면?
 		if (image != null && !image.isEmpty()) {
-			String imageUrl = s3Uploader.upload(image, S3Directory.PROBLEM.getDir());
-			savedProblem.addImage(imageUrl);
+			String imageUrl = uploadImageAfterTransaction(image, savedProblem.getId());
+			updateProblemWithImage(savedProblem.getId(), imageUrl);
 		}
 
 		return ProblemDetailResponse.from(savedProblem);
@@ -90,6 +94,21 @@ public class ProblemService {
 		Problem findProblem = problemDomainService.getProblem(problemId);
 
 		problemDomainService.removeProblem(findProblem);
+	}
+
+	@Transactional
+	public void updateProblemWithImage(Long problemId, String imageUrl) {
+		Problem problem = problemDomainService.getProblem(problemId);
+		problem.addImage(imageUrl);
+	}
+
+	private String uploadImageAfterTransaction(MultipartFile image, Long problemId) {
+		try {
+			return s3Uploader.upload(image, S3Directory.PROBLEM.getDir());
+		} catch (Exception e) {
+			log.error("Problem {} 이미지 업로드 실패", problemId, e);
+			throw new S3Exception(S3ExceptionCode.S3_UPLOAD_FAILED);
+		}
 	}
 }
 


### PR DESCRIPTION
---

## 작업 내용

-  트랜잭션 범위 내 외부 서비스 호출 처리
하지 않으면, 문제점 3가지 발생
1. S3 업로드 실패 시 DB 트랜잭션도 롤백됨
2. S3 업로드 성공 후 DB 저장 실패 시 S3에 불필요한 파일 남음
3. 트랜잭션이 오래 지속됨

---

## 변경 사항

---

## 트러블 슈팅

---

## 해결해야 할 문제

- 수정과 삭제는 아직 되지 않음
- 이게 확실한 이미지 파일인지 검증할 로직 필요.

---

## 참고 사항

---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 문제 생성 시 이미지 업로드 실패에 대한 예외 처리 및 오류 로그가 추가되어 안정성이 향상되었습니다.

- **기타**
  - 문제 이미지 업로드 및 등록 과정이 분리되어 트랜잭션 관리가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->