### PR TITLE
fix: cors error in swagger

### DIFF
--- a/src/main/java/org/ezcode/codetest/infrastructure/swagger/config/SwaggerConfig.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/swagger/config/SwaggerConfig.java
@@ -14,7 +14,7 @@ import io.swagger.v3.oas.annotations.servers.Server;
 @OpenAPIDefinition(
 	servers = {
 		@Server(
-			url = "http://localhost:8080",           // ← 슬래시 없이 호스트만!
+			url = "https://ezcode.my",           // ← 슬래시 없이 호스트만!
 			description = "Production server"
 		)
 	},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * OpenAPI 정의의 서버 URL이 "http://localhost:8080"에서 "https://ezcode.my"로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->