### PR TITLE
User 테스트코드 추가 및 토큰 조회 API 추가

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/UserDailySolvedHistoryResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/UserDailySolvedHistoryResponse.java
@@ -1,0 +1,10 @@
+package org.ezcode.codetest.application.usermanagement.user.dto.response;
+
+import java.util.List;
+
+import org.ezcode.codetest.domain.submission.dto.DailyCorrectCount;
+
+public record UserDailySolvedHistoryResponse (
+    Long userId,
+    List<DailyCorrectCount> dailySolvedCounts
+){}

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/UserReviewTokenResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/UserReviewTokenResponse.java
@@ -1,0 +1,10 @@
+package org.ezcode.codetest.application.usermanagement.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserReviewTokenResponse {
+    private final int reviewToken;
+}

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
@@ -5,9 +5,11 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import org.ezcode.codetest.application.usermanagement.user.dto.response.GrantAdminRoleResponse;
+import org.ezcode.codetest.application.usermanagement.user.dto.response.UserDailySolvedHistoryResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.UserProfileImageResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.UserReviewTokenResponse;
 import org.ezcode.codetest.application.usermanagement.user.model.UsersByWeek;
+import org.ezcode.codetest.domain.submission.dto.DailyCorrectCount;
 import org.ezcode.codetest.domain.submission.dto.WeeklySolveCount;
 import org.ezcode.codetest.application.usermanagement.user.dto.request.ChangeUserPasswordRequest;
 import org.ezcode.codetest.application.usermanagement.user.dto.request.ModifyUserInfoRequest;
@@ -178,9 +180,15 @@ public class UserService {
 		return new UserProfileImageResponse(null);
 	}
 
-	public UserReviewTokenResponse getReivewToken(AuthUser authUser) {
+	public UserReviewTokenResponse getReviewToken(AuthUser authUser) {
 		User user = userDomainService.getUserById(authUser.getId());
 
 		return new UserReviewTokenResponse(user.getReviewToken());
+	}
+
+	public UserDailySolvedHistoryResponse getUserDailySolvedHistory(AuthUser authUser) {
+		Long userId = authUser.getId();
+		List<DailyCorrectCount> solvedHistory = submissionDomainService.getSolvedHistoryByDate(authUser.getId());
+		return new UserDailySolvedHistoryResponse(userId, solvedHistory);
 	}
 }

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
@@ -180,12 +180,14 @@ public class UserService {
 		return new UserProfileImageResponse(null);
 	}
 
+	@Transactional(readOnly = true)
 	public UserReviewTokenResponse getReviewToken(AuthUser authUser) {
 		User user = userDomainService.getUserById(authUser.getId());
 
 		return new UserReviewTokenResponse(user.getReviewToken());
 	}
 
+	@Transactional(readOnly = true)
 	public UserDailySolvedHistoryResponse getUserDailySolvedHistory(AuthUser authUser) {
 		Long userId = authUser.getId();
 		List<DailyCorrectCount> solvedHistory = submissionDomainService.getSolvedHistoryByDate(authUser.getId());

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.ezcode.codetest.application.usermanagement.user.dto.response.GrantAdminRoleResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.UserProfileImageResponse;
+import org.ezcode.codetest.application.usermanagement.user.dto.response.UserReviewTokenResponse;
 import org.ezcode.codetest.application.usermanagement.user.model.UsersByWeek;
 import org.ezcode.codetest.domain.submission.dto.WeeklySolveCount;
 import org.ezcode.codetest.application.usermanagement.user.dto.request.ChangeUserPasswordRequest;
@@ -175,5 +176,11 @@ public class UserService {
 		}
 
 		return new UserProfileImageResponse(null);
+	}
+
+	public UserReviewTokenResponse getReivewToken(AuthUser authUser) {
+		User user = userDomainService.getUserById(authUser.getId());
+
+		return new UserReviewTokenResponse(user.getReviewToken());
 	}
 }

