### PR TITLE
Feature : user테이블에서 GitHub 정보 분리, reposiotory 정보 조회 및 저장

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/request/UserGithubRepoSelectRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/request/UserGithubRepoSelectRequest.java
@@ -1,0 +1,9 @@
+package org.ezcode.codetest.application.usermanagement.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "깃허브 repository 선택 요청")
+public record UserGithubRepoSelectRequest(
+    @Schema(description = "repository 이름", example = "Practice coding")
+    String repositoryName
+) {}

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/GithubOAuth2Response.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/GithubOAuth2Response.java
@@ -1,5 +1,6 @@
 package org.ezcode.codetest.application.usermanagement.user.dto.response;
 
+import java.util.List;
 import java.util.Map;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -41,19 +42,19 @@ public class GithubOAuth2Response implements OAuth2Response{
     }
 
     @Override
-    @Schema(description = "Github Id", example = "1345932")
+    @Schema(description = "깃허브 고유 Id", example = "1345932")
     public String getGithubId() {
         return attributes.get("id").toString();
     }
 
     @Override
-    @Schema(description = "Github URL", example = "https://github.com/id")
+    @Schema(description = "깃허브 홈 URL", example = "https://github.com/id")
     public String getGithubUrl(){
         return attributes.get("html_url").toString();
     }
 
     @Override
-    @Schema(description = "Github owner name", example = "ezcode")
+    @Schema(description = "깃허브 아이디(login name)", example = "ezcode")
     public String getOwner(){
         return attributes.get("login").toString();
     }

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/GithubOAuth2Response.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/GithubOAuth2Response.java
@@ -51,4 +51,10 @@ public class GithubOAuth2Response implements OAuth2Response{
     public String getGithubUrl(){
         return attributes.get("html_url").toString();
     }
+
+    @Override
+    @Schema(description = "Github owner name", example = "ezcode")
+    public String getOwner(){
+        return attributes.get("login").toString();
+    }
 }

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/GoogleOAuth2Response.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/GoogleOAuth2Response.java
@@ -48,5 +48,9 @@ public class GoogleOAuth2Response implements OAuth2Response {
 		return "";
 	}
 
+	@Override
+	public String getOwner() {
+		return "";
+	}
 
 }

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/OAuth2Response.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/OAuth2Response.java
@@ -18,4 +18,8 @@ public interface OAuth2Response {
 
 	//깃헙 링크
 	String getGithubUrl();
+
+
+	//깃헙 owner
+	String getOwner();
 }

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/UserGithubRepoResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/UserGithubRepoResponse.java
@@ -1,0 +1,17 @@
+package org.ezcode.codetest.application.usermanagement.user.dto.response;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "유저의 Public Repository 리스트를 보여줍니다")
+public class UserGithubRepoResponse {
+    private String repoName;
+    private String defaultBranch;
+
+    public UserGithubRepoResponse(String repoName, String defaultBranch) {
+        this.repoName = repoName;
+        this.defaultBranch = defaultBranch;
+    }
+}

--- a/src/main/java/org/ezcode/codetest/common/security/config/WebClientConfig.java
+++ b/src/main/java/org/ezcode/codetest/common/security/config/WebClientConfig.java
@@ -1,0 +1,17 @@
+package org.ezcode.codetest.common.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient githubWebClient() {
+        return WebClient.builder()
+            .baseUrl("https://api.github.com")
+            .defaultHeader(HttpHeaders.ACCEPT, "application/vnd.github+json")
+            .build();
+    }
+}

--- a/src/main/java/org/ezcode/codetest/common/security/config/WebClientConfig.java
+++ b/src/main/java/org/ezcode/codetest/common/security/config/WebClientConfig.java
@@ -12,6 +12,7 @@ public class WebClientConfig {
         return WebClient.builder()
             .baseUrl("https://api.github.com")
             .defaultHeader(HttpHeaders.ACCEPT, "application/vnd.github+json")
+            .defaultHeader(HttpHeaders.USER_AGENT, "ezcode-codetest-server")
             .build();
     }
 }

--- a/src/main/java/org/ezcode/codetest/common/security/hander/CustomSuccessHandler.java
+++ b/src/main/java/org/ezcode/codetest/common/security/hander/CustomSuccessHandler.java
@@ -9,6 +9,7 @@ import org.ezcode.codetest.domain.user.exception.AuthException;
 import org.ezcode.codetest.domain.user.exception.code.AuthExceptionCode;
 import org.ezcode.codetest.domain.user.model.entity.CustomOAuth2User;
 import org.ezcode.codetest.domain.user.model.entity.User;
