### PR TITLE
refactor : 문제 이미지만 수정 로직, UI 부분 추가

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/problem/dto/response/ProblemDetailResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/dto/response/ProblemDetailResponse.java
@@ -48,7 +48,10 @@ public record ProblemDetailResponse(
 	LocalDateTime createdAt,
 
 	@Schema(description = "수정일", example = "2025-06-11 08:12:43.506032")
-	LocalDateTime modifiedAt
+	LocalDateTime modifiedAt,
+
+	@Schema(description = "문제 이미지 URL", example = "https://bucket.s3.ap-northeast-2.amazonaws.com/problem/example.jpg")
+	String imageUrl
 
 ) {
 
@@ -67,6 +70,7 @@ public record ProblemDetailResponse(
 			.reference(problem.getReference())
 			.createdAt(problem.getCreatedAt())
 			.modifiedAt(problem.getModifiedAt())
+			.imageUrl(problem.getImageUrl().isEmpty() ? null : problem.getImageUrl().get(0))
 			.build();
 	}
 }

--- a/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
+++ b/src/main/java/org/ezcode/codetest/application/problem/service/ProblemService.java
@@ -178,5 +178,20 @@ public class ProblemService {
 		String newImageUrl = uploadImageAfterTransaction(newImage, problem.getId());
 		problem.addImage(newImageUrl);
 	}
+
+	@Transactional
+	public void addImageToExistingProblem(Long problemId, MultipartFile imageFile) {
+		Problem problem = problemDomainService.getProblem(problemId);
+
+		// 1. S3 업로드
+		String key = s3Uploader.upload(imageFile, "problem");
+
+		// 2. 문제에 이미지 연결
+		problem.addImage(key); // 또는 setImageUrl(List.of(key))
+
+		// 3. 저장
+		problemDomainService.saveProblem(problem);
+	}
+
 }
 

--- a/src/main/java/org/ezcode/codetest/presentation/problemmanagement/problem/ProblemAdminController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/problemmanagement/problem/ProblemAdminController.java
@@ -8,6 +8,7 @@ import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -48,7 +49,7 @@ public class ProblemAdminController {
 	}
 
 	@PutMapping(path = "/{problemId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
-	@Operation(summary = "문제 수정", description = "문제를 수정합니다.")
+	@Operation(summary = "문제 전체 수정", description = "문제 전체를 수정합니다.")
 	@ApiResponse(responseCode = "200", description = "문제 수정 성공")
 	public ResponseEntity<Void> modifyProblem(
 		@PathVariable Long problemId,
@@ -60,6 +61,18 @@ public class ProblemAdminController {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.build();
+	}
+
+	@PutMapping("/image/{problemId}")
+	@Operation(summary = "문제 이미지 수정", description = "문제 이미지 수정합니다.")
+	@PreAuthorize("hasRole('ADMIN')")
+	@ApiResponse(responseCode = "200", description = "문제 수정 성공")
+	public ResponseEntity<Void> updateProblemImage(
+		@PathVariable Long problemId,
+		@RequestPart(value = "image", required = false) MultipartFile imageFile
+	) {
+		problemService.addImageToExistingProblem(problemId, imageFile);
+		return ResponseEntity.noContent().build();
 	}
 
 	@DeleteMapping("/{problemId}")

--- a/src/main/resources/templates/test-submit.html
+++ b/src/main/resources/templates/test-submit.html
@@ -286,6 +286,9 @@
             <li>메모리 제한: <span id="prob-mem">--</span> KB</li>
             <li>카테고리: <span id="prob-cats">--</span></li>
         </ul>
+        <div id="prob-image-wrapper">
+            <img id="prob-image" src="" alt="문제 이미지" style="max-width: 100%; height: auto;" />
+        </div>
     </div>
     <div class="right">
         <div class="section">
@@ -335,6 +338,7 @@
     const probTimeEl = document.getElementById('prob-time');
     const probMemEl = document.getElementById('prob-mem');
     const probCatsEl = document.getElementById('prob-cats');
+    const probImageEl = document.getElementById('prob-image');
 
     function tokenHeader() {
         const token = sessionStorage.getItem('accessToken');
@@ -365,6 +369,12 @@
             probTimeEl.textContent = data.timeLimit ?? '--';
             probMemEl.textContent = data.memoryLimit ?? '--';
             probCatsEl.textContent = Array.isArray(data.categories) ? data.categories.join(', ') : '';
+            if (data.imageUrl) {
+                probImageEl.src = data.imageUrl;
+                probImageEl.style.display = 'block';
+            } else {
+                probImageEl.style.display = 'none';
+            }
         } catch (err) {
             console.error(err);
             probTitleEl.textContent = '네트워크 오류';


### PR DESCRIPTION
## 작업 내용

- 문제 이미지 수정 로직, UI 부분 추가
 
Put메소드
api/admin/problems/image/{problmeId}   
이미지만 수정 하는 로직

![image](https://github.com/user-attachments/assets/27e5ec44-ff37-4a6c-bb41-c8c41729533d)


### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 문제 상세 정보에 이미지 URL 표시 기능이 추가되었습니다.
  * 관리자가 기존 문제에 이미지를 별도로 업로드 및 수정할 수 있는 엔드포인트가 추가되었습니다.
  * 문제 상세 화면에서 문제 이미지가 있을 경우 자동으로 표시됩니다.

* **문서 및 화면 개선**
  * 문제 수정 관련 설명이 "문제 전체 수정"으로 명확하게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->