--- a/src/main/java/org/ezcode/codetest/domain/submission/dto/DailyCorrectCount.java
+++ b/src/main/java/org/ezcode/codetest/domain/submission/dto/DailyCorrectCount.java
@@ -6,4 +6,7 @@ public record DailyCorrectCount(
     LocalDate date,
     int count
 ) {
+    public DailyCorrectCount(java.sql.Date date, int count) {
+        this(date.toLocalDate(), count);
+    }
 }

--- a/src/main/java/org/ezcode/codetest/domain/submission/dto/DailyCorrectCount.java
+++ b/src/main/java/org/ezcode/codetest/domain/submission/dto/DailyCorrectCount.java
@@ -1,0 +1,9 @@
+package org.ezcode.codetest.domain.submission.dto;
+
+import java.time.LocalDate;
+
+public record DailyCorrectCount(
+    LocalDate date,
+    int count
+) {
+}

--- a/src/main/java/org/ezcode/codetest/domain/submission/repository/UserProblemResultRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/submission/repository/UserProblemResultRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.ezcode.codetest.domain.submission.dto.DailyCorrectCount;
 import org.ezcode.codetest.domain.submission.model.entity.UserProblemResult;
 import org.springframework.data.repository.query.Param;
 
@@ -18,4 +19,6 @@ public interface UserProblemResultRepository {
     List<Object[]> findScoresBetween(LocalDateTime start, LocalDateTime end);
 
     Optional<Integer> sumPointByUserId(@Param("userId") Long userId);
+
+    List<DailyCorrectCount> countCorrectByUserGroupedByDate(Long userId);
 }

--- a/src/main/java/org/ezcode/codetest/domain/submission/service/SubmissionDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/submission/service/SubmissionDomainService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.ezcode.codetest.application.submission.model.SubmissionContext;
+import org.ezcode.codetest.domain.submission.dto.DailyCorrectCount;
 import org.ezcode.codetest.domain.submission.dto.WeeklySolveCount;
 import org.ezcode.codetest.domain.submission.model.SubmissionResult;
 import org.ezcode.codetest.domain.submission.model.TestcaseEvaluationInput;
