### PR TITLE
fix: 타이밍 문제로 init 받아지지 않는 문제 해결

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/submission/service/SubmissionService.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/service/SubmissionService.java
@@ -1,13 +1,9 @@
 package org.ezcode.codetest.application.submission.service;
 
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.ezcode.codetest.application.submission.aop.CodeReviewLock;
-import org.ezcode.codetest.application.submission.dto.event.TestcaseListInitializedEvent;
-import org.ezcode.codetest.application.submission.dto.event.payload.InitTestcaseListPayload;
 import org.ezcode.codetest.application.submission.dto.request.review.CodeReviewRequest;
 import org.ezcode.codetest.application.submission.dto.request.review.ReviewPayload;
 import org.ezcode.codetest.application.submission.dto.response.review.CodeReviewResponse;
@@ -17,7 +13,6 @@ import org.ezcode.codetest.application.submission.model.SubmissionContext;
 import org.ezcode.codetest.application.submission.port.ExceptionNotifier;
 import org.ezcode.codetest.application.submission.port.LockManager;
 import org.ezcode.codetest.application.submission.port.QueueProducer;
-import org.ezcode.codetest.domain.problem.model.entity.Testcase;
 import org.ezcode.codetest.domain.submission.exception.SubmissionException;
 import org.ezcode.codetest.domain.submission.exception.code.SubmissionExceptionCode;
 import org.ezcode.codetest.infrastructure.event.dto.submission.SubmissionMessage;
@@ -33,7 +28,6 @@ import org.ezcode.codetest.domain.submission.service.SubmissionDomainService;
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.ezcode.codetest.domain.user.model.entity.User;
 import org.ezcode.codetest.domain.user.service.UserDomainService;
-import org.ezcode.codetest.infrastructure.event.dto.submission.response.InitTestcaseListResponse;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -78,7 +72,6 @@ public class SubmissionService {
         try {
             log.info("[Submission RUN] Thread = {}", Thread.currentThread().getName());
             log.info("[큐 수신] SubmissionMessage.sessionKey: {}", msg.sessionKey());
-
             SubmissionContext ctx = createSubmissionContext(msg);
             judgementService.publishInitTestcases(ctx);
             judgementService.runTestcases(ctx);

--- a/src/main/java/org/ezcode/codetest/infrastructure/event/listener/RedisJudgeQueueConsumer.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/event/listener/RedisJudgeQueueConsumer.java
@@ -36,6 +36,7 @@ public class RedisJudgeQueueConsumer implements StreamListener<String, MapRecord
 
         try {
             log.info("[컨슈머 수신] {}", msg.sessionKey());
+            Thread.sleep(6000);
             submissionService.processSubmissionAsync(msg);
 
             log.info("[컨슈머 ACK] messageId={}", message.getId());

--- a/src/main/java/org/ezcode/codetest/infrastructure/event/publisher/StompMessageService.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/event/publisher/StompMessageService.java
@@ -9,17 +9,14 @@ import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessageType;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class StompMessageService {
@@ -65,6 +62,7 @@ public class StompMessageService {
         String principalName,
         List<InitTestcaseListResponse> dataList
     ) {
+        log.info("init 발행");
         messagingTemplate.convertAndSendToUser(
             principalName,
             SUBMISSION_DEST_PREFIX.formatted(sessionKey) + "/init",
@@ -77,6 +75,7 @@ public class StompMessageService {
         String principalName,
         JudgeResultResponse data
     ) {
+        log.info("case 발행");
         messagingTemplate.convertAndSendToUser(
             principalName,
             SUBMISSION_DEST_PREFIX.formatted(sessionKey) + "/case",
@@ -89,6 +88,7 @@ public class StompMessageService {
         String principalName,
         SubmissionFinalResultResponse data
     ) {
+        log.info("final 발행");
         messagingTemplate.convertAndSendToUser(
             principalName,
             SUBMISSION_DEST_PREFIX.formatted(sessionKey) + "/final",


### PR DESCRIPTION
일단 임시방편으로 thread.sleep 6초 걸어뒀습니다.
이러니 init이 유실 안 되네요.. 더 나은 방법을 찾아야할 거 같습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 메시지 발행 시 각 단계(init, case, final)에 대한 정보성 로그가 추가되었습니다.

* **버그 수정**
  * 불필요한 공백 및 사용되지 않는 import 문이 제거되었습니다.

* **기타**
  * 메시지 처리 시 6초의 대기 시간이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->