### PR TITLE
refactor : 파일 크기 제한, DB 잔존 데이터 로직 수정

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
@@ -136,6 +136,12 @@ public class ProblemService {
 			for(String fileUrl : findProblem.getImageUrl()) {
 				s3Uploader.delete(fileUrl, "problem");
 			}
+
+			// 문제 엔티티의 imageUrl 컬렉션도 clear
+			findProblem.clearImages();
+
+			// DB에서 연관 이미지 정보 제거 위해 save
+			problemDomainService.saveProblem(findProblem);
 		}
 
 		// Soft Delete
@@ -166,6 +172,7 @@ public class ProblemService {
 				s3Uploader.delete(fileUrl, "problem");
 			}
 			problem.clearImages();
+			problemDomainService.saveProblem(problem);
 		}
 
 		String newImageUrl = uploadImageAfterTransaction(newImage, problem.getId());

--- a/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/service/ProblemDomainService.java
@@ -121,4 +121,8 @@ public class ProblemDomainService {
 		return new ProblemInfo(problem, problem.getTestcases(), categoryNames);
 	}
 
+	// 문제 수정시 문제를 DB 저장 용도
+	public void saveProblem(Problem problem) {
+		problemRepository.save(problem);
+	}
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/s3/S3Uploader.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/s3/S3Uploader.java
@@ -23,6 +23,9 @@ public class S3Uploader {
 
 	private final AmazonS3 amazonS3;
 
+	// 5MB 파일 최대 크기
+	private static final long MAX_FILE_SIZE = 5 * 1024 * 1024;
+
 	@Value("${cloud.aws.s3.bucket}")
 	private String bucket;
 
@@ -33,6 +36,11 @@ public class S3Uploader {
 			String contentType = multipartFile.getContentType();
 			if (contentType == null || !contentType.startsWith("image/")) {
 				throw new S3Exception(S3ExceptionCode.S3_INVALID_FILE_TYPE);
+			}
+
+			// 파일 크기 검사
+			if (multipartFile.getSize() > MAX_FILE_SIZE) {
+				throw new S3Exception(S3ExceptionCode.S3_FILE_TOO_LARGE);
 			}
 
 			// S3 파일명 지정 ( 디렉토리/UUID-원본파일명 )
@@ -79,9 +87,9 @@ public class S3Uploader {
 	}
 
 	// 문제 이미지 URL 가져오기
-	private String extractKeyFromProblemUrl(String fileUrl) {
+	private String extractKeyFromProblemUrl(String problemfileUrl) {
 		// S3 주소 포맷 기준으로 잘라내기
-		return fileUrl.substring(fileUrl.indexOf("problem/"));
+		return problemfileUrl.substring(problemfileUrl.indexOf("problem/"));
 	}
 
 	// 프로필 이미지 URL 가져오기

--- a/src/main/java/org/ezcode/codetest/infrastructure/s3/exception/code/S3ExceptionCode.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/s3/exception/code/S3ExceptionCode.java
@@ -12,7 +12,9 @@ public enum S3ExceptionCode implements ResponseCode {
 
 	S3_UPLOAD_FAILED(false, HttpStatus.INTERNAL_SERVER_ERROR, "S3 이미지 업로드 중 오류가 발생 했습니다."),
 	S3_INVALID_FILE_TYPE(false, HttpStatus.BAD_REQUEST, "이미지 파일만 업로드할 수 있습니다."),
-	S3_DELETE_FAILED(false, HttpStatus.INTERNAL_SERVER_ERROR, "S3 이미지 삭제 중 오류가 발생 했습니다.");
+	S3_DELETE_FAILED(false, HttpStatus.INTERNAL_SERVER_ERROR, "S3 이미지 삭제 중 오류가 발생 했습니다."),
+	S3_FILE_TOO_LARGE(false, HttpStatus.BAD_REQUEST, "파일 크기가 허용 범위를 초과했습니다.");
+
 	private final boolean success;
 
 	private final HttpStatus status;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -142,6 +142,12 @@ cloud.aws.region.static=ap-northeast-2
 cloud.aws.stack.auto=false
 
 # ========================
+# multipart
+# ========================
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=5MB
+
+# ========================
 # AES
 # ========================
 aes.secret.key=${AES_SECRET_KEY}
@@ -150,3 +156,4 @@ aes.secret.key=${AES_SECRET_KEY}
 # git push
 # ========================
 github.repo.root-folder=ezcode
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -142,12 +142,6 @@ cloud.aws.region.static=ap-northeast-2
 cloud.aws.stack.auto=false
 
 # ========================
-# multipart
-# ========================
-spring.servlet.multipart.max-file-size=5MB
-spring.servlet.multipart.max-request-size=5MB
-
-# ========================
 # AES
 # ========================
 aes.secret.key=${AES_SECRET_KEY}


### PR DESCRIPTION
## 작업 내용

- 파일 크기 제한 검사로직 추가 ( 이미지 업로드 )
- 문제 수정, 삭제 시 DB내 데이터 존재하지 않게 로직 추가.

## 변경 사항

---

## 트러블 슈팅

---

## 해결해야 할 문제

---

## 참고 사항

![postman크기제한](https://github.com/user-attachments/assets/d1bcd17d-b584-40f8-874e-d813275a64b7)
postman 내에서 자체적으로 파일 크기를 5MB 크기 제한을 함.

---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이미지 파일 업로드 시 5MB 용량 제한이 적용됩니다. 제한을 초과할 경우 업로드가 차단되고 안내 메시지가 표시됩니다.
  * 문제 정보를 저장하는 새로운 기능이 추가되었습니다.

* **버그 수정**
  * 문제 삭제 및 이미지 변경 시, 연관된 이미지 정보가 데이터베이스에서 확실히 제거되어 저장소와 데이터베이스 상태가 일치하도록 개선되었습니다.

* **설정**
  * 파일 업로드 최대 크기 및 요청 크기 제한이 5MB로 설정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->