### PR TITLE
feature : GitHub commit & push 기능 구현

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/submission/dto/request/github/GitHubPushRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/dto/request/github/GitHubPushRequest.java
@@ -1,0 +1,49 @@
+package org.ezcode.codetest.application.submission.dto.request.github;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.ezcode.codetest.application.submission.model.SubmissionContext;
+import org.ezcode.codetest.domain.user.model.entity.UserGithubInfo;
+
+public record GitHubPushRequest(
+
+    String owner,
+
+    String repo,
+
+    String branch,
+
+    String accessToken,
+
+    Long problemId,
+
+    String problemTitle,
+
+    String problemDescription,
+
+    Long averageMemoryUsage,
+
+    Long averageExecutionTime,
+
+    String sourceCode,
+
+    String submittedAt
+
+) {
+    public static GitHubPushRequest of(SubmissionContext ctx, UserGithubInfo info) {
+        return new GitHubPushRequest(
+            info.getOwner(),
+            info.getRepo(),
+            info.getBranch(),
+            info.getGithubAccessToken(),
+            ctx.getProblem().getId(),
+            ctx.getProblem().getTitle(),
+            ctx.getProblem().getDescription(),
+            ctx.aggregator().averageMemoryUsage(),
+            ctx.aggregator().averageExecutionTime(),
+            ctx.getSourceCode(),
+            LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))
+        );
+    }
+}

--- a/src/main/java/org/ezcode/codetest/application/submission/model/SubmissionContext.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/model/SubmissionContext.java
@@ -3,8 +3,8 @@ package org.ezcode.codetest.application.submission.model;
 import org.ezcode.codetest.application.submission.dto.event.payload.SubmissionFinalResultPayload;
 import org.ezcode.codetest.domain.language.model.entity.Language;
 import org.ezcode.codetest.domain.problem.model.ProblemInfo;
-import org.ezcode.codetest.domain.problem.model.entity.Category;
 import org.ezcode.codetest.domain.problem.model.entity.Problem;
+import org.ezcode.codetest.domain.problem.model.entity.ProblemCategory;
 import org.ezcode.codetest.domain.problem.model.entity.Testcase;
 import org.ezcode.codetest.domain.submission.model.SubmissionAggregator;
 import org.ezcode.codetest.domain.user.model.entity.User;
