### PR TITLE
Refactor/oauth redirecting

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
@@ -134,7 +134,7 @@ public class ProblemService {
 		// 문제 이미지가 있으면 삭제
 		if (!findProblem.getImageUrl().isEmpty()) {
 			for(String fileUrl : findProblem.getImageUrl()) {
-				s3Uploader.delete(fileUrl);
+				s3Uploader.delete(fileUrl, "problem");
 			}
 		}
 
@@ -163,7 +163,7 @@ public class ProblemService {
 		// 기존 이미지가 있다면 삭제 처리
 		if (!problem.getImageUrl().isEmpty()) {
 			for(String fileUrl : problem.getImageUrl()) {
-				s3Uploader.delete(fileUrl);
+				s3Uploader.delete(fileUrl, "problem");
 			}
 			problem.clearImages();
 		}

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/request/ResetPasswordRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/request/ResetPasswordRequest.java
@@ -1,15 +1,19 @@
 package org.ezcode.codetest.application.usermanagement.user.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "비밀번호 리셋을 위한 입력")
 public record ResetPasswordRequest (
+    @NotBlank(message = "임시 재설정 토큰은 필수입니다")
     @Schema(description = "비밀번호 리셋 유저의 토큰 - 유효 시간 10분")
     String tempResetToken,
 
+    @NotBlank(message = "새 비밀번호는 필수입니다")
     @Schema(description = "변경할 비밀번호", example = "myPassword@@!")
     String newPassword,
 
+    @NotBlank(message = "비밀번호 확인은 필수입니다")
     @Schema(description = "변경할 비밀번호 확인용 재입력", example = "myPassword@@!")
     String newPasswordConfirm
 ){

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/GrantAdminRoleResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/GrantAdminRoleResponse.java
@@ -1,0 +1,13 @@
+package org.ezcode.codetest.application.usermanagement.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "Admin 권한을 부여")
+@AllArgsConstructor
+public class GrantAdminRoleResponse {
+    private final String message;
+
+}

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/UserProfileImageResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/UserProfileImageResponse.java
@@ -1,0 +1,11 @@
+package org.ezcode.codetest.application.usermanagement.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserProfileImageResponse {
+    private final String message;
+
+}

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
@@ -161,8 +161,20 @@ public class UserService {
 	@Transactional
 	public UserProfileImageResponse deleteUserProfileImage(AuthUser authUser) {
 		User user = userDomainService.getUserById(authUser.getId());
-		user.modifyProfileImage(null);
-		return new UserProfileImageResponse(user.getProfileImageUrl());
+
+		String oldImageUrl = user.getProfileImageUrl();
+
+		// S3에서 기존 이미지 파일 삭제
+		if (oldImageUrl != null) {
+			try {
+				s3Uploader.delete(oldImageUrl, "profile");
+				user.modifyProfileImage(null);
+			} catch (Exception e) {
+				log.warn("프로필 이미지 삭제 실패 - url: {}", oldImageUrl, e);
+			}
+		}
+
+		return new UserProfileImageResponse(null);
 	}
 
 	@Transactional

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
+import org.ezcode.codetest.application.usermanagement.user.dto.response.GrantAdminRoleResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.UserProfileImageResponse;
 import org.ezcode.codetest.application.usermanagement.user.model.UsersByWeek;
 import org.ezcode.codetest.domain.submission.dto.WeeklySolveCount;
@@ -14,10 +15,13 @@ import org.ezcode.codetest.application.usermanagement.user.dto.response.UserInfo
 import org.ezcode.codetest.application.usermanagement.user.dto.response.WithdrawUserResponse;
 import org.ezcode.codetest.domain.submission.service.SubmissionDomainService;
 import org.ezcode.codetest.domain.user.exception.AuthException;
+import org.ezcode.codetest.domain.user.exception.UserException;
 import org.ezcode.codetest.domain.user.exception.code.AuthExceptionCode;
+import org.ezcode.codetest.domain.user.exception.code.UserExceptionCode;
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.ezcode.codetest.domain.user.model.entity.User;
 import org.ezcode.codetest.domain.user.model.enums.AuthType;
+import org.ezcode.codetest.domain.user.model.enums.UserRole;
 import org.ezcode.codetest.domain.user.service.MailService;
 import org.ezcode.codetest.domain.user.service.UserDomainService;
 import org.ezcode.codetest.infrastructure.s3.S3Directory;
@@ -159,5 +163,19 @@ public class UserService {
 		User user = userDomainService.getUserById(authUser.getId());
 		user.modifyProfileImage(null);
 		return new UserProfileImageResponse(user.getProfileImageUrl());
+	}
+
+	@Transactional
+	public GrantAdminRoleResponse grantAdminRole(AuthUser authUser, Long userId) {
+		if (authUser.getId().equals(userId)) {
+			throw new UserException(UserExceptionCode.GRANT_ADMIN_SELF);
+		}
+		User user = userDomainService.getUserById(userId);
+		if (user.getRole().equals(UserRole.ADMIN)) {
+			throw new UserException(UserExceptionCode.ALREADY_ADMIN_USER);
+		}
+		user.modifyUserRole(UserRole.ADMIN);
+
+		return new GrantAdminRoleResponse("ADMIN 권한을 부여합니다");
 	}
 }

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
+import org.ezcode.codetest.application.usermanagement.user.dto.response.UserProfileImageResponse;
 import org.ezcode.codetest.application.usermanagement.user.model.UsersByWeek;
 import org.ezcode.codetest.domain.submission.dto.WeeklySolveCount;
 import org.ezcode.codetest.application.usermanagement.user.dto.request.ChangeUserPasswordRequest;
@@ -19,10 +20,15 @@ import org.ezcode.codetest.domain.user.model.entity.User;
 import org.ezcode.codetest.domain.user.model.enums.AuthType;
 import org.ezcode.codetest.domain.user.service.MailService;
 import org.ezcode.codetest.domain.user.service.UserDomainService;
+import org.ezcode.codetest.infrastructure.s3.S3Directory;
+import org.ezcode.codetest.infrastructure.s3.S3Uploader;
+import org.ezcode.codetest.infrastructure.s3.exception.S3Exception;
+import org.ezcode.codetest.infrastructure.s3.exception.code.S3ExceptionCode;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,6 +41,7 @@ public class UserService {
 	private final UserDomainService userDomainService;
 	private final SubmissionDomainService submissionDomainService;
 	private final RedisTemplate<String, String> redisTemplate;
+	private final S3Uploader s3Uploader;
 
 	@Transactional(readOnly = true)
 	public UserInfoResponse getUserInfo(AuthUser authUser) {
@@ -126,4 +133,31 @@ public class UserService {
 		userDomainService.resetReviewTokensForUsers(UsersByWeek.from(counts, weekLength));
 	}
 
+	@Transactional
+	public UserProfileImageResponse uploadUserProfileImage(AuthUser authUser, MultipartFile image) {
+		User user = userDomainService.getUserById(authUser.getId());
+		if (user.getProfileImageUrl()!=null) {
+			s3Uploader.delete(user.getProfileImageUrl(), "profile");
+		}
+		String profileImageUrl = uploadProfileImage(image);
+
+		user.modifyProfileImage(profileImageUrl);
+		return new UserProfileImageResponse(profileImageUrl);
+	}
+
+	private String uploadProfileImage(MultipartFile image) {
+		try {
+			return s3Uploader.upload(image, S3Directory.PROFILE.getDir());
+		} catch (Exception e) {
+			log.error("프로필 이미지 업로드 실패 - image {}", image, e);
+			throw new S3Exception(S3ExceptionCode.S3_UPLOAD_FAILED);
+		}
+	}
+
+	@Transactional
+	public UserProfileImageResponse deleteUserProfileImage(AuthUser authUser) {
+		User user = userDomainService.getUserById(authUser.getId());
+		user.modifyProfileImage(null);
+		return new UserProfileImageResponse(user.getProfileImageUrl());
+	}
 }

--- a/src/main/java/org/ezcode/codetest/common/security/config/SecurityConfig.java
+++ b/src/main/java/org/ezcode/codetest/common/security/config/SecurityConfig.java
@@ -73,11 +73,11 @@ public class SecurityConfig {
 					.requestMatchers(new DispatcherTypeRequestMatcher(DispatcherType.ASYNC)).permitAll()
 					.requestMatchers(
 						SecurityPath.PUBLIC_PATH).permitAll()
+					.requestMatchers("/api/admin/**").hasRole("ADMIN") //어드민 권한 필요 (문제 생성, 관리 등)
 					.requestMatchers(HttpMethod.GET,
 						"/api/problems/*/discussions",
 						"/api/problems/{problemId}/discussions/{discussionId}/replies",
 						"/api/problems/{problemId}/discussions/{discussionId}/replies/**").permitAll()
-					.requestMatchers("/admin/**").hasRole("ADMIN") //어드민 권한 필요 (문제 생성, 관리 등)
 					.anyRequest().authenticated() //나머지는 일반 인증
 			)
 			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/org/ezcode/codetest/common/security/hander/CustomSuccessHandler.java
+++ b/src/main/java/org/ezcode/codetest/common/security/hander/CustomSuccessHandler.java
@@ -117,8 +117,6 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 			.queryParam("refreshToken", refreshToken)
 			.build().toUriString();
 
-		//JSON 문자열로 바꿔서 클라이언트에게 응답 본문으로 전달
-		OAuthResponse oAuthResponse = new OAuthResponse(accessToken, refreshToken);
 
 		response.sendRedirect(targetUri);
 		}

--- a/src/main/java/org/ezcode/codetest/common/security/hander/CustomSuccessHandler.java
+++ b/src/main/java/org/ezcode/codetest/common/security/hander/CustomSuccessHandler.java
@@ -120,10 +120,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 		//JSON 문자열로 바꿔서 클라이언트에게 응답 본문으로 전달
 		OAuthResponse oAuthResponse = new OAuthResponse(accessToken, refreshToken);
 
-		response.setContentType("application/json");
-		response.setCharacterEncoding("UTF-8");
-		response.getWriter().write(objectMapper.writeValueAsString(oAuthResponse));
-		// response.sendRedirect(targetUri);
+		response.sendRedirect(targetUri);
 		}
 
 }