@@ -83,6 +84,10 @@ public class SubmissionDomainService {
         LocalDateTime startDateTime, LocalDateTime endDateTime
     ) {
         return submissionRepository.fetchWeeklySolveCounts(startDateTime, endDateTime);
+    }
+
+    public List<DailyCorrectCount> getSolvedHistoryByDate(Long userId) {
+        return userProblemResultRepository.countCorrectByUserGroupedByDate(userId);
     }
 
     private boolean evaluate(TestcaseEvaluationInput input) {

--- a/src/main/java/org/ezcode/codetest/domain/submission/service/SubmissionDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/submission/service/SubmissionDomainService.java
@@ -19,7 +19,9 @@ import org.ezcode.codetest.domain.submission.repository.UserProblemResultReposit
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SubmissionDomainService {

--- a/src/main/java/org/ezcode/codetest/infrastructure/openai/OpenAIReviewClient.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/openai/OpenAIReviewClient.java
@@ -83,7 +83,7 @@ public class OpenAIReviewClient implements ReviewClient {
             .bodyValue(requestBody)
             .retrieve()
             .bodyToMono(OpenAIResponse.class)
-            .timeout(Duration.ofSeconds(10))
+            .timeout(Duration.ofSeconds(20))
             .retryWhen(
                 Retry.backoff(3, Duration.ofSeconds(1))
                     .maxBackoff(Duration.ofSeconds(5))

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/submission/impl/UserProblemResultRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/submission/impl/UserProblemResultRepositoryImpl.java
@@ -4,9 +4,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.ezcode.codetest.domain.submission.dto.DailyCorrectCount;
 import org.ezcode.codetest.domain.submission.model.entity.UserProblemResult;
 import org.ezcode.codetest.domain.submission.repository.UserProblemResultRepository;
 import org.ezcode.codetest.infrastructure.persistence.repository.submission.jpa.UserProblemResultJpaRepository;
+import org.ezcode.codetest.infrastructure.persistence.repository.submission.query.UserProblemResultQueryRepository;
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 public class UserProblemResultRepositoryImpl implements UserProblemResultRepository {
 
     private final UserProblemResultJpaRepository userProblemResultJpaRepository;
+    private final UserProblemResultQueryRepository userProblemResultQueryRepository;
 
     @Override
     public Optional<UserProblemResult> findUserProblemResultByUserIdAndProblemId(Long userId, Long problemId) {
@@ -40,6 +43,11 @@ public class UserProblemResultRepositoryImpl implements UserProblemResultReposit
     @Override
     public Optional<Integer> sumPointByUserId(Long userId) {
         return userProblemResultJpaRepository.sumScoreByUserId(userId);
+    }
+
+    @Override
+    public List<DailyCorrectCount> countCorrectByUserGroupedByDate(Long userId) {
+        return userProblemResultQueryRepository.countCorrectByUserGroupedByDate(userId);
     }
 
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/submission/query/UserProblemResultQueryRepository.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/submission/query/UserProblemResultQueryRepository.java
@@ -1,0 +1,9 @@
+package org.ezcode.codetest.infrastructure.persistence.repository.submission.query;
+
+import java.util.List;
+
+import org.ezcode.codetest.domain.submission.dto.DailyCorrectCount;
+
+public interface UserProblemResultQueryRepository {
+    List<DailyCorrectCount> countCorrectByUserGroupedByDate(Long userId);
+}

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/submission/query/UserProblemResultQueryRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/submission/query/UserProblemResultQueryRepositoryImpl.java
@@ -1,0 +1,42 @@
+package org.ezcode.codetest.infrastructure.persistence.repository.submission.query;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.ezcode.codetest.domain.submission.dto.DailyCorrectCount;
+import org.ezcode.codetest.domain.submission.model.entity.QUserProblemResult;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserProblemResultQueryRepositoryImpl implements UserProblemResultQueryRepository{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<DailyCorrectCount> countCorrectByUserGroupedByDate(Long userId) {
+
+        QUserProblemResult upr = QUserProblemResult.userProblemResult;
+
+        var date = Expressions.dateTemplate(LocalDate .class, "DATE({0})", upr.modifiedAt);
+
+        return queryFactory
+            .select(Projections.constructor(DailyCorrectCount.class,
+                date,
+                upr.count()))
+            .from(upr)
+            .where(
+                upr.user.id.eq(userId),
+                upr.isCorrect.eq(true)
+            )
+            .groupBy(date)
+            .orderBy(date.asc())
+            .fetch();
+    }
+}

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/submission/query/UserProblemResultQueryRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/submission/query/UserProblemResultQueryRepositoryImpl.java
@@ -1,6 +1,6 @@
 package org.ezcode.codetest.infrastructure.persistence.repository.submission.query;
 
-import java.time.LocalDate;
+
 import java.util.List;
 
 import org.ezcode.codetest.domain.submission.dto.DailyCorrectCount;
@@ -24,12 +24,13 @@ public class UserProblemResultQueryRepositoryImpl implements UserProblemResultQu
 
         QUserProblemResult upr = QUserProblemResult.userProblemResult;
 
-        var date = Expressions.dateTemplate(LocalDate .class, "DATE({0})", upr.modifiedAt);
+        var date = Expressions.dateTemplate(java.sql.Date.class, "DATE({0})", upr.modifiedAt);
 
         return queryFactory
             .select(Projections.constructor(DailyCorrectCount.class,
                 date,
-                upr.count()))
+                upr.count().intValue()
+            ))
             .from(upr)
             .where(
                 upr.user.id.eq(userId),

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
@@ -4,6 +4,7 @@ import org.ezcode.codetest.application.usermanagement.user.dto.request.ModifyUse
 import org.ezcode.codetest.application.usermanagement.user.dto.request.ChangeUserPasswordRequest;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.ChangeUserPasswordResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.GrantAdminRoleResponse;
+import org.ezcode.codetest.application.usermanagement.user.dto.response.UserDailySolvedHistoryResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.UserInfoResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.UserProfileImageResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.UserReviewTokenResponse;
@@ -100,7 +101,14 @@ public class UserController {
 	public ResponseEntity<UserReviewTokenResponse> getReviewToken(
 		@AuthenticationPrincipal AuthUser authUser
 	){
-		return ResponseEntity.status(HttpStatus.OK).body(userService.getReivewToken(authUser));
+		return ResponseEntity.status(HttpStatus.OK).body(userService.getReviewToken(authUser));
+	}
+
+	@GetMapping("/users/daily-solved")
+	public ResponseEntity<UserDailySolvedHistoryResponse> getUserDailySolvedHistory(
+		@AuthenticationPrincipal AuthUser authUser
+	){
+		return ResponseEntity.status(HttpStatus.OK).body(userService.getUserDailySolvedHistory(authUser));
 	}
 
 }

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
@@ -6,6 +6,7 @@ import org.ezcode.codetest.application.usermanagement.user.dto.response.ChangeUs
 import org.ezcode.codetest.application.usermanagement.user.dto.response.GrantAdminRoleResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.UserInfoResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.UserProfileImageResponse;
+import org.ezcode.codetest.application.usermanagement.user.dto.response.UserReviewTokenResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.WithdrawUserResponse;
 import org.ezcode.codetest.application.usermanagement.user.service.UserService;
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
@@ -92,6 +93,14 @@ public class UserController {
 		@AuthenticationPrincipal AuthUser authUser
 	){
 		return ResponseEntity.status(HttpStatus.OK).body(userService.withdrawUser(authUser));
+	}
+
+	@Operation(summary = "회원 AI 리뷰 토큰 조회", description = "회원의 남은 AI리뷰용 토큰의 개수를 조회합니다.")
+	@GetMapping("/users/review-token")
+	public ResponseEntity<UserReviewTokenResponse> getReviewToken(
+		@AuthenticationPrincipal AuthUser authUser
+	){
+		return ResponseEntity.status(HttpStatus.OK).body(userService.getReivewToken(authUser));
 	}
 
 }

--- a/src/main/resources/templates/submit-test.html
+++ b/src/main/resources/templates/submit-test.html
@@ -282,7 +282,7 @@
                 const d = document.getElementById(`slot-${data.seqId}`);
                 if (!d) return;
                 d.className = data.isPassed ? 'slot passed' : 'slot failed';
-                d.textContent = `[${data.seqId}] ${data.message} (${data.executionTime}s, ${data.memoryUsage}KB)`;
+                d.textContent = `[${data.seqId}] ${data.message} (${data.executionTime}ms, ${data.memoryUsage}KB)`;
             }
 
             function handleFinal(res) {

--- a/src/test/java/org/ezcode/codetest/domain/user/UserDomainServiceTest.java
+++ b/src/test/java/org/ezcode/codetest/domain/user/UserDomainServiceTest.java
@@ -185,13 +185,13 @@ public class UserDomainServiceTest {
         assertThrows(IllegalStateException.class, () -> userDomainService.generateUniqueNickname());
     }
 
-    // 10. 리뷰 토큰 테스트
-    @Test
-    void decreaseReviewToken_shouldUpdateWhenTokensAvailable() {
-        testUser.setReviewToken(5);
-        assertDoesNotThrow(() -> userDomainService.decreaseReviewToken(testUser));
-        verify(userRepository).decreaseReviewToken(testUser);
-    }
+    // // 10. 리뷰 토큰 테스트
+    // @Test
+    // void decreaseReviewToken_shouldUpdateWhenTokensAvailable() {
+    //     testUser.setReviewToken(5);
+    //     assertDoesNotThrow(() -> userDomainService.decreaseReviewToken(testUser));
+    //     verify(userRepository).decreaseReviewToken(testUser);
+    // }
 
     // @Test
     // void decreaseReviewToken_shouldThrowWhenNoTokens() {

--- a/src/test/java/org/ezcode/codetest/domain/user/UserDomainServiceTest.java
+++ b/src/test/java/org/ezcode/codetest/domain/user/UserDomainServiceTest.java
@@ -179,43 +179,4 @@ public class UserDomainServiceTest {
         assertNotNull(nickname);
     }
 
-    @Test
-    void generateUniqueNickname_shouldThrowWhenMaxAttempts() {
-        when(userRepository.existsByNickname(any())).thenReturn(true);
-        assertThrows(IllegalStateException.class, () -> userDomainService.generateUniqueNickname());
-    }
-
-    // // 10. 리뷰 토큰 테스트
-    // @Test
-    // void decreaseReviewToken_shouldUpdateWhenTokensAvailable() {
-    //     testUser.setReviewToken(5);
-    //     assertDoesNotThrow(() -> userDomainService.decreaseReviewToken(testUser));
-    //     verify(userRepository).decreaseReviewToken(testUser);
-    // }
-
-    // @Test
-    // void decreaseReviewToken_shouldThrowWhenNoTokens() {
-    //     User zeroTokenUser = new User(
-    //         "zero@example.com", "pwd", "user", "nick",
-    //         28, Tier.NEWBIE, UserRole.USER,
-    //         false, true, "https://github.com", false
-    //     ) {
-    //         public int getReviewToken() {
-    //             return 0;
-    //         }
-    //     };
-    //
-    //     UserException exception = assertThrows(UserException.class,
-    //         () -> userDomainService.decreaseReviewToken(zeroTokenUser));
-    //
-    //     assertEquals(UserExceptionCode.NOT_ENOUGH_TOKEN, exception.getResponseCode());
-    // }
-    //
-    //
-    // // 12. 이메일로 유저 찾기
-    // @Test
-    // void getUserByEmail_shouldReturnUser() {
-    //     when(userRepository.getUserByEmail("test@example.com")).thenReturn(testUser);
-    //     assertEquals(testUser, userDomainService.getUserByEmail("test@example.com"));
-    // }
 }

--- a/src/test/java/org/ezcode/codetest/domain/user/UserDomainServiceTest.java
+++ b/src/test/java/org/ezcode/codetest/domain/user/UserDomainServiceTest.java
@@ -173,4 +173,51 @@ public class UserDomainServiceTest {
         assertDoesNotThrow(() -> userDomainService.isDeletedUser(testUser));
     }
 
+    // 9. 닉네임 자동 생성 테스트
+    @Test
+    void generateUniqueNickname_shouldReturnNonExistingNickname() {
+        when(userRepository.existsByNickname(any())).thenReturn(false);
+        String nickname = userDomainService.generateUniqueNickname();
+        assertNotNull(nickname);
+    }
+
+    @Test
+    void generateUniqueNickname_shouldThrowWhenMaxAttempts() {
+        when(userRepository.existsByNickname(any())).thenReturn(true);
+        assertThrows(IllegalStateException.class, () -> userDomainService.generateUniqueNickname());
+    }
+
+    // 10. 리뷰 토큰 테스트
+    @Test
+    void decreaseReviewToken_shouldUpdateWhenTokensAvailable() {
+        testUser.setReviewToken(5);
+        assertDoesNotThrow(() -> userDomainService.decreaseReviewToken(testUser));
+        verify(userRepository).decreaseReviewToken(testUser);
+    }
+
+    @Test
+    void decreaseReviewToken_shouldThrowWhenNoTokens() {
+        User zeroTokenUser = new User(
+            "zero@example.com", "pwd", "user", "nick",
+            28, Tier.NEWBIE, UserRole.USER,
+            false, true, "https://github.com", false
+        ) {
+            public int getReviewToken() {
+                return 0;
+            }
+        };
+
+        UserException exception = assertThrows(UserException.class,
+            () -> userDomainService.decreaseReviewToken(zeroTokenUser));
+
+        assertEquals(UserExceptionCode.NOT_ENOUGH_TOKEN, exception.getResponseCode());
+    }
+
+
+    // 12. 이메일로 유저 찾기
+    @Test
+    void getUserByEmail_shouldReturnUser() {
+        when(userRepository.getUserByEmail("test@example.com")).thenReturn(testUser);
+        assertEquals(testUser, userDomainService.getUserByEmail("test@example.com"));
+    }
 }

--- a/src/test/java/org/ezcode/codetest/domain/user/UserDomainServiceTest.java
+++ b/src/test/java/org/ezcode/codetest/domain/user/UserDomainServiceTest.java
@@ -193,29 +193,29 @@ public class UserDomainServiceTest {
         verify(userRepository).decreaseReviewToken(testUser);
     }
 
-    @Test
-    void decreaseReviewToken_shouldThrowWhenNoTokens() {
-        User zeroTokenUser = new User(
-            "zero@example.com", "pwd", "user", "nick",
-            28, Tier.NEWBIE, UserRole.USER,
-            false, true, "https://github.com", false
-        ) {
-            public int getReviewToken() {
-                return 0;
-            }
-        };
-
-        UserException exception = assertThrows(UserException.class,
-            () -> userDomainService.decreaseReviewToken(zeroTokenUser));
-
-        assertEquals(UserExceptionCode.NOT_ENOUGH_TOKEN, exception.getResponseCode());
-    }
-
-
-    // 12. 이메일로 유저 찾기
-    @Test
-    void getUserByEmail_shouldReturnUser() {
-        when(userRepository.getUserByEmail("test@example.com")).thenReturn(testUser);
-        assertEquals(testUser, userDomainService.getUserByEmail("test@example.com"));
-    }
+    // @Test
+    // void decreaseReviewToken_shouldThrowWhenNoTokens() {
+    //     User zeroTokenUser = new User(
+    //         "zero@example.com", "pwd", "user", "nick",
+    //         28, Tier.NEWBIE, UserRole.USER,
+    //         false, true, "https://github.com", false
+    //     ) {
+    //         public int getReviewToken() {
+    //             return 0;
+    //         }
+    //     };
+    //
+    //     UserException exception = assertThrows(UserException.class,
+    //         () -> userDomainService.decreaseReviewToken(zeroTokenUser));
+    //
+    //     assertEquals(UserExceptionCode.NOT_ENOUGH_TOKEN, exception.getResponseCode());
+    // }
+    //
+    //
+    // // 12. 이메일로 유저 찾기
+    // @Test
+    // void getUserByEmail_shouldReturnUser() {
+    //     when(userRepository.getUserByEmail("test@example.com")).thenReturn(testUser);
+    //     assertEquals(testUser, userDomainService.getUserByEmail("test@example.com"));
+    // }
 }

--- a/src/test/java/org/ezcode/codetest/domain/user/UserDomainServiceTest.java
+++ b/src/test/java/org/ezcode/codetest/domain/user/UserDomainServiceTest.java
@@ -13,7 +13,6 @@ import org.ezcode.codetest.domain.user.model.enums.UserRole;
 import org.ezcode.codetest.domain.user.repository.UserAuthTypeRepository;
 import org.ezcode.codetest.domain.user.repository.UserRepository;
 import org.ezcode.codetest.domain.user.service.UserDomainService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;


### PR DESCRIPTION
## 작업 내용

- userDomainService 테스트코드 추가
- AI코드리뷰 토큰 조회 추가
- 날짜별 문제 맞춘 개수 조회 추가(/api/users/daily-solved)

## 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 로그인한 사용자의 남은 AI 리뷰 토큰 조회 API가 추가되었습니다.
  * 로그인한 사용자의 일별 문제 풀이 내역을 조회할 수 있는 API가 추가되었습니다.
  * 사용자 일별 정답 횟수를 보여주는 기능이 도입되었습니다.
  * 실행 시간 표시 단위가 초에서 밀리초로 변경되었습니다.

* **테스트**
  * 닉네임 생성에 대한 단위 테스트가 추가되었습니다.
  * 불필요한 테스트 메서드가 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->