@@ -18,116 +18,136 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public record SubmissionContext(
 
-	SubmissionAggregator aggregator,
+    SubmissionAggregator aggregator,
 
-	AtomicInteger passedCount,
+    AtomicInteger passedCount,
 
-	AtomicInteger processedCount,
+    AtomicInteger processedCount,
 
-	AtomicReference<String> message,
+    AtomicReference<String> message,
 
-	CountDownLatch latch,
+    CountDownLatch latch,
 
-	AtomicBoolean notified,
+    AtomicBoolean notified,
 
-	User user,
+    User user,
 
-	Language language,
+    Language language,
 
-	ProblemInfo problemInfo,
+    ProblemInfo problemInfo,
 
-	SubmissionMessage msg
+    SubmissionMessage msg
 ) {
-	public static SubmissionContext initialize(
-		User user, Language language, ProblemInfo problemInfo, SubmissionMessage msg
-	) {
-		return new SubmissionContext(
-			new SubmissionAggregator(),
-			new AtomicInteger(0),
-			new AtomicInteger(0),
-			new AtomicReference<>("Accepted"),
-			new CountDownLatch(problemInfo.getTestcaseCount()),
-			new AtomicBoolean(false),
-			user,
-			language,
-			problemInfo,
-			msg
-		);
-	}
+    public static SubmissionContext initialize(
+        User user, Language language, ProblemInfo problemInfo, SubmissionMessage msg
+    ) {
+        return new SubmissionContext(
+            new SubmissionAggregator(),
+            new AtomicInteger(0),
+            new AtomicInteger(0),
+            new AtomicReference<>("Accepted"),
+            new CountDownLatch(problemInfo.getTestcaseCount()),
+            new AtomicBoolean(false),
+            user,
+            language,
+            problemInfo,
+            msg
+        );
+    }
 
-	public SubmissionFinalResultPayload toFinalResult() {
-		return new SubmissionFinalResultPayload(
-			this.getTestcaseCount(),
-			this.getPassedCount(),
-			this.getCurrentMessage()
-		);
-	}
+    public SubmissionFinalResultPayload toFinalResult() {
+        return new SubmissionFinalResultPayload(
+            this.getTestcaseCount(),
+            this.getPassedCount(),
+            this.getCurrentMessage()
+        );
+    }
 
-	public void incrementPassedCount() {
-		passedCount.incrementAndGet();
-	}
+    public void incrementPassedCount() {
+        passedCount.incrementAndGet();
+    }
 
-	public void incrementProcessedCount() {
-		processedCount.incrementAndGet();
-	}
+    public void incrementProcessedCount() {
+        processedCount.incrementAndGet();
+    }
 
-	public int getPassedCount() {
-		return passedCount.get();
-	}
+    public int getPassedCount() {
+        return passedCount.get();
+    }
 
-	public String getCurrentMessage() {
-		return message.get();
-	}
+    public String getCurrentMessage() {
+        return message.get();
+    }
 
-	public void updateMessage(String message) {
-		this.message.set(message);
-	}
+    public void updateMessage(String message) {
+        this.message.set(message);
+    }
 
-	public void countDown() {
-		latch.countDown();
-	}
+    public void countDown() {
+        latch.countDown();
+    }
 
-	public List<Testcase> getTestcases() {
-		return problemInfo.testcaseList();
-	}
+    public List<Testcase> getTestcases() {
+        return problemInfo.testcaseList();
+    }
 
-	public int getTestcaseCount() {
-		return problemInfo.getTestcaseCount();
-	}
+    public int getTestcaseCount() {
+        return problemInfo.getTestcaseCount();
+    }
 
-	public String getSourceCode() {
-		return msg.sourceCode();
-	}
+    public String getSourceCode() {
+        return msg.sourceCode();
+    }
 
-	public long getJudge0Id() {
-		return language.getJudge0Id();
-	}
+    public long getJudge0Id() {
+        return language.getJudge0Id();
+    }
 
-	public String getInput(int seqId) {
-		return getTestcases().get(seqId - 1).getInput();
-	}
+    public String getInput(int seqId) {
+        return getTestcases().get(seqId - 1).getInput();
+    }
 
-	public String getExpectedOutput(int seqId) {
-		return getTestcases().get(seqId - 1).getOutput();
-	}
+    public String getExpectedOutput(int seqId) {
+        return getTestcases().get(seqId - 1).getOutput();
+    }
 
-	public long getTimeLimit() {
-		return problemInfo.getTimeLimit();
-	}
+    public long getTimeLimit() {
+        return problemInfo.getTimeLimit();
+    }
 
-	public long getMemoryLimit() {
-		return problemInfo.getMemoryLimit();
-	}
+    public long getMemoryLimit() {
+        return problemInfo.getMemoryLimit();
+    }
 
-	public String getSessionKey() {
-		return msg.sessionKey();
-	}
+    public String getSessionKey() {
+        return msg.sessionKey();
+    }
 
-	public Problem getProblem() {
-		return problemInfo.problem();
-	}
+    public Problem getProblem() {
+        return problemInfo.problem();
+    }
 
-	public List<String> getProblemCategories() {
-		return problemInfo.problemCategories().stream().map(Category::getKorName).toList();
-	}
+    public List<String> getCategories() {
+        return getProblem().getCategories().stream().map(ProblemCategory::getCategoryForKor).toList();
+    }
+
+    public void incrementTotalSubmissions() {
+        getProblem().incrementTotalSubmissions();
+    }
+
+    public void incrementCorrectSubmissions() {
+        getProblem().incrementCorrectSubmissions();
+    }
+
+    public boolean isGitPushStatus(){
+        return user.isGitPushStatus();
+    }
+
+    public Long getUserId() {
+        return user.getId();
+    }
+
+    public boolean isPassed() {
+        return getPassedCount() == getTestcaseCount();
+    }
 }