--- a/src/main/java/org/ezcode/codetest/common/security/util/JwtFilter.java
+++ b/src/main/java/org/ezcode/codetest/common/security/util/JwtFilter.java
@@ -70,6 +70,7 @@ public class JwtFilter extends OncePerRequestFilter {
 			tier
 		);
 
+
 		// 인가를 위한 권한 정보 저장
 		Collection<? extends GrantedAuthority> authorities =
 			List.of(new SimpleGrantedAuthority("ROLE_" + authUser.getRole().name()));
@@ -77,6 +78,7 @@ public class JwtFilter extends OncePerRequestFilter {
 		// Spring Security 인증 토큰 생성
 		Authentication authToken;
 		authToken = new UsernamePasswordAuthenticationToken(authUser, null, authorities);
+
 
 		// SecurityContextHolder(세션)에 토큰 담기
 		SecurityContextHolder.getContext().setAuthentication(authToken);

--- a/src/main/java/org/ezcode/codetest/common/security/util/JwtUtil.java
+++ b/src/main/java/org/ezcode/codetest/common/security/util/JwtUtil.java
@@ -150,7 +150,7 @@ public class JwtUtil {
 	}
 
     public String createEmailToken(Long userId, String email) {
-		if ( email == null ) {
+		if ( email == null || userId == null) {
 			throw new IllegalArgumentException("토큰에 필요한 필수 매개변수가 null입니다.");
 		}
 

--- a/src/main/java/org/ezcode/codetest/common/security/util/SecurityPath.java
+++ b/src/main/java/org/ezcode/codetest/common/security/util/SecurityPath.java
@@ -8,6 +8,7 @@ public class SecurityPath {
 		"/login/oauth2/**", //OAuth로그인 접근
 		"/api/auth/**",
 		"/api/oauth2/**",
+		"/oauth/**",
 		"/login",
 		"/ezlogin",
 		"/login/**",

--- a/src/main/java/org/ezcode/codetest/domain/user/exception/code/AuthExceptionCode.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/exception/code/AuthExceptionCode.java
@@ -20,7 +20,8 @@ public enum AuthExceptionCode implements ResponseCode {
 	PASSWORD_IS_SAME(false, HttpStatus.BAD_REQUEST, "기존 비밀번호와 같습니다. 새로운 비밀번호는 기존 비밀번호와 달라야합니다."),
 	ALREADY_WITHDRAW_USER(false, HttpStatus.NOT_FOUND, "탈퇴된 회원입니다."),
     TOKEN_ENCODE_FAIL(false, HttpStatus.BAD_REQUEST, "토큰 인코딩에 실패했습니다."),
-	REDIRECT_URI_NOT_FOUND(false, HttpStatus.BAD_REQUEST, "redirect_uri를 찾을 수 없습니다");
+	REDIRECT_URI_NOT_FOUND(false, HttpStatus.BAD_REQUEST, "redirect_uri를 찾을 수 없습니다"),
+	INVALID_AUTH_USER(false, HttpStatus.BAD_REQUEST, "ADMIN만 접근 가능합니다");
 
 	private final boolean success;
 	private final HttpStatus status;

--- a/src/main/java/org/ezcode/codetest/domain/user/exception/code/UserExceptionCode.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/exception/code/UserExceptionCode.java
@@ -13,7 +13,9 @@ public enum UserExceptionCode implements ResponseCode {
 	NOT_ENOUGH_TOKEN(false, HttpStatus.BAD_REQUEST, "리뷰 토큰이 부족합니다."),
     NOT_MATCH_CODE(false, HttpStatus.BAD_REQUEST, "이메일 인증 코드가 일치하지 않습니다."),
 	NO_GITHUB_INFO(false, HttpStatus.BAD_REQUEST, "깃허브 정보가 없습니다."),
-	NO_GITHUB_REPO(false, HttpStatus.BAD_REQUEST, "해당하는 Repository를 찾을 수 없습니다.");
+	NO_GITHUB_REPO(false, HttpStatus.BAD_REQUEST, "해당하는 Repository를 찾을 수 없습니다."),
+	GRANT_ADMIN_SELF(false, HttpStatus.BAD_REQUEST, "본인에게 ADMIN 권한을 부여할 수 없습니다."),
+	ALREADY_ADMIN_USER(false, HttpStatus.BAD_REQUEST, "이미 ADMIN 권한을 가진 유저입니다.");
 
 	private final boolean success;
 	private final HttpStatus status;

--- a/src/main/java/org/ezcode/codetest/domain/user/model/entity/AuthUser.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/model/entity/AuthUser.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.ezcode.codetest.domain.user.model.enums.Tier;
 import org.ezcode.codetest.domain.user.model.enums.UserRole;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import lombok.Getter;
@@ -29,7 +30,9 @@ public class AuthUser implements UserDetails {
 	}
 
 	@Override
-	public Collection<? extends GrantedAuthority> getAuthorities() { return List.of(() -> "ROLE_" + role.name()); }
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
+	}
 
 	@Override
 	public String getPassword() { return ""; }

--- a/src/main/java/org/ezcode/codetest/domain/user/model/entity/User.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/model/entity/User.java
@@ -202,4 +202,8 @@ public class User extends BaseEntity {
     public void modifyProfileImage(String profileImageUrl) {
 		this.profileImageUrl = profileImageUrl;
     }
+
+	public void modifyUserRole(UserRole userRole) {
+		this.role = userRole;
+	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/user/model/entity/User.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/model/entity/User.java
@@ -9,9 +9,11 @@ import org.ezcode.codetest.domain.user.model.enums.UserRole;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -196,4 +198,8 @@ public class User extends BaseEntity {
 	public boolean getGitPushStatus() {
 		return gitPushStatus;
 	}
+
+    public void modifyProfileImage(String profileImageUrl) {
+		this.profileImageUrl = profileImageUrl;
+    }
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/s3/S3Uploader.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/s3/S3Uploader.java
@@ -61,9 +61,15 @@ public class S3Uploader {
 	}
 
 	// 이미지 삭제
-	public void delete(String fileUrl) {
+	public void delete(String fileUrl, String dirName) {
 		try {
-			String fileName = extractKeyFromProblemUrl(fileUrl);
+			String fileName = "";
+			if (dirName.equalsIgnoreCase("problem")) {
+				fileName = extractKeyFromProblemUrl(fileUrl);
+			}
+			if (dirName.equalsIgnoreCase("profile")) {
+				fileName = extractKeyFromProfileUrl(fileUrl);
+			}
 			amazonS3.deleteObject(bucket, fileName); // S3 내 이미지 객체 제거.
 			log.info("S3에서 이미지 삭제 완료: {}", fileName);
 		} catch (Exception e) {
@@ -76,5 +82,10 @@ public class S3Uploader {
 	private String extractKeyFromProblemUrl(String fileUrl) {
 		// S3 주소 포맷 기준으로 잘라내기
 		return fileUrl.substring(fileUrl.indexOf("problem/"));
+	}
+
+	// 프로필 이미지 URL 가져오기
+	private String extractKeyFromProfileUrl(String profileFileUrl) {
+		return profileFileUrl.substring(profileFileUrl.indexOf("profile/"));
 	}
 }

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/OAuth2Controller.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/OAuth2Controller.java
@@ -1,6 +1,7 @@
 package org.ezcode.codetest.presentation.usermanagement;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -39,10 +40,15 @@ public class OAuth2Controller {
         HttpServletResponse response,
         @RequestParam(required = false) String redirect_uri
     ) throws IOException {
-        if (redirect_uri != null) {
+        if (redirect_uri != null && isValidRedirectUri(redirect_uri)) {
             request.getSession().setAttribute("redirect_uri", redirect_uri);
         }
 
         response.sendRedirect("/oauth2/authorization/" + provider);
+    }
+
+    private boolean isValidRedirectUri(String uri) {
+        List<String> allowedDomains = List.of("http://localhost:8080", "https://ezcode.my");
+        return allowedDomains.stream().anyMatch(uri::startsWith);
     }
 }

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/OAuth2Controller.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/OAuth2Controller.java
@@ -28,7 +28,7 @@ public class OAuth2Controller {
                프론트엔드에서 GitHub 로그인 버튼 클릭 시 이 API를 먼저 호출
                redirect_uri는 로그인 완료 후 accessToken과 refreshToken을 전달받을 프론트의 콜백 URL
 
-               예시: GET /api/oauth2/authorize/github?redirect_uri=https://ezcode.my/oauth/callback
+               예시: GET /api/oauth2/authorize/google?redirect_uri=https://ezcode.my
                """)
     @Parameters({
         @Parameter(name = "redirect_uri", description = "프론트 콜백 URI", required = true, example = "https://ezcode.my/oauth/callback (이 uri는 예시이니 편하신걸로 바꾸심 됩니당)")
@@ -48,7 +48,7 @@ public class OAuth2Controller {
     }
 
     private boolean isValidRedirectUri(String uri) {
-        List<String> allowedDomains = List.of("http://localhost:8080", "https://ezcode.my");
+        List<String> allowedDomains = List.of("http://localhost:8080", "http://localhost:3000","https://ezcode.my");
         return allowedDomains.stream().anyMatch(uri::startsWith);
     }
 }

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
@@ -4,6 +4,7 @@ import org.ezcode.codetest.application.usermanagement.user.dto.request.ModifyUse
 import org.ezcode.codetest.application.usermanagement.user.dto.request.ChangeUserPasswordRequest;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.ChangeUserPasswordResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.UserInfoResponse;
+import org.ezcode.codetest.application.usermanagement.user.dto.response.UserProfileImageResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.WithdrawUserResponse;
 import org.ezcode.codetest.application.usermanagement.user.service.UserService;
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
@@ -15,7 +16,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -45,6 +48,28 @@ public class UserController {
 		@RequestBody ModifyUserInfoRequest modifyUserInfoRequest
 	){
 		return ResponseEntity.status(HttpStatus.OK).body(userService.modifyUserInfo(authUser, modifyUserInfoRequest));
+	}
+
+	//유저 프로필 이미지 등록
+	@Operation(
+		summary = "프로필 이미지 등록",
+		description = "유저의 프로필 이미지를 등록합니다. 기존의 이미지가 있는 경우, 기존 이미지가 삭제되고 새로운 이미지로 교체됩니다.")
+	@PutMapping("/users/profile")
+	public ResponseEntity<UserProfileImageResponse> uploadUserProfileImage(
+		@AuthenticationPrincipal AuthUser authUser,
+		@RequestPart(value = "image", required = false) MultipartFile image
+	){
+		return ResponseEntity.status(HttpStatus.OK).body(userService.uploadUserProfileImage(authUser, image));
+	}
+
+	@Operation(
+		summary = "프로필 이미지 삭제",
+		description = "유저의 프로필 이미지를 삭제 후 기본 이미지로 대체됩니다.")
+	@DeleteMapping("/users/profile")
+	public ResponseEntity<UserProfileImageResponse> deleteUserProfileImage(
+		@AuthenticationPrincipal AuthUser authUser
+	){
+	return ResponseEntity.status(HttpStatus.OK).body(userService.deleteUserProfileImage(authUser));
 	}
 
 	@Operation(summary = "비밀번호 변경", description = "기존 비밀번호와 새 비밀번호를 입력하여 비밀번호를 변경합니다.")

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
@@ -3,6 +3,7 @@ package org.ezcode.codetest.presentation.usermanagement;
 import org.ezcode.codetest.application.usermanagement.user.dto.request.ModifyUserInfoRequest;
 import org.ezcode.codetest.application.usermanagement.user.dto.request.ChangeUserPasswordRequest;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.ChangeUserPasswordResponse;
+import org.ezcode.codetest.application.usermanagement.user.dto.response.GrantAdminRoleResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.UserInfoResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.UserProfileImageResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.WithdrawUserResponse;
@@ -13,9 +14,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -87,6 +92,14 @@ public class UserController {
 		@AuthenticationPrincipal AuthUser authUser
 	){
 		return ResponseEntity.status(HttpStatus.OK).body(userService.withdrawUser(authUser));
+	}
 
+	@Operation(summary = "유저 권한 전환", description = "관리자 권한을 가지고 있는 유저는 다른 유저의 권한을 수정할 수 있습니다.")
+	@PostMapping("/admin/users/{userId}/grant-admin")
+	public ResponseEntity<GrantAdminRoleResponse> grantAdminRole(
+		@AuthenticationPrincipal AuthUser authUser,
+		@PathVariable Long userId
+	){
+		return ResponseEntity.status(HttpStatus.OK).body(userService.grantAdminRole(authUser, userId));
 	}
 }


### PR DESCRIPTION
## 작업 내용

### 1. 소셜로그인 RedirectURI 전달 값 변경
기본 api  
→ GET : `/api/oauth2/authorize/{provider}?c={redirect_uri}`
{provider} : oauth2 인증할 곳 이름 (github/google)
{redirect_url} : 인증 성공 후 사용자에게 보여줄 화면의 주소

보안 상 허용된 uri만 가능하게 하기 위해서 현재 백엔드에 아래 두가지 경로만 허용되어있습니다
```java
- 테스트용
"http://localhost:8080", //백엔드
"http://localhost:3000", //프론트엔드

- 배포된 메인페이지 경로
"https://ezcode.my"
```

결과는 다음과같이 옵니다
```java
http://도메인명/callback?
  accessToken=eyJhbGci...&
  refreshToken=eyJhbGci...
```

### 2. 프로필 이미지 등록, 삭제, 업데이트
 **1. 프로필 이미지 등록 & 업데이트**

PUT : `/api/users/profile`

- 프로필 이미지가 없을 때
    - 등록한 사진이 aws로 업데이트되며, DB에는 해당 URL이 저장됩니다.
- 프로필 이미지가 이미 있을 때
    - 기존 이미지는 삭제됩니다
    - 등록한 사진이 새로 DB에 저장됩니다.
- 프로필 이미지는 1장만 등록 가능합니다.
- 만약 DB의 프로필 이미지가 null이라면 기본 이미지(피그마에 있는 기본 프로필 이미지)로 설정됩니다.


**2. 프로필 이미지 삭제 (기본 이미지로 설정)**

DELETE : `/api/users/profile`   
삭제 api를 불러오면 db에 저장되어있던 이미지url은 삭제되고, 기본 이미지로 대체


### 3. 어드민 권한 부여 API
: ADMIN 권한을 가진 유저는 다른 유저에게 ADMIN 권한을 부여할 수 있습니다.

### 4. 어드민 경로 제한
: `/api/admin`으로 시작하는 경로는 어드민 권한을 가진 유저만 접근 가능하도록 변경 (기존에 앞에 api를 빼먹어서 적용이 안됐었음)


---

## 참고 사항

- 테스트코드 작성 필요

---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 프로필 이미지를 업로드, 교체, 삭제할 수 있는 기능이 추가되었습니다.
  * 관리자가 다른 사용자에게 관리자 권한을 부여할 수 있는 기능이 추가되었습니다.

* **버그 수정 및 개선**
  * 비밀번호 재설정 요청 시 필수 입력값 검증 메시지가 추가되었습니다.
  * 관리자 전용 API 경로가 "/api/admin/**"로 변경되었습니다.
  * OAuth2 리디렉션 URI에 대한 유효성 검사가 강화되었습니다.
  * 인증 관련 예외 코드 및 메시지가 추가되었습니다.
  * 보안 경로에 "/oauth/**"가 공개 경로로 포함되었습니다.

* **기타**
  * 일부 내부 로직 및 예외 처리 방식이 개선되었습니다.
  * API 응답 메시지용 DTO가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->