### PR TITLE
refactor : refreshToken 인식 문제 해결

### DIFF
--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/AuthController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/AuthController.java
@@ -70,12 +70,12 @@ public class AuthController {
 	}
 
 	@Operation(summary = "토큰 재발급", description = "리프레시 토큰을 이용하여 새로운 액세스 토큰을 발급합니다.",
-		security = @SecurityRequirement(name = "JWT_REFRESH")
+		security = @SecurityRequirement(name = "Authorization")
 	)
 	@PostMapping("/auth/refresh")
 	public ResponseEntity<RefreshTokenResponse> refresh(HttpServletRequest request) {
 
-		String token = Optional.ofNullable(request.getHeader("JWT_REFRESH"))
+		String token = Optional.ofNullable(request.getHeader("Authorization"))
 			.map(h -> h.replace("Bearer ", ""))
 			.orElseThrow(()-> new AuthException(AuthExceptionCode.INVALID_AUTHORIZATION_HEADER));
 


### PR DESCRIPTION

## 작업 내용

- refresh토큰이 헤더에 들어가지 않는 문제 해결

---

## 트러블 슈팅
- Swagger이름과 헤더 이름을 다르게 설정함

---

## 해결해야 할 문제

- 포스트맨에서는 작동하지만 스웨거 이름 아직 변경x


---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 토큰 갱신 엔드포인트에서 사용되는 HTTP 헤더가 "JWT_REFRESH"에서 "Authorization"으로 변경되었습니다.  
  * 이제 "Authorization" 헤더에서 Bearer 토큰을 추출하도록 동작이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->