### PR TITLE
feat : 0점인 유저도 랭킹 조회 가능

### DIFF
--- a/src/main/java/org/ezcode/codetest/infrastructure/ranking/redis/RedisRankingService.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/ranking/redis/RedisRankingService.java
@@ -68,8 +68,51 @@ public class RedisRankingService {
 
     public List<TargetRankingResponse> getRanking(String key, Long userId) {
         Long myRank = redisTemplate.opsForZSet().reverseRank(key, userId.toString());
-        if (myRank == null) return List.of();
 
+        // 랭킹에 없을 경우
+        if (myRank == null) {
+            long total = Optional.ofNullable(redisTemplate.opsForZSet().zCard(key)).orElse(0L);
+
+            // 점수 있는 가장 꼴찌 유저 조회
+            Set<ZSetOperations.TypedTuple<String>> lastOneSet = redisTemplate.opsForZSet()
+                    .rangeWithScores(key, 0, 0); // 정방향 range로 가장 낮은 점수 유저
+            List<TargetRankingResponse> result = new ArrayList<>();
+
+            if (lastOneSet != null && !lastOneSet.isEmpty()) {
+                ZSetOperations.TypedTuple<String> last = lastOneSet.iterator().next();
+                Long lastUserId = Long.parseLong(last.getValue());
+                int lastScore = last.getScore().intValue();
+                String lastNickname = userJpaRepository.findById(lastUserId)
+                        .map(u -> u.getNickname())
+                        .orElse("알 수 없음");
+
+                Long lastUserRank = redisTemplate.opsForZSet().reverseRank(key, last.getValue());
+                result.add(new TargetRankingResponse(
+                        lastUserId,
+                        lastNickname,
+                        lastUserRank != null ? lastUserRank.intValue() + 1 : -1,
+                        lastScore,
+                        false
+                ));
+            }
+
+            // 0점인 본인 유저 추가
+            String myNickname = userJpaRepository.findById(userId)
+                    .map(u -> u.getNickname())
+                    .orElse("알 수 없음");
+
+            result.add(new TargetRankingResponse(
+                    userId,
+                    myNickname,
+                    (int) total + 1,
+                    0,
+                    true
+            ));
+
+            return result;
+        }
+
+        // 내가 랭킹 안에 있는 경우: 위 1명, 나, 아래 1명 조회
         long start = Math.max(0, myRank - 1);
         long end = myRank + 1;
 
@@ -99,5 +142,6 @@ public class RedisRankingService {
             );
         }).sorted(Comparator.comparingInt(TargetRankingResponse::ranks)).toList();
     }
+
 
 }


### PR DESCRIPTION
---

## 작업 내용

- 어떤 기능(또는 수정 사항)을 구현했는지 간략하게 설명해주세요.
- 예) "회원가입 API에 이메일 중복 검사 기능 추가"

---

## 변경 사항

- 구현한 주요 로직, 클래스, 메서드 등을 bullet 형식으로 기술해주세요.
- 예)
    - `UserService.createUser()` 메서드 추가
    - `@Email` 유효성 검증 적용

---

## 트러블 슈팅

- 구현 중 마주한 문제와 해결 방법을 기술해주세요.
- 예)
    - 문제: `@Transactional`이 적용되지 않음
    - 해결: 메서드 호출 방식 변경 (`this.` → `AopProxyUtils.` 사용)

---

## 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.
- 예)D
    - `UserController`에서 비즈니스 로직 일부 처리 → 서비스로 이전 고려 필요

---

## 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 랭킹에 존재하지 않는 사용자가 조회될 때, 최하위 랭커와 해당 사용자를 함께 보여주도록 개선되었습니다. 이제 랭킹에 없는 사용자는 최하위 랭커 바로 아래에 0점으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->