+import org.ezcode.codetest.domain.user.model.entity.UserGithubInfo;
 import org.ezcode.codetest.domain.user.service.UserDomainService;
 import org.ezcode.codetest.common.security.util.JwtUtil;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -66,15 +67,18 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 				oauthToken.getName()
 			);
 
+			UserGithubInfo userGithubInfo = userDomainService.getUserGithubInfoById(loginUser.getId());
+
 			//AES 암호화
             try {
 				String encodedGithubToken = aesUtil.encrypt(client.getAccessToken().getTokenValue());
-				loginUser.setGithubAccessToken(encodedGithubToken);
+
+				userGithubInfo.setGithubAccessToken(encodedGithubToken);
             } catch (Exception e) {
 				log.error(e.getMessage());
                 throw new AuthException(AuthExceptionCode.TOKEN_ENCODE_FAIL);
             }
-			userDomainService.updateUserGithubAccessToken(loginUser);
+			userDomainService.updateUserGithubAccessToken(userGithubInfo);
 		}
 
 		String accessToken = jwtUtil.createAccessToken(

--- a/src/main/java/org/ezcode/codetest/common/security/hander/CustomSuccessHandler.java
+++ b/src/main/java/org/ezcode/codetest/common/security/hander/CustomSuccessHandler.java
@@ -12,6 +12,7 @@ import org.ezcode.codetest.domain.user.model.entity.User;
 import org.ezcode.codetest.domain.user.model.entity.UserGithubInfo;
 import org.ezcode.codetest.domain.user.service.UserDomainService;
 import org.ezcode.codetest.common.security.util.JwtUtil;
+import org.ezcode.codetest.domain.user.service.UserGithubService;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
@@ -33,17 +34,20 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
 	private final JwtUtil jwtUtil;
 	private final UserDomainService userDomainService;
+	private final UserGithubService userGithubService;
 	private final RedisTemplate<String, String> redisTemplate;
 	private final ObjectMapper objectMapper; //json직렬화
 	private final OAuth2AuthorizedClientService authorizedClientService;
 	private final AESUtil aesUtil;
 
 	public CustomSuccessHandler(JwtUtil jwtUtil, UserDomainService userDomainService,
+        UserGithubService userGithubService,
 		RedisTemplate<String, String> redisTemplate, ObjectMapper objectMapper,
         OAuth2AuthorizedClientService authorizedClientService, AESUtil aesUtil) {
 		this.jwtUtil = jwtUtil;
 		this.userDomainService = userDomainService;
-		this.redisTemplate = redisTemplate;
+        this.userGithubService = userGithubService;
+        this.redisTemplate = redisTemplate;
 		this.objectMapper = objectMapper;
         this.authorizedClientService = authorizedClientService;
         this.aesUtil = aesUtil;
@@ -67,7 +71,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 				oauthToken.getName()
 			);
 
-			UserGithubInfo userGithubInfo = userDomainService.getUserGithubInfoById(loginUser.getId());
+			UserGithubInfo userGithubInfo = userGithubService.getUserGithubInfoById(loginUser.getId());
 
 			//AES 암호화
             try {
@@ -78,7 +82,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 				log.error(e.getMessage());
                 throw new AuthException(AuthExceptionCode.TOKEN_ENCODE_FAIL);
             }
-			userDomainService.updateUserGithubAccessToken(userGithubInfo);
+			userGithubService.updateUserGithubAccessToken(userGithubInfo);
 		}
 
 		String accessToken = jwtUtil.createAccessToken(

--- a/src/main/java/org/ezcode/codetest/domain/user/exception/code/UserExceptionCode.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/exception/code/UserExceptionCode.java
@@ -11,7 +11,8 @@ import lombok.RequiredArgsConstructor;
 public enum UserExceptionCode implements ResponseCode {
 
 	NOT_ENOUGH_TOKEN(false, HttpStatus.BAD_REQUEST, "리뷰 토큰이 부족합니다."),
-    NOT_MATCH_CODE(false, HttpStatus.BAD_REQUEST, "이메일 인증 코드가 일치하지 않습니다.");
+    NOT_MATCH_CODE(false, HttpStatus.BAD_REQUEST, "이메일 인증 코드가 일치하지 않습니다."),
+	NO_GITHUB_INFO(false, HttpStatus.BAD_REQUEST, "깃허브 정보가 없습니다.");
 
 	private final boolean success;
 	private final HttpStatus status;

--- a/src/main/java/org/ezcode/codetest/domain/user/exception/code/UserExceptionCode.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/exception/code/UserExceptionCode.java
@@ -12,7 +12,8 @@ public enum UserExceptionCode implements ResponseCode {
 
 	NOT_ENOUGH_TOKEN(false, HttpStatus.BAD_REQUEST, "리뷰 토큰이 부족합니다."),
     NOT_MATCH_CODE(false, HttpStatus.BAD_REQUEST, "이메일 인증 코드가 일치하지 않습니다."),
-	NO_GITHUB_INFO(false, HttpStatus.BAD_REQUEST, "깃허브 정보가 없습니다.");
+	NO_GITHUB_INFO(false, HttpStatus.BAD_REQUEST, "깃허브 정보가 없습니다."),
+	NO_GITHUB_REPO(false, HttpStatus.BAD_REQUEST, "해당하는 Repository를 찾을 수 없습니다.");
 
 	private final boolean success;
 	private final HttpStatus status;

--- a/src/main/java/org/ezcode/codetest/domain/user/model/entity/User.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/model/entity/User.java
@@ -72,7 +72,7 @@ public class User extends BaseEntity {
 
 	private boolean verified; //이메일 인증 여부
 
-	private String githubAccessToken; //깃허브 access_token 값
+	private boolean gitPushStatus; //깃허브 자동 push 여부
 
 
 	/*
@@ -91,6 +91,7 @@ public class User extends BaseEntity {
 			.role(UserRole.ADMIN) // 테스트용
 			.isDeleted(false)
 			.verified(false)
+			.gitPushStatus(false)
 			.build();
 	}
 
@@ -108,6 +109,7 @@ public class User extends BaseEntity {
 			.password(password)
 			.isDeleted(false)
 			.verified(false)
+			.gitPushStatus(false)
 			.build();
 	}
 
@@ -123,13 +125,14 @@ public class User extends BaseEntity {
 			.isDeleted(false)
 			.verified(false)
 			.githubUrl(githubUrl)
+			.gitPushStatus(false)
 			.build();
 	}
 
 
 	@Builder
 	public User(String email, String password, String username, String nickname,
-		Integer age, Tier tier, UserRole role, boolean isDeleted, boolean verified, String githubUrl) {
+		Integer age, Tier tier, UserRole role, boolean isDeleted, boolean verified, String githubUrl, boolean gitPushStatus) {
 		this.email = email;
 		this.password = password;
 		this.username = username;
@@ -140,6 +143,7 @@ public class User extends BaseEntity {
 		this.isDeleted = isDeleted;
 		this.verified = verified;
 		this.githubUrl = githubUrl;
+		this.gitPushStatus = gitPushStatus;
 	}
 
 	/*
@@ -181,9 +185,6 @@ public class User extends BaseEntity {
 		this.githubUrl = githubUrl;
 	}
 
-	public void setGithubAccessToken(String githubAccessToken){
-		this.githubAccessToken = githubAccessToken;
-	}
 
 	public void decreaseReviewToken() {
 		this.reviewToken -= 1;

--- a/src/main/java/org/ezcode/codetest/domain/user/model/entity/UserFactory.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/model/entity/UserFactory.java
@@ -12,7 +12,8 @@ public class UserFactory {
     ) {
         //나중에 확장성 고려해서 switch문 사용
         return switch (provider.toLowerCase()) {
-            case "github" -> User.githubUser(
+            case "github" ->
+                User.githubUser(
                 response.getEmail(),
                 response.getName(),
                 nickname,

--- a/src/main/java/org/ezcode/codetest/domain/user/model/entity/UserGithubInfo.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/model/entity/UserGithubInfo.java
@@ -1,0 +1,49 @@
+package org.ezcode.codetest.domain.user.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "user_github")
+@NoArgsConstructor
+public class UserGithubInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", unique = true)
+    private User user;
+
+    @Column(nullable = false)
+    private String owner;
+
+    private String repo;
+
+    private String branch;
+
+    private String githubAccessToken;
+
+    @Builder
+    public UserGithubInfo(User user, String owner) {
+        this.user = user;
+        this.owner = owner;
+    }
+
+    public void setGithubAccessToken(String githubAccessToken){
+        this.githubAccessToken = githubAccessToken;
+    }
+
+}

--- a/src/main/java/org/ezcode/codetest/domain/user/model/entity/UserGithubInfo.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/model/entity/UserGithubInfo.java
@@ -46,4 +46,8 @@ public class UserGithubInfo {
         this.githubAccessToken = githubAccessToken;
     }
 
+    public void setGithubRepo(String githubRepoName, String defaultBranch) {
+        this.repo = githubRepoName;
+        this.branch = defaultBranch;
+    }
 }

--- a/src/main/java/org/ezcode/codetest/domain/user/repository/UserGithubInfoRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/repository/UserGithubInfoRepository.java
@@ -1,0 +1,11 @@
+package org.ezcode.codetest.domain.user.repository;
+
+import org.ezcode.codetest.domain.user.model.entity.UserGithubInfo;
+
+public interface UserGithubInfoRepository {
+    void createUserGithubInfo(UserGithubInfo userGithubInfo);
+
+    UserGithubInfo getUserGithubInfo(Long id);
+
+    void updateGithubAccessToken(UserGithubInfo userGithubInfo);
+}

--- a/src/main/java/org/ezcode/codetest/domain/user/repository/UserGithubInfoRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/repository/UserGithubInfoRepository.java
@@ -8,4 +8,6 @@ public interface UserGithubInfoRepository {
     UserGithubInfo getUserGithubInfo(Long id);
 
     void updateGithubAccessToken(UserGithubInfo userGithubInfo);
+
+    void updateGithubInfo(UserGithubInfo userGithub);
 }

--- a/src/main/java/org/ezcode/codetest/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/repository/UserRepository.java
@@ -21,4 +21,5 @@ public interface UserRepository {
 	void updateReviewTokens(List<Long> ids , int newToken);
 
 	void updateUserGithubAccessToken(User loginUser);
+
 }

--- a/src/main/java/org/ezcode/codetest/domain/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/service/CustomOAuth2UserService.java
@@ -31,6 +31,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 	private final UserRepository userRepository;
 	private final UserAuthTypeRepository userAuthTypeRepository;
 	private final UserDomainService userDomainService;
+	private final UserGithubService userGithubService;
 
 	@Override
 	@Transactional
@@ -107,7 +108,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 					.user(user)
 					.build();
 
-			userDomainService.createUserGithubInfo(userGithubInfo);
+			userGithubService.createUserGithubInfo(userGithubInfo);
 		}
 	}
 

--- a/src/main/java/org/ezcode/codetest/domain/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/service/CustomOAuth2UserService.java
@@ -9,6 +9,7 @@ import org.ezcode.codetest.domain.user.model.entity.CustomOAuth2User;
 import org.ezcode.codetest.domain.user.model.entity.User;
 import org.ezcode.codetest.domain.user.model.entity.UserAuthType;
 import org.ezcode.codetest.domain.user.model.entity.UserFactory;
+import org.ezcode.codetest.domain.user.model.entity.UserGithubInfo;
 import org.ezcode.codetest.domain.user.model.enums.AuthType;
 import org.ezcode.codetest.domain.user.repository.UserAuthTypeRepository;
 import org.ezcode.codetest.domain.user.repository.UserRepository;
@@ -75,6 +76,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 			updateExistingUser(user, response, authType, provider);
 		}
 	}
+
 	private void createNewUser(OAuth2Response response, AuthType authType, String provider) {
 		String nickname = userDomainService.generateUniqueNickname();
 		User newUser = UserFactory.createSocialUser(response, nickname, provider);
@@ -82,6 +84,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 		newUser.setReviewToken(20);
 		userRepository.createUser(newUser);
 		userAuthTypeRepository.createUserAuthType(new UserAuthType(newUser, authType));
+		updateGithubUrl(newUser, response, provider);
 	}
 
 	private void updateExistingUser(User user, OAuth2Response response, AuthType authType, String provider) {
@@ -95,8 +98,16 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 		}
 	}
 	private void updateGithubUrl(User user, OAuth2Response response, String provider) {
-		if ("github".equals(provider) && user.getGithubUrl()==null) {
+		if ("github".equals(provider)) {
 			user.setGithubUrl(response.getGithubUrl());
+
+			UserGithubInfo userGithubInfo =
+				UserGithubInfo.builder()
+					.owner(response.getOwner())
+					.user(user)
+					.build();
+
+			userDomainService.createUserGithubInfo(userGithubInfo);
 		}
 	}
 

--- a/src/main/java/org/ezcode/codetest/domain/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/service/CustomOAuth2UserService.java
@@ -5,6 +5,8 @@ import java.util.Map;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.GithubOAuth2Response;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.GoogleOAuth2Response;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.OAuth2Response;
+import org.ezcode.codetest.domain.user.exception.UserException;
+import org.ezcode.codetest.domain.user.exception.code.UserExceptionCode;
 import org.ezcode.codetest.domain.user.model.entity.CustomOAuth2User;
 import org.ezcode.codetest.domain.user.model.entity.User;
 import org.ezcode.codetest.domain.user.model.entity.UserAuthType;
@@ -108,7 +110,12 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 					.user(user)
 					.build();
 
-			userGithubService.createUserGithubInfo(userGithubInfo);
+			try {
+				userGithubService.createUserGithubInfo(userGithubInfo);
+			} catch (Exception e) {
+				throw new UserException(UserExceptionCode.NO_GITHUB_INFO);
+			}
+
 		}
 	}
 

--- a/src/main/java/org/ezcode/codetest/domain/user/service/UserDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/service/UserDomainService.java
@@ -131,15 +131,5 @@ public class UserDomainService {
 		return userRepository.getUserByEmail(email);
 	}
 
-	public void updateUserGithubAccessToken(UserGithubInfo userGithubInfo) {
-		userGithubInfoRepository.updateGithubAccessToken(userGithubInfo);
-	}
 
-	public void createUserGithubInfo(UserGithubInfo userGithubInfo) {
-		userGithubInfoRepository.createUserGithubInfo(userGithubInfo);
-	}
-
-	public UserGithubInfo getUserGithubInfoById(Long id) {
-		return userGithubInfoRepository.getUserGithubInfo(id);
-	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/user/service/UserDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/service/UserDomainService.java
@@ -7,6 +7,7 @@ import org.ezcode.codetest.application.usermanagement.user.model.UsersByWeek;
 import org.ezcode.codetest.domain.user.exception.UserException;
 import org.ezcode.codetest.domain.user.exception.code.UserExceptionCode;
 import org.ezcode.codetest.domain.user.model.entity.UserAuthType;
+import org.ezcode.codetest.domain.user.model.entity.UserGithubInfo;
 import org.ezcode.codetest.domain.user.model.enums.Adjective;
 import org.ezcode.codetest.domain.user.model.enums.AuthType;
 import org.ezcode.codetest.domain.user.model.enums.Noun;
@@ -14,6 +15,7 @@ import org.ezcode.codetest.domain.user.exception.AuthException;
 import org.ezcode.codetest.domain.user.exception.code.AuthExceptionCode;
 import org.ezcode.codetest.domain.user.model.entity.User;
 import org.ezcode.codetest.domain.user.repository.UserAuthTypeRepository;
+import org.ezcode.codetest.domain.user.repository.UserGithubInfoRepository;
 import org.ezcode.codetest.domain.user.repository.UserRepository;
 import org.ezcode.codetest.common.security.util.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -30,6 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 public class UserDomainService {
 	private final UserRepository userRepository;
 	private final UserAuthTypeRepository userAuthTypeRepository;
+	private final UserGithubInfoRepository userGithubInfoRepository;
 	private final PasswordEncoder passwordEncoder;
 	private static final java.util.Random RANDOM = new java.util.Random();
 
@@ -128,8 +131,15 @@ public class UserDomainService {
 		return userRepository.getUserByEmail(email);
 	}
 
-	public void updateUserGithubAccessToken(User loginUser) {
-		log.info("Updating github access token for user: {}", loginUser);
-		userRepository.updateUserGithubAccessToken(loginUser);
+	public void updateUserGithubAccessToken(UserGithubInfo userGithubInfo) {
+		userGithubInfoRepository.updateGithubAccessToken(userGithubInfo);
+	}
+
+	public void createUserGithubInfo(UserGithubInfo userGithubInfo) {
+		userGithubInfoRepository.createUserGithubInfo(userGithubInfo);
+	}
+
+	public UserGithubInfo getUserGithubInfoById(Long id) {
+		return userGithubInfoRepository.getUserGithubInfo(id);
 	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/user/service/UserGithubService.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/service/UserGithubService.java
@@ -69,7 +69,7 @@ public class UserGithubService {
             .onStatus(
                 status -> status.is4xxClientError() || status.is5xxServerError(),
                 response -> response.bodyToMono(String.class)
-                    .flatMap(errorBody -> Mono.error(new IllegalAccessException( //UserException 대신 github 문구 받아오게 수정
+                    .flatMap(errorBody -> Mono.error(new Exception( //UserException 대신 github 문구 받아오게 수정
                         "GitHub API 오류: " + response.statusCode() + " - " + errorBody
                     )))
             )

--- a/src/main/java/org/ezcode/codetest/domain/user/service/UserGithubService.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/service/UserGithubService.java
@@ -1,0 +1,94 @@
+package org.ezcode.codetest.domain.user.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.ezcode.codetest.application.usermanagement.user.dto.request.UserGithubRepoSelectRequest;
+import org.ezcode.codetest.application.usermanagement.user.dto.response.UserGithubRepoResponse;
+import org.ezcode.codetest.common.security.util.AESUtil;
+import org.ezcode.codetest.domain.user.exception.UserException;
+import org.ezcode.codetest.domain.user.exception.code.UserExceptionCode;
+import org.ezcode.codetest.domain.user.model.entity.AuthUser;
+import org.ezcode.codetest.domain.user.model.entity.UserGithubInfo;
+import org.ezcode.codetest.domain.user.repository.UserGithubInfoRepository;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserGithubService {
+    private final UserGithubInfoRepository userGithubInfoRepository;
+    private final WebClient githubWebClient;
+    private final AESUtil aesUtil;
+
+
+    public void updateUserGithubAccessToken(UserGithubInfo userGithubInfo) {
+        userGithubInfoRepository.updateGithubAccessToken(userGithubInfo);
+    }
+
+    public void createUserGithubInfo(UserGithubInfo userGithubInfo) {
+        userGithubInfoRepository.createUserGithubInfo(userGithubInfo);
+    }
+
+    public UserGithubInfo getUserGithubInfoById(Long id) {
+        return userGithubInfoRepository.getUserGithubInfo(id);
+    }
+
+
+    @Transactional
+    public List<UserGithubRepoResponse> getGithubRepos(AuthUser authUser) throws Exception {
+        // 1. 사용자 accessToken 가져오기
+        UserGithubInfo userGithub = userGithubInfoRepository.getUserGithubInfo(authUser.getId());
+
+        if (userGithub == null) {
+            throw new UserException(UserExceptionCode.NO_GITHUB_INFO);
+        }
+
+        String accessToken = aesUtil.decrypt(userGithub.getGithubAccessToken());
+
+        // 2. WebClient로 GitHub API 호출
+        return githubWebClient.get()
+            .uri("/user/repos")
+            .headers(headers -> {
+                headers.setBearerAuth(accessToken);
+                headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+            })
+            .retrieve()
+            .bodyToMono(new ParameterizedTypeReference<List<Map<String, Object>>>() {})
+            .block()
+            .stream()
+            .map(repo -> new UserGithubRepoResponse(
+                repo.get("name").toString(),
+                repo.get("default_branch").toString()
+            ))
+            .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public UserGithubRepoResponse selectGithubRepo(AuthUser authUser, UserGithubRepoSelectRequest reqeust) throws
+        Exception {
+        UserGithubInfo userGithub = userGithubInfoRepository.getUserGithubInfo(authUser.getId());
+
+        if (userGithub == null) {
+            throw new UserException(UserExceptionCode.NO_GITHUB_INFO);
+        }
+
+        List<UserGithubRepoResponse> repos = getGithubRepos(authUser);
+
+        UserGithubRepoResponse selectedRepo = repos.stream()
+            .filter(repo -> repo.getRepoName().equals(reqeust.repositoryName()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("해당 이름의 레포를 찾을 수 없습니다."));
+
+        userGithub.setGithubRepo(reqeust.repositoryName(), selectedRepo.getDefaultBranch());
+        userGithubInfoRepository.updateGithubInfo(userGithub);
+
+        return selectedRepo;
+    }
+}

--- a/src/main/java/org/ezcode/codetest/domain/user/service/UserGithubService.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/service/UserGithubService.java
@@ -13,12 +13,14 @@ import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.ezcode.codetest.domain.user.model.entity.UserGithubInfo;
 import org.ezcode.codetest.domain.user.repository.UserGithubInfoRepository;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
 
 @Service
 @RequiredArgsConstructor
@@ -60,6 +62,17 @@ public class UserGithubService {
                 headers.setAccept(List.of(MediaType.APPLICATION_JSON));
             })
             .retrieve()
+            // .onStatus(
+            //     status -> status == HttpStatus.BAD_REQUEST,  // 상태 코드 조건
+            //     response -> Mono.error(new UserException(UserExceptionCode.NO_GITHUB_INFO))
+            // )
+            .onStatus(
+                status -> status.is4xxClientError() || status.is5xxServerError(),
+                response -> response.bodyToMono(String.class)
+                    .flatMap(errorBody -> Mono.error(new IllegalAccessException( //UserException 대신 github 문구 받아오게 수정
+                        "GitHub API 오류: " + response.statusCode() + " - " + errorBody
+                    )))
+            )
             .bodyToMono(new ParameterizedTypeReference<List<Map<String, Object>>>() {})
             .block()
             .stream()
@@ -71,7 +84,7 @@ public class UserGithubService {
     }
 
     @Transactional
-    public UserGithubRepoResponse selectGithubRepo(AuthUser authUser, UserGithubRepoSelectRequest reqeust) throws
+    public UserGithubRepoResponse selectGithubRepo(AuthUser authUser, UserGithubRepoSelectRequest request) throws
         Exception {
         UserGithubInfo userGithub = userGithubInfoRepository.getUserGithubInfo(authUser.getId());
 
@@ -82,11 +95,11 @@ public class UserGithubService {
         List<UserGithubRepoResponse> repos = getGithubRepos(authUser);
 
         UserGithubRepoResponse selectedRepo = repos.stream()
-            .filter(repo -> repo.getRepoName().equals(reqeust.repositoryName()))
+            .filter(repo -> repo.getRepoName().equals(request.repositoryName()))
             .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("해당 이름의 레포를 찾을 수 없습니다."));
+            .orElseThrow(() -> new UserException(UserExceptionCode.NO_GITHUB_REPO));
 
-        userGithub.setGithubRepo(reqeust.repositoryName(), selectedRepo.getDefaultBranch());
+        userGithub.setGithubRepo(request.repositoryName(), selectedRepo.getDefaultBranch());
         userGithubInfoRepository.updateGithubInfo(userGithub);
 
         return selectedRepo;

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/user/UserGithubInfoJpaRepository.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/user/UserGithubInfoJpaRepository.java
@@ -1,0 +1,13 @@
+package org.ezcode.codetest.infrastructure.persistence.repository.user;
+
+import org.ezcode.codetest.domain.user.model.entity.User;
+import org.ezcode.codetest.domain.user.model.entity.UserGithubInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserGithubInfoJpaRepository extends JpaRepository<UserGithubInfo, Long> {
+    UserGithubInfo findUserGithubInfoByUser(User user);
+
+    UserGithubInfo findUserGithubInfoByUser_Id(Long userId);
+}

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/user/UserGithubInfoRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/user/UserGithubInfoRepositoryImpl.java
@@ -1,0 +1,28 @@
+package org.ezcode.codetest.infrastructure.persistence.repository.user;
+
+import org.ezcode.codetest.domain.user.model.entity.UserGithubInfo;
+import org.ezcode.codetest.domain.user.repository.UserGithubInfoRepository;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserGithubInfoRepositoryImpl implements UserGithubInfoRepository {
+    private final UserGithubInfoJpaRepository userGithubInfoJpaRepository;
+
+    @Override
+    public void createUserGithubInfo(UserGithubInfo userGithubInfo) {
+        userGithubInfoJpaRepository.save(userGithubInfo);
+    }
+
+    @Override
+    public UserGithubInfo getUserGithubInfo(Long userId) {
+        return userGithubInfoJpaRepository.findUserGithubInfoByUser_Id(userId);
+    }
+
+    @Override
+    public void updateGithubAccessToken(UserGithubInfo userGithubInfo) {
+        userGithubInfoJpaRepository.save(userGithubInfo);
+    }
+}

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/user/UserGithubInfoRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/user/UserGithubInfoRepositoryImpl.java
@@ -25,4 +25,9 @@ public class UserGithubInfoRepositoryImpl implements UserGithubInfoRepository {
     public void updateGithubAccessToken(UserGithubInfo userGithubInfo) {
         userGithubInfoJpaRepository.save(userGithubInfo);
     }
+
+    @Override
+    public void updateGithubInfo(UserGithubInfo userGithub) {
+        userGithubInfoJpaRepository.save(userGithub);
+    }
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/user/UserRepositoryImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.ezcode.codetest.domain.user.model.entity.User;
+import org.ezcode.codetest.domain.user.model.entity.UserGithubInfo;
 import org.ezcode.codetest.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Repository;
 
@@ -51,5 +52,7 @@ public class UserRepositoryImpl implements UserRepository {
 	public void updateUserGithubAccessToken(User loginUser) {
 		userJpaRepository.save(loginUser);
 	}
+
+
 
 }

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserGithubController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserGithubController.java
@@ -1,0 +1,45 @@
+package org.ezcode.codetest.presentation.usermanagement;
+
+import java.util.List;
+
+import org.ezcode.codetest.application.usermanagement.user.dto.request.UserGithubRepoSelectRequest;
+import org.ezcode.codetest.application.usermanagement.user.dto.response.UserGithubRepoResponse;
+import org.ezcode.codetest.domain.user.model.entity.AuthUser;
+import org.ezcode.codetest.domain.user.service.UserGithubService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Tag(name = "깃허브 자동 push 관련 api", description = "자동 Push할 Repository 선택, 자동 Push 여부 선택")
+public class UserGithubController {
+
+    private final UserGithubService userGithubService;
+
+    @GetMapping("/users/github")
+    public ResponseEntity<List<UserGithubRepoResponse>> getGithubRepos(
+        @AuthenticationPrincipal AuthUser authUser
+    ) throws Exception {
+        return ResponseEntity.status(HttpStatus.OK).body(userGithubService.getGithubRepos(authUser));
+    }
+
+    @Operation(summary = "Repository 선택", description = "사용자의 Repository 중, 자동 push를 원하는 repo를 선택합니다")
+    @PostMapping("/users/github")
+    public ResponseEntity<UserGithubRepoResponse> selectGithubRepo(
+        @AuthenticationPrincipal AuthUser authUser,
+        @RequestBody UserGithubRepoSelectRequest reqeust
+    ) throws Exception {
+        return ResponseEntity.status(HttpStatus.OK).body(userGithubService.selectGithubRepo(authUser, reqeust));
+    }
+}

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserGithubController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserGithubController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -27,6 +28,7 @@ public class UserGithubController {
 
     private final UserGithubService userGithubService;
 
+    @Operation(summary = "GitHub 레포지토리 목록 조회", description = "사용자의 GitHub 레포지토리 목록을 조회합니다")
     @GetMapping("/users/github")
     public ResponseEntity<List<UserGithubRepoResponse>> getGithubRepos(
         @AuthenticationPrincipal AuthUser authUser
@@ -38,7 +40,7 @@ public class UserGithubController {
     @PostMapping("/users/github")
     public ResponseEntity<UserGithubRepoResponse> selectGithubRepo(
         @AuthenticationPrincipal AuthUser authUser,
-        @RequestBody UserGithubRepoSelectRequest reqeust
+        @Valid @RequestBody UserGithubRepoSelectRequest reqeust
     ) throws Exception {
         return ResponseEntity.status(HttpStatus.OK).body(userGithubService.selectGithubRepo(authUser, reqeust));
     }


### PR DESCRIPTION


## 작업 내용
- User 테이블 정규화 -> user, user_github_
- GitHub 자동 Push를 위한 사용자별 Repository 선택 및 관련 정보 관리 기능 구현
- 사용자의 GitHub 저장소(Repository) 목록 조회 및 저장소 선택 API 추가
---

## 변경 사항

- UserGithubInfo 엔티티
    - 사용자별 GitHub 정보(owner, repo, branch, accessToken 등) 저장
    - setGithubAccessToken(), setGithubRepo() 메서드 추가

- UserGithubInfoRepository / UserGithubInfoJpaRepository
    - 사용자별 GitHub 정보 CRUD 및 조회 인터페이스/구현체

- UserGithubRepoResponse DTO
    - GitHub 저장소 이름 및 기본 브랜치 정보 응답용

- UserGithubRepoSelectRequest DTO
    - GitHub 저장소 선택 요청용

- WebClientConfig
    - GitHub API 호출용 WebClient 빈 등록

- UserGithubService
    - getGithubRepos(): 사용자의 GitHub 저장소 목록 조회 및 변환
    - selectGithubRepo(): 사용자가 선택한 저장소 정보 저장

- UserGithubController
    - 레포지토리 조회 및 선택 api 추가
    - GET: GitHub 저장소 목록 조회
    - POST: 저장소 선택 및 정보 저장


---

## 참고 사항

- user 테이블 변경되었습니다. drop 후 생성해주세요

---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 자신의 깃허브 저장소 목록을 조회하고, 자동 푸시용 저장소를 선택할 수 있는 API가 추가되었습니다.
  * 깃허브 관련 사용자 정보 관리 기능이 추가되어, 저장소 선택 및 토큰 관리가 분리되었습니다.
  * 깃허브 API 호출을 위한 WebClient가 설정되어 원활한 통신이 가능해졌습니다.
  * 깃허브 자동 푸시 활성화 상태를 나타내는 필드가 사용자 정보에 도입되었습니다.
  * 깃허브 소유자 정보 제공 기능이 OAuth2 응답에 추가되었습니다.

* **버그 수정**
  * 없음

* **문서화**
  * API 문서에 깃허브 저장소 선택 및 조회 관련 설명과 예시가 추가되었습니다.

* **기타**
  * 깃허브 정보가 없는 경우 및 저장소 미존재 시의 예외 코드가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->