### PR TITLE
refactor : 알림 데이터 추가 및 관련 문서 작성

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/community/service/DiscussionVoteService.java
+++ b/src/main/java/org/ezcode/codetest/application/community/service/DiscussionVoteService.java
@@ -49,17 +49,12 @@ public class DiscussionVoteService extends BaseVoteService<DiscussionVote, Discu
 	protected void afterVote(User voter, Long targetId) {
 
 		notificationExecutor.execute(() -> {
+			Discussion discussion = discussionDomainService.getDiscussionById(targetId);
 
-			try {
-				Discussion discussion = discussionDomainService.getDiscussionById(targetId);
+			Optional<NotificationCreateEvent> notificationEvent = voteDomainService.createDiscussionVoteNotification(
+				voter, discussion);
 
-				Optional<NotificationCreateEvent> notificationEvent = voteDomainService.createDiscussionVoteNotification(voter, discussion);
-
-				return notificationEvent.map(List::of).orElse(Collections.emptyList());
-			} catch (Exception ex) {
-				log.error("토론글 추천 알림 생성 중 에러 발생 : {}", ex.getMessage());
-				return Collections.emptyList();
-			}
+			return notificationEvent.map(List::of).orElse(Collections.emptyList());
 		});
 	}
 }

--- a/src/main/java/org/ezcode/codetest/application/community/service/ReplyService.java
+++ b/src/main/java/org/ezcode/codetest/application/community/service/ReplyService.java
@@ -49,20 +49,15 @@ public class ReplyService {
 		Reply reply = replyDomainService.createReply(discussion, user, request.parentReplyId(), request.content());
 
 		notificationExecutor.execute(() -> {
-			try {
-				List<User> notificationTargets = reply.generateNotificationTargets();
+			List<User> notificationTargets = reply.generateNotificationTargets();
 
-				if (notificationTargets.isEmpty()) {
-					return Collections.emptyList();
-				}
-
-				return notificationTargets.stream()
-					.map(target -> replyDomainService.createReplyNotification(target, reply))
-					.toList();
-			} catch (Exception ex) {
-				log.error("댓글 알림 생성 중 에러 발생 : {}", ex.getMessage());
+			if (notificationTargets.isEmpty()) {
 				return Collections.emptyList();
 			}
+
+			return notificationTargets.stream()
+				.map(target -> replyDomainService.createReplyNotification(target, reply))
+				.toList();
 		});
 
 		return ReplyResponse.fromEntity(reply);

--- a/src/main/java/org/ezcode/codetest/application/community/service/ReplyService.java
+++ b/src/main/java/org/ezcode/codetest/application/community/service/ReplyService.java
@@ -48,17 +48,11 @@ public class ReplyService {
 
 		Reply reply = replyDomainService.createReply(discussion, user, request.parentReplyId(), request.content());
 
-		notificationExecutor.execute(() -> {
-			List<User> notificationTargets = reply.generateNotificationTargets();
-
-			if (notificationTargets.isEmpty()) {
-				return Collections.emptyList();
-			}
-
-			return notificationTargets.stream()
+		notificationExecutor.execute(() ->
+			reply.generateNotificationTargets().stream()
 				.map(target -> replyDomainService.createReplyNotification(target, reply))
-				.toList();
-		});
+				.toList()
+		);
 
 		return ReplyResponse.fromEntity(reply);
 	}

--- a/src/main/java/org/ezcode/codetest/application/community/service/ReplyVoteService.java
+++ b/src/main/java/org/ezcode/codetest/application/community/service/ReplyVoteService.java
@@ -50,17 +50,12 @@ public class ReplyVoteService extends BaseVoteService<ReplyVote, ReplyVoteDomain
 	protected void afterVote(User voter, Long targetId) {
 
 		notificationExecutor.execute(() -> {
+			Reply reply = replyDomainService.getReplyById(targetId);
 
-			try {
-				Reply reply = replyDomainService.getReplyById(targetId);
+			Optional<NotificationCreateEvent> notificationEvent = voteDomainService.createReplyVoteNotification(voter,
+				reply);
 
-				Optional<NotificationCreateEvent> notificationEvent = voteDomainService.createReplyVoteNotification(voter, reply);
-
-				return notificationEvent.map(List::of).orElse(Collections.emptyList());
-			} catch (Exception ex) {
-				log.error("댓글 추천 알림 생성 중 에러 발생 : {}", ex.getMessage());
-				return Collections.emptyList();
-			}
+			return notificationEvent.map(List::of).orElse(Collections.emptyList());
 		});
 	}
 }

--- a/src/main/java/org/ezcode/codetest/application/notification/enums/NotificationType.java
+++ b/src/main/java/org/ezcode/codetest/application/notification/enums/NotificationType.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 @Getter
 public enum NotificationType {
 	/* 커뮤니티 */
-	COMMUNITY_REPLY("새로운 댓글이 달렸습니다.", "/problems/{problemId}/discussions/{discussionId}"),
+	COMMUNITY_DISCUSSION_REPLY("작성하신 토론글에 새로운 댓글이 달렸습니다.", "/problems/{problemId}/discussions/{discussionId}"),
+	COMMUNITY_CHILD_REPLY("작성하신 댓글에 새로운 대댓글이 달렸습니다.", "/problems/{problemId}/discussions/{discussionId}"),
 	COMMUNITY_DISCUSSION_VOTED_UP("토론글에 추천을 받았습니다.", "/problems/{problemId}/discussions/{discussionId}"),
 	COMMUNITY_REPLY_VOTED_UP("댓글에 추천을 받았습니다.", "/problems/{problemId}/discussions/{discussionId}/replies/{replyId}"),
 	COMMUNITY_MENTIONED("멘션", ""),

--- a/src/main/java/org/ezcode/codetest/application/notification/event/payload/DiscussionVotePayload.java
+++ b/src/main/java/org/ezcode/codetest/application/notification/event/payload/DiscussionVotePayload.java
@@ -3,6 +3,7 @@ package org.ezcode.codetest.application.notification.event.payload;
 public record DiscussionVotePayload(
 	Long problemId,
 	Long discussionId,
+	Long voterId,
 	String voterNickname
 ) implements NotificationPayload {
 }

--- a/src/main/java/org/ezcode/codetest/application/notification/event/payload/ReplyCreatePayload.java
+++ b/src/main/java/org/ezcode/codetest/application/notification/event/payload/ReplyCreatePayload.java
@@ -2,8 +2,11 @@ package org.ezcode.codetest.application.notification.event.payload;
 
 public record ReplyCreatePayload(
 	Long problemId,
-	Long replyId,
 	Long discussionId,
+	Long replyId,
+	Long parentReplyId,
+	Long authorId,
+	String authorNickname,
 	String content
 ) implements NotificationPayload {
 }

--- a/src/main/java/org/ezcode/codetest/application/notification/event/payload/ReplyVotePayload.java
+++ b/src/main/java/org/ezcode/codetest/application/notification/event/payload/ReplyVotePayload.java
@@ -3,6 +3,7 @@ package org.ezcode.codetest.application.notification.event.payload;
 public record ReplyVotePayload(
 	Long problemId,
 	Long replyId,
+	Long voterId,
 	String voterNickname
 ) implements NotificationPayload {
 }

--- a/src/main/java/org/ezcode/codetest/domain/community/model/entity/Reply.java
+++ b/src/main/java/org/ezcode/codetest/domain/community/model/entity/Reply.java
@@ -93,7 +93,7 @@ public class Reply extends BaseEntity {
 
 	public List<User> generateNotificationTargets() {
 
-		Set<User> targets = new HashSet<>(); 	// 중복 방지를 위해 Set 사용
+		Set<User> targets = new HashSet<>();
 
 		User discussionAuthor = discussion.getUser();
 		User parentAuthor = this.getParentReplyUser();
@@ -107,5 +107,10 @@ public class Reply extends BaseEntity {
 		}
 
 		return new ArrayList<>(targets);
+	}
+
+	public Long getParentReplyId() {
+
+		return this.getParent() != null ? this.getParent().getId() : null;
 	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/community/service/DiscussionVoteDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/community/service/DiscussionVoteDomainService.java
@@ -55,6 +55,7 @@ public class DiscussionVoteDomainService extends BaseVoteDomainService<Discussio
 		DiscussionVotePayload payload = new DiscussionVotePayload(
 			discussion.getProblemId(),
 			discussion.getId(),
+			voter.getId(),
 			voter.getNickname()
 		);
 

--- a/src/main/java/org/ezcode/codetest/domain/community/service/ReplyDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/community/service/ReplyDomainService.java
@@ -107,16 +107,24 @@ public class ReplyDomainService {
 
 	public NotificationCreateEvent createReplyNotification(User target, Reply reply) {
 
+		Long parentReplyId = reply.getParentReplyId();
+		User author = reply.getUser();
+
 		ReplyCreatePayload payload = new ReplyCreatePayload(
 			reply.getProblemId(),
-			reply.getId(),
 			reply.getDiscussionId(),
+			reply.getId(),
+			parentReplyId,
+			author.getId(),
+			author.getNickname(),
 			reply.getContent()
 		);
 
 		return NotificationCreateEvent.of(
 			target.getEmail(),
-			NotificationType.COMMUNITY_REPLY,
+			parentReplyId == null
+				? NotificationType.COMMUNITY_DISCUSSION_REPLY
+				: NotificationType.COMMUNITY_CHILD_REPLY,
 			payload
 		);
 	}

--- a/src/main/java/org/ezcode/codetest/domain/community/service/ReplyVoteDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/community/service/ReplyVoteDomainService.java
@@ -60,6 +60,7 @@ public class ReplyVoteDomainService extends BaseVoteDomainService<ReplyVote, Rep
 		ReplyVotePayload payload = new ReplyVotePayload(
 			reply.getProblemId(),
 			reply.getId(),
+			voter.getId(),
 			voter.getNickname()
 		);
 

--- a/src/main/java/org/ezcode/codetest/infrastructure/notification/dto/NotificationResponse.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/notification/dto/NotificationResponse.java
@@ -12,6 +12,10 @@ public record NotificationResponse(
 
 	NotificationType notificationType,
 
+	String message,
+
+	String redirectUrl,
+
 	NotificationPayload payload,
 
 	boolean isRead,
@@ -25,6 +29,8 @@ public record NotificationResponse(
 		return new NotificationResponse(
 			document.getId(),
 			document.getNotificationType(),
+			document.getNotificationType().getMessage(),
+			document.getNotificationType().getRedirectUrl(),
 			document.getPayload(),
 			document.isRead(),
 			document.getCreatedAt()

--- a/src/main/java/org/ezcode/codetest/presentation/notification/NotificationController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/notification/NotificationController.java
@@ -30,7 +30,16 @@ public class NotificationController {
 
 	@Operation(
 		summary = "알림 목록 조회",
-		description = "현재 사용자(authUser)의 알림을 페이징하여 조회 요청을 보냅니다.",
+		description = """
+			현재 사용자(authUser)의 알림을 페이징하여 조회 요청을 보냅니다.
+			해당 API는 요청만 날릴 뿐 실제 알림 데이터는 웹소켓을 통해 전달 받습니다.
+			웹소켓 구독 경로는 다음과 같습니다.
+			
+			- 신규 알림 : /user/queue/notification
+			- 알림 목록 : /user/queue/notifications
+			
+			자세한 내용은 다음 [링크](https://www.notion.so/teamsparta/1-5-2002dc3ef51481e7afbec86e90d0010e?p=2232dc3ef51480638fd9eecc3b90a0fc&pm=s) 참고
+			""",
 		parameters = {
 			@Parameter(name = "pageable", description = "페이징 정보 (page, size, sort)")
 		}


### PR DESCRIPTION
## 작업 내용

- swagger에 알림 관련 설명 추가 및 링크 첨부
  - 데이터 사용 용도와 실제 예시 데이터 등이 작성되어 있음
- 알림 데이터 추가
  - 알림에 필요한 데이터들을 추가로 삽입함

---

## 참고 사항

- [관련 문서](https://www.notion.so/teamsparta/2232dc3ef51480638fd9eecc3b90a0fc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 알림 응답에 메시지와 리다이렉트 URL 정보가 추가되었습니다.
  * 답글 엔티티에 부모 답글 ID를 조회할 수 있는 기능이 추가되었습니다.

* **Enhancements**
  * 알림 타입이 기존 단일 답글 알림에서, 게시글 답글 알림과 대댓글 알림으로 세분화되었습니다.
  * 알림 관련 페이로드에 작성자, 부모 답글, 투표자 등 더 많은 정보가 포함되어 알림의 상세도가 향상되었습니다.

* **Documentation**
  * 알림 목록 조회 API의 Swagger/OpenAPI 설명이 더욱 상세하게 보완되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->