### PR TITLE
feat : s3 문제 수정, 삭제 기능  ( + 이미지 기능 포함 로직 추가 )

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/problem/dto/request/ProblemCreateRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/dto/request/ProblemCreateRequest.java
@@ -13,11 +13,10 @@ import jakarta.validation.constraints.NotNull;
 
 public record ProblemCreateRequest(
 
-
+	// Map으로 묶여있으니 {} 중괄호 사용
 	@NotNull(message = "카테고리 이름를 설정해야 합니다.")
 	@Schema(description = "카테고리 코드 식별자(영어) / 한글 이름", example = "FOR_BEGINNER : 입문자용")
 	Map<String, String> categories,
-
 
 	@NotBlank(message = "문제 제목을 입력하세요.")
 	@Schema(description = "제목", example = "A+B")

--- a/src/main/java/org/ezcode/codetest/application/problem/dto/request/ProblemUpdateRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/dto/request/ProblemUpdateRequest.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ProblemUpdateRequest(
 
+	// 리스트 이므로, [] 대괄호 사용
 	@Schema(description = "카테고리", example = "FOR_BEGINNER")
 	List<String> categories,
 

--- a/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
@@ -46,7 +46,7 @@ public class ProblemService {
 	@Transactional
 	public void createCategory(CategoryCreateRequest requestDto) {
 
-		Category category =problemDomainService.createCategory(requestDto.toCategory());
+		Category category = problemDomainService.createCategory(requestDto.toCategory());
 
 		statUpdateUtil.save(new CategoryStat(category));
 	}
@@ -102,7 +102,7 @@ public class ProblemService {
 
 	// 문제 수정 ( 관리자 )
 	@Transactional
-	public void modifyProblem(Long problemId, ProblemUpdateRequest request) {
+	public void modifyProblem(Long problemId, ProblemUpdateRequest request, MultipartFile newImage) {
 
 		Problem findProblem = problemDomainService.getProblem(problemId);
 
@@ -115,6 +115,11 @@ public class ProblemService {
 			request.timeLimit(),
 			request.reference()
 		);
+
+		// 이미지 수정 처리
+		if (newImage != null && !newImage.isEmpty()) {
+			updateProblemImage(findProblem, newImage);
+		}
 
 		problemDomainService.updateCategoryAndSearchEngine(findProblem, request.categories());
 
@@ -142,6 +147,21 @@ public class ProblemService {
 			log.error("Problem {} 이미지 업로드 실패", problemId, e);
 			throw new S3Exception(S3ExceptionCode.S3_UPLOAD_FAILED);
 		}
+	}
+
+	// 이미지 수정
+	private void updateProblemImage(Problem problem, MultipartFile newImage) {
+
+		// 기존 이미지가 있다면 삭제 처리
+		if (!problem.getImageUrl().isEmpty()) {
+			for(String imageUrl : problem.getImageUrl()) {
+				s3Uploader.delete(imageUrl);
+			}
+			problem.clearImages();
+		}
+
+		String newImageUrl = uploadImageAfterTransaction(newImage, problem.getId());
+		problem.addImage(newImageUrl);
 	}
 }
 

--- a/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
@@ -131,13 +131,14 @@ public class ProblemService {
 
 		Problem findProblem = problemDomainService.getProblem(problemId);
 
+		// 문제 이미지가 있으면 삭제
 		if (!findProblem.getImageUrl().isEmpty()) {
 			for(String imageUrl : findProblem.getImageUrl()) {
 				s3Uploader.delete(imageUrl);
 			}
-			findProblem.clearImages();
 		}
 
+		// Soft Delete
 		problemDomainService.removeProblem(findProblem);
 	}
 

--- a/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
@@ -131,6 +131,13 @@ public class ProblemService {
 
 		Problem findProblem = problemDomainService.getProblem(problemId);
 
+		if (!findProblem.getImageUrl().isEmpty()) {
+			for(String imageUrl : findProblem.getImageUrl()) {
+				s3Uploader.delete(imageUrl);
+			}
+			findProblem.clearImages();
+		}
+
 		problemDomainService.removeProblem(findProblem);
 	}
 

--- a/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
@@ -133,8 +133,8 @@ public class ProblemService {
 
 		// 문제 이미지가 있으면 삭제
 		if (!findProblem.getImageUrl().isEmpty()) {
-			for(String imageUrl : findProblem.getImageUrl()) {
-				s3Uploader.delete(imageUrl);
+			for(String fileUrl : findProblem.getImageUrl()) {
+				s3Uploader.delete(fileUrl);
 			}
 		}
 
@@ -162,8 +162,8 @@ public class ProblemService {
 
 		// 기존 이미지가 있다면 삭제 처리
 		if (!problem.getImageUrl().isEmpty()) {
-			for(String imageUrl : problem.getImageUrl()) {
-				s3Uploader.delete(imageUrl);
+			for(String fileUrl : problem.getImageUrl()) {
+				s3Uploader.delete(fileUrl);
 			}
 			problem.clearImages();
 		}

--- a/src/main/java/org/ezcode/codetest/domain/problem/model/entity/Problem.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/model/entity/Problem.java
@@ -152,6 +152,7 @@ public class Problem extends BaseEntity {
 	// 이미지 초기화
 	public void clearImages() {
 		this.imageUrl.clear();
+	}
 
 	public void incrementTotalSubmissions() {
 		totalSubmissions += 1;

--- a/src/main/java/org/ezcode/codetest/domain/problem/model/entity/Problem.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/model/entity/Problem.java
@@ -149,4 +149,8 @@ public class Problem extends BaseEntity {
 		imageUrl.add(image);
 	}
 
+	// 이미지 초기화
+	public void clearImages() {
+		this.imageUrl.clear();
+	}
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/s3/S3Uploader.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/s3/S3Uploader.java
@@ -61,13 +61,13 @@ public class S3Uploader {
 	}
 
 	// 이미지 삭제
-	public void delete(String imageUrl) {
+	public void delete(String fileUrl) {
 		try {
-			String fileName = extractKeyFromProblemUrl(imageUrl);
+			String fileName = extractKeyFromProblemUrl(fileUrl);
 			amazonS3.deleteObject(bucket, fileName); // S3 내 이미지 객체 제거.
 			log.info("S3에서 이미지 삭제 완료: {}", fileName);
 		} catch (Exception e) {
-			log.error("S3 이미지 삭제 실패: {}", imageUrl, e);
+			log.error("S3 이미지 삭제 실패: {}", fileUrl, e);
 			throw new S3Exception(S3ExceptionCode.S3_DELETE_FAILED);
 		}
 	}

--- a/src/main/java/org/ezcode/codetest/infrastructure/s3/S3Uploader.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/s3/S3Uploader.java
@@ -26,6 +26,7 @@ public class S3Uploader {
 	@Value("${cloud.aws.s3.bucket}")
 	private String bucket;
 
+	// 이미지 업로드
 	public String upload(MultipartFile multipartFile, String dirName) {
 		try {
 			// MIME 타입 검사 (png, jpeg, jpg, webp 만 가능)
@@ -57,5 +58,23 @@ public class S3Uploader {
 			log.error("예상치 못한 업로드 오류 발생", e);
 			throw new S3Exception(S3ExceptionCode.S3_UPLOAD_FAILED);
 		}
+	}
+
+	// 이미지 삭제
+	public void delete(String imageUrl) {
+		try {
+			String fileName = extractKeyFromProblemUrl(imageUrl);
+			amazonS3.deleteObject(bucket, fileName); // S3 내 이미지 객체 제거.
+			log.info("S3에서 이미지 삭제 완료: {}", fileName);
+		} catch (Exception e) {
+			log.error("S3 이미지 삭제 실패: {}", imageUrl, e);
+			throw new S3Exception(S3ExceptionCode.S3_DELETE_FAILED);
+		}
+	}
+
+	// 문제 이미지 URL 가져오기
+	private String extractKeyFromProblemUrl(String fileUrl) {
+		// S3 주소 포맷 기준으로 잘라내기
+		return fileUrl.substring(fileUrl.indexOf("problem/"));
 	}
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/s3/exception/code/S3ExceptionCode.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/s3/exception/code/S3ExceptionCode.java
@@ -10,9 +10,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum S3ExceptionCode implements ResponseCode {
 
-	S3_UPLOAD_FAILED(false, HttpStatus.INTERNAL_SERVER_ERROR, "S3 이미지 업로드 중 오류가 발생했습니다."),
-	S3_INVALID_FILE_TYPE(false, HttpStatus.BAD_REQUEST, "이미지 파일만 업로드할 수 있습니다.");
-
+	S3_UPLOAD_FAILED(false, HttpStatus.INTERNAL_SERVER_ERROR, "S3 이미지 업로드 중 오류가 발생 했습니다."),
+	S3_INVALID_FILE_TYPE(false, HttpStatus.BAD_REQUEST, "이미지 파일만 업로드할 수 있습니다."),
+	S3_DELETE_FAILED(false, HttpStatus.INTERNAL_SERVER_ERROR, "S3 이미지 삭제 중 오류가 발생 했습니다.");
 	private final boolean success;
 
 	private final HttpStatus status;

--- a/src/main/java/org/ezcode/codetest/presentation/problemmanagement/problem/ProblemAdminController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/problemmanagement/problem/ProblemAdminController.java
@@ -47,14 +47,15 @@ public class ProblemAdminController {
 			.build();
 	}
 
-	@PutMapping("/{problemId}")
+	@PutMapping(path = "/{problemId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
 	@Operation(summary = "문제 수정", description = "문제를 수정합니다.")
 	@ApiResponse(responseCode = "200", description = "문제 수정 성공")
 	public ResponseEntity<Void> modifyProblem(
 		@PathVariable Long problemId,
-		@Valid @RequestBody ProblemUpdateRequest request
+		@RequestPart @Valid ProblemUpdateRequest request,
+		@RequestPart(value = "image", required = false) MultipartFile image
 	) {
-		problemService.modifyProblem(problemId, request);
+		problemService.modifyProblem(problemId, request, image);
 
 		return ResponseEntity
 			.status(HttpStatus.OK)


### PR DESCRIPTION
## 작업 내용

- 문제 수정, 삭제시 이미지가 있다면, DB뿐만 아니라 AWS S3 버킷 내에서도 해당하는 파일이 수정되거나 삭제되게 구현
---

## 변경 사항

---

## 트러블 슈팅

---

## 해결해야 할 문제

---

## 참고 사항
![image](https://github.com/user-attachments/assets/2294c282-c642-444d-90b5-0d5e8e227118)
- 문제 수정, 삭제 API 호출시, 이미지가 있다면 AWS 내에서 해당하는 API에 맞게 파일 변화가 생김.
---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * 문제 수정 시 이미지 파일을 함께 업로드할 수 있도록 지원합니다.
  * 문제에 등록된 이미지를 모두 삭제하는 기능이 추가되었습니다.
  * S3에서 이미지 삭제 기능이 추가되었습니다.

* **Bug Fixes**
  * 문제 삭제 시 연관된 이미지가 S3에서 함께 삭제됩니다.

* **Documentation**
  * 문제 생성 및 수정 요청의 카테고리 필드 사용법에 대한 주석이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->