### PR TITLE
refactor :  문제 카테고리 read 시 캐쉬 설정

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/submission/model/SubmissionContext.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/model/SubmissionContext.java
@@ -128,7 +128,7 @@ public record SubmissionContext(
     }
 
     public List<String> getCategories() {
-        return getProblem().getCategories().stream().map(ProblemCategory::getCategoryForKor).toList();
+        return problemInfo.categories();
     }
 
     public void incrementTotalSubmissions() {

--- a/src/main/java/org/ezcode/codetest/domain/game/model/character/CharacterRealStat.java
+++ b/src/main/java/org/ezcode/codetest/domain/game/model/character/CharacterRealStat.java
@@ -96,7 +96,6 @@ public class CharacterRealStat {
 			case DEBUGGING:
 				this.crit += rate / 10;
 				this.def += rate / 10;
-				this.atk += rate / 10;
 				this.stun += rate / 10;
 				break;
 			case OPTIMIZATION:

--- a/src/main/java/org/ezcode/codetest/domain/problem/model/ProblemInfo.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/model/ProblemInfo.java
@@ -2,7 +2,6 @@ package org.ezcode.codetest.domain.problem.model;
 
 import java.util.List;
 
-import org.ezcode.codetest.domain.problem.model.entity.Category;
 import org.ezcode.codetest.domain.problem.model.entity.Problem;
 import org.ezcode.codetest.domain.problem.model.entity.Testcase;
 
@@ -10,7 +9,9 @@ public record ProblemInfo(
 
 	Problem problem,
 
-	List<Testcase> testcaseList
+	List<Testcase> testcaseList,
+
+	List<String> categories
 
 ) {
 	public long getTimeLimit() {
@@ -24,4 +25,5 @@ public record ProblemInfo(
 	public int getTestcaseCount() {
 		return this.testcaseList.size();
 	}
+
 }

--- a/src/main/java/org/ezcode/codetest/domain/problem/model/entity/Problem.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/model/entity/Problem.java
@@ -1,9 +1,7 @@
 package org.ezcode.codetest.domain.problem.model.entity;
 
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.ezcode.codetest.common.base.entity.BaseEntity;
 import org.ezcode.codetest.domain.problem.model.enums.Difficulty;
@@ -75,9 +73,6 @@ public class Problem extends BaseEntity {
 
 	@OneToMany(mappedBy = "problem", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Testcase> testcases = new ArrayList<>();
-
-	@OneToMany(mappedBy = "problem", cascade = CascadeType.ALL, orphanRemoval = true)
-	private Set<ProblemCategory> categories = new LinkedHashSet<>();
 
 	@ElementCollection(fetch = FetchType.LAZY)
 	private List<String> imageUrl = new ArrayList<>();

--- a/src/main/java/org/ezcode/codetest/domain/problem/model/entity/ProblemCategory.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/model/entity/ProblemCategory.java
@@ -57,4 +57,5 @@ public class ProblemCategory {
 	public String getCategoryForKor() {
 		return category.getKorName();
 	}
+
 }

--- a/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
@@ -114,7 +114,11 @@ public class ProblemDomainService {
 		Problem problem = problemRepository.findProblemWithTestcasesById(problemId)
 			.orElseThrow(() -> new ProblemException(ProblemExceptionCode.PROBLEM_NOT_FOUND));
 
-		return new ProblemInfo(problem, problem.getTestcases());
+		List<ProblemCategory> categories = problemCategoryRepository.findByProblemId(problemId);
+
+		List<String> categoryNames = categories.stream().map(cat -> cat.getCategory().getKorName()).toList();
+
+		return new ProblemInfo(problem, problem.getTestcases(), categoryNames);
 	}
 
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/cache/config/CaffeineCacheConfig.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/cache/config/CaffeineCacheConfig.java
@@ -18,6 +18,7 @@ public class CaffeineCacheConfig {
 
 	@Bean
 	public CacheManager cacheManager() {
+
 		CaffeineCache countCache = new CaffeineCache("counts",
 			Caffeine.newBuilder()
 				.expireAfterWrite(Duration.ofMinutes(1))
@@ -53,10 +54,16 @@ public class CaffeineCacheConfig {
 				.expireAfterWrite(Duration.ofMinutes(10))
 				.build());
 
+		CaffeineCache problemCategory = new CaffeineCache("problemCategory",
+			Caffeine.newBuilder()
+				.expireAfterWrite(Duration.ofMinutes(10))
+				.build());
+
 		SimpleCacheManager manager = new SimpleCacheManager();
 		manager.setCaches(
 			List.of(skillCache, itemsByCategoryCache, encountersCache, countCache, historyCache, choiceCache,
-				categoryStatCache));
+				categoryStatCache, problemCategory));
+
 		return manager;
 	}
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/problem/ProblemCategoryRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/problem/ProblemCategoryRepositoryImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.ezcode.codetest.domain.problem.model.entity.ProblemCategory;
 import org.ezcode.codetest.domain.problem.repository.ProblemCategoryRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
@@ -40,6 +41,7 @@ public class ProblemCategoryRepositoryImpl implements ProblemCategoryRepository 
 	}
 
 	@Override
+	@Cacheable(value = "problemCategory", key = "#problemId")
 	public List<ProblemCategory> findByProblemId(Long problemId) {
 
 		return problemCategoryRepository.findByProblemId(problemId);

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/problem/ProblemJpaRepository.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/problem/ProblemJpaRepository.java
@@ -16,8 +16,6 @@ public interface ProblemJpaRepository extends JpaRepository<Problem, Long> {
 		select distinct p
 		from Problem p
 		left join fetch p.testcases
-		left join fetch p.categories c
-		left join fetch c.category
 		where p.id = :problemId
 		""")
 	Optional<Problem> findProblemWithTestcasesById(@Param("problemId") Long problemId);


### PR DESCRIPTION


---

## 작업 내용

- 문제 카테고리 조회시 10분 간 캐시 설정을 넣었습니다. 
- 기타 문제 풀시에 스탯 상승률 조정을 미세 조정하였습니다.

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 문제 정보에 카테고리명이 포함되어 표시됩니다.

* **버그 수정**
  * 디버깅 능력치 증가 시 공격력(atk)이 더 이상 증가하지 않습니다.

* **성능 개선**
  * 문제 카테고리 조회에 캐시가 적용되어 반복 조회 시 성능이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->