--- a/src/main/java/org/ezcode/codetest/application/submission/port/GitHubClient.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/port/GitHubClient.java
@@ -1,0 +1,7 @@
+package org.ezcode.codetest.application.submission.port;
+
+import org.ezcode.codetest.application.submission.dto.request.github.GitHubPushRequest;
+
+public interface GitHubClient {
+    void commitAndPushToRepo(GitHubPushRequest request);
+}

--- a/src/main/java/org/ezcode/codetest/application/submission/service/GitHubService.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/service/GitHubService.java
@@ -1,0 +1,25 @@
+package org.ezcode.codetest.application.submission.service;
+
+import org.ezcode.codetest.application.submission.dto.request.github.GitHubPushRequest;
+import org.ezcode.codetest.application.submission.model.SubmissionContext;
+import org.ezcode.codetest.application.submission.port.GitHubClient;
+import org.ezcode.codetest.domain.user.model.entity.UserGithubInfo;
+import org.ezcode.codetest.domain.user.service.UserGithubService;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GitHubService {
+
+    private final GitHubClient gitHubClient;
+    private final UserGithubService userGithubService;
+
+    public void commitAndPushToRepo(SubmissionContext ctx) {
+        if (ctx.isGitPushStatus() && ctx.isPassed()) {
+            UserGithubInfo info = userGithubService.getUserGithubInfoById(ctx.getUserId());
+            gitHubClient.commitAndPushToRepo(GitHubPushRequest.of(ctx, info));
+        }
+    }
+}

--- a/src/main/java/org/ezcode/codetest/application/submission/service/JudgementService.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/service/JudgementService.java
@@ -24,7 +24,6 @@ import org.ezcode.codetest.domain.submission.model.SubmissionResult;
 import org.ezcode.codetest.domain.submission.model.TestcaseEvaluationInput;
 import org.ezcode.codetest.domain.submission.service.SubmissionDomainService;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -56,7 +55,6 @@ public class JudgementService {
         }
     }
 
-    @Transactional
     public void finalizeAndPublish(SubmissionContext ctx) {
         SubmissionResult submissionResult = submissionDomainService.finalizeSubmission(ctx);
 

--- a/src/main/java/org/ezcode/codetest/application/submission/service/SubmissionService.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/service/SubmissionService.java
@@ -49,6 +49,7 @@ public class SubmissionService {
     private final ExceptionNotifier exceptionNotifier;
     private final LockManager lockManager;
     private final JudgementService judgementService;
+    private final GitHubService gitHubService;
 
     public String enqueueCodeSubmission(Long problemId, CodeSubmitRequest request, AuthUser authUser) {
 
@@ -66,6 +67,7 @@ public class SubmissionService {
     }
 
     @Async("judgeSubmissionExecutor")
+    @Transactional
     public void submitCodeStream(SubmissionMessage msg) {
         try {
             log.info("[Submission RUN] Thread = {}", Thread.currentThread().getName());
@@ -75,6 +77,7 @@ public class SubmissionService {
             judgementService.publishInitTestcases(ctx);
             judgementService.runTestcases(ctx);
             judgementService.finalizeAndPublish(ctx);
+            gitHubService.commitAndPushToRepo(ctx);
         } catch (Exception e) {
             judgementService.publishSubmissionError(msg.sessionKey(), e);
             exceptionNotifier.notifyException("submitCodeStream", e);

--- a/src/main/java/org/ezcode/codetest/domain/problem/model/ProblemInfo.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/model/ProblemInfo.java
@@ -10,9 +10,7 @@ public record ProblemInfo(
 
 	Problem problem,
 
-	List<Testcase> testcaseList,
-
-	List<Category> problemCategories
+	List<Testcase> testcaseList
 
 ) {
 	public long getTimeLimit() {

--- a/src/main/java/org/ezcode/codetest/domain/problem/model/entity/Problem.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/model/entity/Problem.java
@@ -1,7 +1,9 @@
 package org.ezcode.codetest.domain.problem.model.entity;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.ezcode.codetest.common.base.entity.BaseEntity;
 import org.ezcode.codetest.domain.problem.model.enums.Difficulty;
@@ -73,6 +75,9 @@ public class Problem extends BaseEntity {
 
 	@OneToMany(mappedBy = "problem", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Testcase> testcases = new ArrayList<>();
+
+	@OneToMany(mappedBy = "problem", cascade = CascadeType.ALL, orphanRemoval = true)
+	private Set<ProblemCategory> categories = new LinkedHashSet<>();
 
 	@ElementCollection(fetch = FetchType.LAZY)
 	private List<String> imageUrl = new ArrayList<>();
@@ -149,4 +154,11 @@ public class Problem extends BaseEntity {
 		imageUrl.add(image);
 	}
 
+	public void incrementTotalSubmissions() {
+		totalSubmissions += 1;
+	}
+
+	public void incrementCorrectSubmissions() {
+		correctSubmissions += 1;
+	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/problem/model/entity/ProblemCategory.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/model/entity/ProblemCategory.java
@@ -54,4 +54,7 @@ public class ProblemCategory {
 		return new ProblemCategory(problem, category);
 	}
 
+	public String getCategoryForKor() {
+		return category.getKorName();
+	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
@@ -114,11 +114,7 @@ public class ProblemDomainService {
 		Problem problem = problemRepository.findProblemWithTestcasesById(problemId)
 			.orElseThrow(() -> new ProblemException(ProblemExceptionCode.PROBLEM_NOT_FOUND));
 
-		List<ProblemCategory> problemCategories = problemCategoryRepository.findByProblemId(problemId);
-
-		List<Category> categories = problemCategories.stream().map(ProblemCategory::getCategory).toList();
-
-		return new ProblemInfo(problem, problem.getTestcases(), categories);
+		return new ProblemInfo(problem, problem.getTestcases());
 	}
 
 }

--- a/src/main/java/org/ezcode/codetest/domain/submission/service/SubmissionDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/submission/service/SubmissionDomainService.java
@@ -23,86 +23,93 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SubmissionDomainService {
 
-	private final SubmissionRepository submissionRepository;
-	private final UserProblemResultRepository userProblemResultRepository;
+    private final SubmissionRepository submissionRepository;
+    private final UserProblemResultRepository userProblemResultRepository;
 
-	public SubmissionResult finalizeSubmission(SubmissionContext ctx) {
+    public SubmissionResult finalizeSubmission(SubmissionContext ctx) {
 
-		createSubmission(SubmissionData.toEntity(ctx));
+        createSubmission(SubmissionData.toEntity(ctx));
 
-		boolean allPassed = (ctx.getPassedCount() == ctx.getTestcaseCount());
+        boolean allPassed = ctx.isPassed();
 
-		return getUserProblemResult(ctx.user().getId(), ctx.getProblem().getId()).map(
-				result -> {
-					if (!result.isCorrect() && allPassed) {
-						modifyUserProblemResult(result, true);
-						return SubmissionResult.from(result, ctx.getProblemCategories(), false);
-					}
-					return SubmissionResult.from(result, ctx.getProblemCategories(), true);
-				})
-			.orElseGet(() -> SubmissionResult.from(createUserProblemResult(
-						UserProblemResult.builder()
-							.user(ctx.user())
-							.problem(ctx.getProblem())
-							.isCorrect(allPassed)
-							.build()
-					), ctx.getProblemCategories()
-					, false)
-			);
-	}
+        return getUserProblemResult(ctx.user().getId(), ctx.getProblem().getId()).map(
+                result -> {
+                    ctx.incrementTotalSubmissions();
+                    if (!result.isCorrect() && allPassed) {
+                        modifyUserProblemResult(result, true);
+                        ctx.incrementCorrectSubmissions();
+                        return SubmissionResult.from(result, ctx.getCategories(), false);
+                    }
+                    return SubmissionResult.from(result, ctx.getCategories(), true);
+                })
+            .orElseGet(() -> {
+                    ctx.incrementTotalSubmissions();
+                    if (allPassed) {
+                        ctx.incrementCorrectSubmissions();
+                    }
+                    return SubmissionResult.from(createUserProblemResult(
+                        UserProblemResult.builder()
+                            .user(ctx.user())
+                            .problem(ctx.getProblem())
+                            .isCorrect(allPassed)
+                            .build()
+                    ), ctx.getCategories(), false);
+                }
+            );
+    }
 
-	public boolean handleEvaluationAndUpdateStats(
-		TestcaseEvaluationInput input, SubmissionContext ctx
-	) {
-		boolean isPassed = evaluate(input);
+    public boolean handleEvaluationAndUpdateStats(
+        TestcaseEvaluationInput input, SubmissionContext ctx
+    ) {
+        boolean isPassed = evaluate(input);
 
-		if (isPassed) {
-			ctx.incrementPassedCount();
-		} else {
-			ctx.updateMessage(input.resultMessage());
-		}
-		ctx.incrementProcessedCount();
+        if (isPassed) {
+            ctx.incrementPassedCount();
+        } else {
+            ctx.updateMessage(input.resultMessage());
+        }
+        ctx.incrementProcessedCount();
 
-		collectStatistics(ctx.aggregator(), input);
+        collectStatistics(ctx.aggregator(), input);
 
-		return isPassed;
-	}
+        return isPassed;
+    }
 
-	public List<Submission> getSubmissions(Long userId) {
-		return submissionRepository.findSubmissionsByUserId(userId);
-	}
+    public List<Submission> getSubmissions(Long userId) {
+        return submissionRepository.findSubmissionsByUserId(userId);
+    }
 
-	public List<WeeklySolveCount> getWeeklySolveCounts(
-		LocalDateTime startDateTime, LocalDateTime endDateTime
-	) {
-		return submissionRepository.fetchWeeklySolveCounts(startDateTime, endDateTime);
-	}
+    public List<WeeklySolveCount> getWeeklySolveCounts(
+        LocalDateTime startDateTime, LocalDateTime endDateTime
+    ) {
+        return submissionRepository.fetchWeeklySolveCounts(startDateTime, endDateTime);
+    }
 
-	private boolean evaluate(TestcaseEvaluationInput input) {
-		boolean isCorrect = input.isCorrect();
-		boolean timeEfficient = input.timeEfficient();
-		boolean memoryEfficient = input.memoryEfficient();
-		AnswerEvaluation answerEvaluation = new AnswerEvaluation(isCorrect, timeEfficient, memoryEfficient);
-		return answerEvaluation.isPassed();
-	}
+    private boolean evaluate(TestcaseEvaluationInput input) {
+        boolean isCorrect = input.isCorrect();
+        boolean timeEfficient = input.timeEfficient();
+        boolean memoryEfficient = input.memoryEfficient();
+        AnswerEvaluation answerEvaluation = new AnswerEvaluation(isCorrect, timeEfficient, memoryEfficient);
+        return answerEvaluation.isPassed();
+    }
 
-	private void collectStatistics(SubmissionAggregator aggregator, TestcaseEvaluationInput input) {
-		aggregator.accumulate(input);
-	}
+    private void collectStatistics(SubmissionAggregator aggregator, TestcaseEvaluationInput input) {
+        aggregator.accumulate(input);
+    }
 
-	private void createSubmission(Submission submission) {
-		submissionRepository.saveSubmission(submission);
-	}
+    private void createSubmission(Submission submission) {
+        submissionRepository.saveSubmission(submission);
+    }
 
-	private Optional<UserProblemResult> getUserProblemResult(Long userId, Long problemId) {
-		return userProblemResultRepository.findUserProblemResultByUserIdAndProblemId(userId, problemId);
-	}
+    private Optional<UserProblemResult> getUserProblemResult(Long userId, Long problemId) {
+        return userProblemResultRepository.findUserProblemResultByUserIdAndProblemId(userId, problemId);
+    }
 
-	private UserProblemResult createUserProblemResult(UserProblemResult userProblemResult) {
-		return userProblemResultRepository.saveUserProblemResult(userProblemResult);
-	}
+    private UserProblemResult createUserProblemResult(UserProblemResult userProblemResult) {
+        return userProblemResultRepository.saveUserProblemResult(userProblemResult);
+    }
 
-	private void modifyUserProblemResult(UserProblemResult userProblemResult, boolean isCorrect) {
-		userProblemResultRepository.updateUserProblemResult(userProblemResult, isCorrect);
-	}
+    private void modifyUserProblemResult(UserProblemResult userProblemResult, boolean isCorrect) {
+        userProblemResultRepository.updateUserProblemResult(userProblemResult, isCorrect);
+    }
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/github/GitHubApiClient.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/github/GitHubApiClient.java
@@ -1,0 +1,152 @@
+package org.ezcode.codetest.infrastructure.github;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Optional;
+
+import org.ezcode.codetest.application.submission.dto.request.github.GitHubPushRequest;
+import org.ezcode.codetest.application.submission.port.GitHubClient;
+import org.ezcode.codetest.common.security.util.AESUtil;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class GitHubApiClient implements GitHubClient {
+
+    private final AESUtil aesUtil;
+    private final WebClient.Builder webClientBuilder;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commitAndPushToRepo(GitHubPushRequest request) {
+
+        try {
+            String owner = request.owner();
+            String repo = request.repo();
+            String branch = request.branch();
+            String accessToken = aesUtil.decrypt(request.accessToken());
+            Long problemId = request.problemId();
+            String problemTitle = request.problemTitle();
+            String problemDescription = request.problemDescription();
+            Long averageMemoryUsage = request.averageMemoryUsage();
+            Long averageExecutionTime = request.averageExecutionTime();
+            String sourceCode = request.sourceCode();
+            String submittedAt = request.submittedAt();
+
+            String mdPath = "test/ezcode/README.md";
+            String codePath = String.format("test/ezcode/%s.java", problemTitle);
+            String commitMsg = String.format("Add solution for %s", problemId);
+
+            WebClient webClient = webClientBuilder
+                .baseUrl("https://api.github.com")
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .defaultHeader(HttpHeaders.ACCEPT, "application/vnd.github+json")
+                .build();
+
+            String newSha = calculateBlobSha(sourceCode);
+            Optional<String> existingSha = webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                    .path("/repos/{owner}/{repo}/contents/{path}")
+                    .queryParam("ref", branch)
+                    .build(owner, repo, codePath)
+                )
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .map(node -> node.get("sha").asText())
+                .onErrorResume(err -> Mono.empty())
+                .blockOptional();
+
+            if (existingSha.filter(sha -> sha.equals(newSha)).isPresent()) {
+                return;
+            }
+
+            String md =
+                """
+                    # 문제 풀이 상세
+                    - 사이트: Ezcode
+                    
+                    ## 문제: %s
+                    ### 문제 설명
+                    %s
+                    
+                    ## 제출 요약
+                    - 메모리: %sKB
+                    - 실행 시간: %sms
+                    - 제출 일자: %s
+                    """.formatted(problemTitle, problemDescription, averageMemoryUsage, averageExecutionTime,
+                    submittedAt);
+            String code = String.format("%s", sourceCode);
+
+            ObjectNode mdBody = objectMapper.createObjectNode();
+            mdBody.put("message", commitMsg);
+            mdBody.put("branch", branch);
+            mdBody.put("content", encodeBase64(md));
+            existingSha.ifPresent(sha -> mdBody.put("sha", sha));
+
+            webClient.put()
+                .uri("/repos/{owner}/{repo}/contents/{path}", owner, repo, mdPath)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(mdBody)
+                .retrieve()
+                .toBodilessEntity()
+                .block();
+
+            ObjectNode codeBody = objectMapper.createObjectNode();
+            codeBody.put("message", commitMsg);
+            codeBody.put("branch", branch);
+            codeBody.put("content", encodeBase64(code));
+            existingSha.ifPresent(sha -> codeBody.put("sha", sha));
+            webClient.put()
+                .uri("/repos/{owner}/{repo}/contents/{path}", owner, repo, codePath)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(codeBody)
+                .retrieve()
+                .toBodilessEntity()
+                .block();
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    public String calculateBlobSha(String content) {
+        try {
+            byte[] contentBytes = content.getBytes(StandardCharsets.UTF_8);
+            String header = "blob " + contentBytes.length + "\0";
+            byte[] headerBytes = header.getBytes(StandardCharsets.UTF_8);
+
+            byte[] store = new byte[headerBytes.length + contentBytes.length];
+            System.arraycopy(headerBytes, 0, store, 0, headerBytes.length);
+            System.arraycopy(contentBytes, 0, store, headerBytes.length, contentBytes.length);
+
+            MessageDigest md = MessageDigest.getInstance("SHA-1");
+            byte[] shaBytes = md.digest(store);
+
+            StringBuilder sb = new StringBuilder();
+            for (byte b : shaBytes) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-1 algorithm not available", e);
+        }
+    }
+
+    public String encodeBase64(String utf8) {
+        if (utf8 == null) return "";
+        return Base64.getEncoder().encodeToString(utf8.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/org/ezcode/codetest/infrastructure/judge0/Judge0ResponseMapper.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/judge0/Judge0ResponseMapper.java
@@ -1,8 +1,5 @@
 package org.ezcode.codetest.infrastructure.judge0;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-
 import org.ezcode.codetest.application.submission.dto.response.compile.ExecutionResultResponse;
 import org.ezcode.codetest.application.submission.model.JudgeResult;
 import org.springframework.stereotype.Component;
@@ -50,10 +47,5 @@ public class Judge0ResponseMapper {
         return output
             .replaceAll("[\\r\\n]+$", "")
             .strip();
-    }
-
-    private String decodeBase64(String base64) {
-        if (base64 == null) return "";
-        return new String(Base64.getDecoder().decode(base64), StandardCharsets.US_ASCII);
     }
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/problem/ProblemJpaRepository.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/problem/ProblemJpaRepository.java
@@ -16,6 +16,8 @@ public interface ProblemJpaRepository extends JpaRepository<Problem, Long> {
 		select distinct p
 		from Problem p
 		left join fetch p.testcases
+		left join fetch p.categories c
+		left join fetch c.category
 		where p.id = :problemId
 		""")
 	Optional<Problem> findProblemWithTestcasesById(@Param("problemId") Long problemId);


### PR DESCRIPTION
## 작업 내용

- Problem, Category N+1 문제, 컬렉션에 따라 multiple fetch join 안 되는 에러 해결
- 정답 제출 시 깃 허브 자동 커밋 & 푸시 기능 구현

## 해결해야 할 문제

- 문제 요약용 md 파일과 소스코드용 파일 2개를 업로드 하는데, 커밋이 2개로 남겨져서 트리로 묶어서 해결해야 합니다.
- sha 해시 값으로 이전 파일과 변경 점이 없으면 얼리 리턴 처리를 하는데, md 파일도 이걸 해야할 지 고민입니다.
- 이걸 다 하면 한 번 푸시할 때마다 Git OpenAPI 요청이 5회~6회 정도 나오는데 그냥 해야할 거 같습니다.

## 참고 사항
- 일단 기본 기능만 대충 만들어둔 거라 세세한 예외 처리 및 고도화는 다음 주 월요일 안에 끝내겠습니다.
- 다음 PR에 환경 변수도 추가될 예정입니다.

테스트는 완료했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 코드 제출 시 GitHub 저장소로 자동 커밋 및 푸시 기능이 추가되었습니다.
  * 제출된 문제의 정보와 소스코드가 마크다운 및 자바 파일로 저장소에 업로드됩니다.

* **버그 수정**
  * 문제 카테고리 처리 방식이 개선되어, 문제의 카테고리 정보가 보다 정확하게 반영됩니다.

* **리팩터링**
  * 제출 및 문제 관련 통계 처리 로직이 개선되어, 제출 횟수 및 정답 횟수 집계가 정확해졌습니다.

* **기타**
  * 일부 불필요한 코드와 주석이 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->