### PR TITLE
refactor: 깃허브 이벤트 발행 위치 변경

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/submission/model/SubmissionContext.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/model/SubmissionContext.java
@@ -134,14 +134,6 @@ public record SubmissionContext(
         return problemInfo.categories();
     }
 
-    public void incrementTotalSubmissions() {
-        getProblem().incrementTotalSubmissions();
-    }
-
-    public void incrementCorrectSubmissions() {
-        getProblem().incrementCorrectSubmissions();
-    }
-
     public boolean isGitPushStatus() {
         return user.getGitPushStatus();
     }

--- a/src/main/java/org/ezcode/codetest/application/submission/port/GitHubClient.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/port/GitHubClient.java
@@ -3,5 +3,8 @@ package org.ezcode.codetest.application.submission.port;
 import org.ezcode.codetest.application.submission.dto.request.github.GitHubPushRequest;
 
 public interface GitHubClient {
-    void commitAndPushToRepo(GitHubPushRequest request);
+
+    boolean isSourceCodeNewOrChanged(GitHubPushRequest req);
+
+    void commitAndPushToRepo(GitHubPushRequest req);
 }

--- a/src/main/java/org/ezcode/codetest/application/submission/service/GitHubPushService.java
+++ b/src/main/java/org/ezcode/codetest/application/submission/service/GitHubPushService.java
@@ -28,12 +28,17 @@ public class GitHubPushService {
             return;
         }
 
-        eventService.publishGitPushStatus(GitPushStatusEvent.started(ctx));
-        UserGithubInfo info = userGithubService.getUserGithubInfoById(ctx.getUserId());
-
         try {
+            UserGithubInfo info = userGithubService.getUserGithubInfoById(ctx.getUserId());
             String decryptedToken = aesUtil.decrypt(info.getGithubAccessToken());
-            gitHubClient.commitAndPushToRepo(GitHubPushRequest.of(ctx, info, decryptedToken));
+            GitHubPushRequest req = GitHubPushRequest.of(ctx, info, decryptedToken);
+
+            if (!gitHubClient.isSourceCodeNewOrChanged(req)) {
+                return;
+            }
+
+            eventService.publishGitPushStatus(GitPushStatusEvent.started(ctx));
+            gitHubClient.commitAndPushToRepo(req);
             eventService.publishGitPushStatus(GitPushStatusEvent.succeeded(ctx));
         } catch (Exception e) {
             exceptionNotifier.notifyException("commitAndPush", e);

--- a/src/main/java/org/ezcode/codetest/domain/problem/model/entity/Testcase.java
+++ b/src/main/java/org/ezcode/codetest/domain/problem/model/entity/Testcase.java
@@ -58,6 +58,7 @@ public class Testcase {
 	}
 
 	public String getOutput() {
-		return this.output.replace("\\n", "\n");
+		if (output != null) return this.output.replace("\\n", "\n");
+		return null;
 	}
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/github/GitHubClientImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/github/GitHubClientImpl.java
@@ -20,13 +20,16 @@ public class GitHubClientImpl implements GitHubClient {
     private final GitBlobCalculator blobCalculator;
 
     @Override
-    public void commitAndPushToRepo(GitHubPushRequest req) {
+    public boolean isSourceCodeNewOrChanged(GitHubPushRequest req) {
         String codeBlobSha = blobCalculator.calculateBlobSha(req.sourceCode());
         Optional<String> existingSha = gitHubApiClient.fetchSourceBlobSha(req);
 
-        if (existingSha.map(codeBlobSha::equals).orElse(false)) {
-            return;
-        }
+        return !existingSha.map(codeBlobSha::equals).orElse(false);
+    }
+
+    @Override
+    public void commitAndPushToRepo(GitHubPushRequest req) {
+        String codeBlobSha = blobCalculator.calculateBlobSha(req.sourceCode());
 
         List<Map<String, Object>> entries = templateBuilder.buildGitTreeEntries(req, codeBlobSha);
 

--- a/src/test/java/org/ezcode/codetest/application/submission/GitHubPushServiceTest.java
+++ b/src/test/java/org/ezcode/codetest/application/submission/GitHubPushServiceTest.java
@@ -106,6 +106,38 @@ public class GitHubPushServiceTest {
         }
 
         @Test
+        @DisplayName("코드 변경 없음 -> 푸시 생략")
+        void noPushWhenCodeNotChanged() throws Exception {
+
+            // given
+            given(ctx.isGitPushStatus()).willReturn(true);
+            given(ctx.isPassed()).willReturn(true);
+
+            given(ctx.getSessionKey()).willReturn(sessionKey);
+            given(ctx.getUserId()).willReturn(userId);
+
+            given(userGithubService.getUserGithubInfoById(userId)).willReturn(info);
+            given(info.getGithubAccessToken()).willReturn(encryptedToken);
+
+            given(aesUtil.decrypt(encryptedToken)).willReturn(decryptedToken);
+
+            try (var ms = mockStatic(GitHubPushRequest.class)) {
+                ms.when(() -> GitHubPushRequest.of(ctx, info, decryptedToken)).thenReturn(req);
+
+                given(gitHubClient.isSourceCodeNewOrChanged(req)).willReturn(false);
+
+                // when
+                gitHubPushService.pushSolutionToRepo(ctx);
+
+                // then
+                then(gitHubClient).should(never()).commitAndPushToRepo(any());
+                then(eventService).should(never()).publishGitPushStatus(GitPushStatusEvent.started(ctx));
+                then(eventService).should(never()).publishGitPushStatus(GitPushStatusEvent.succeeded(ctx));
+                then(exceptionNotifier).should(never()).notifyException(anyString(), any());
+            }
+        }
+
+        @Test
         @DisplayName("활성화 & 정답 제출 -> 메서드 실행 및 시작 & 성공 이벤트 발행")
         void pushSuccess() throws Exception {
 
@@ -123,6 +155,8 @@ public class GitHubPushServiceTest {
             // when & then
             try (var ms = mockStatic(GitHubPushRequest.class)) {
                 ms.when(() -> GitHubPushRequest.of(ctx, info, decryptedToken)).thenReturn(req);
+
+                given(gitHubClient.isSourceCodeNewOrChanged(req)).willReturn(true);
 
                 gitHubPushService.pushSolutionToRepo(ctx);
 
@@ -157,6 +191,8 @@ public class GitHubPushServiceTest {
             try (var ms = mockStatic(GitHubPushRequest.class)) {
                 ms.when(() -> GitHubPushRequest.of(ctx, info, decryptedToken))
                     .thenReturn(req);
+
+                given(gitHubClient.isSourceCodeNewOrChanged(req)).willReturn(true);
 
                 gitHubPushService.pushSolutionToRepo(ctx);
 

--- a/src/test/java/org/ezcode/codetest/infrastructure/github/GitHubClientTest.java
+++ b/src/test/java/org/ezcode/codetest/infrastructure/github/GitHubClientTest.java
@@ -56,13 +56,10 @@ public class GitHubClientTest {
         given(gitHubApiClient.fetchSourceBlobSha(request)).willReturn(Optional.of(sha));
 
         // when
-        gitHubClientImpl.commitAndPushToRepo(request);
+        boolean result = gitHubClientImpl.isSourceCodeNewOrChanged(request);
 
         // then
-        then(gitHubApiClient).should(never()).fetchCommitContext(any());
-        then(templateBuilder).should(never()).buildGitTreeEntries(any(), any());
-        then(gitHubApiClient).should(never()).createTree(any(), any(), anyList());
-        then(gitHubApiClient).should(never()).commitAndPush(any(), any(), any());
+        assert !result;
     }
 
     @Test
@@ -70,18 +67,16 @@ public class GitHubClientTest {
     void newBlobEqualsTreeBlob_earlyReturn() {
 
         // given
-        String oldSha = "old";
         String newSha = "new";
         given(request.sourceCode()).willReturn(sourceCode);
         given(blobCalculator.calculateBlobSha(request.sourceCode())).willReturn(newSha);
-        given(gitHubApiClient.fetchSourceBlobSha(request)).willReturn(Optional.of(oldSha));
-        given(gitHubApiClient.fetchCommitContext(request)).willReturn(ctx);
 
         List<Map<String, Object>> entries = List.of(Map.of());
         given(templateBuilder.buildGitTreeEntries(request, newSha)).willReturn(entries);
 
         given(ctx.baseTreeSha()).willReturn("tree");
         given(gitHubApiClient.createTree(request, "tree", entries)).willReturn("tree");
+        given(gitHubApiClient.fetchCommitContext(request)).willReturn(ctx);
 
         // when
         gitHubClientImpl.commitAndPushToRepo(request);
@@ -98,24 +93,27 @@ public class GitHubClientTest {
     void blobAndTreeChanged_commitAndPush() {
 
         // given
-        String oldSha = "old";
         String newSha = "new";
-        given(blobCalculator.calculateBlobSha(request.sourceCode())).willReturn(newSha);
-        given(gitHubApiClient.fetchSourceBlobSha(request)).willReturn(Optional.of(oldSha));
-        given(gitHubApiClient.fetchCommitContext(request)).willReturn(ctx);
+        String baseTree = "tree";
+        String head = "head";
+        String newTree = "newTree";
 
         List<Map<String,Object>> entries = List.of(Map.of());
+
+        given(request.sourceCode()).willReturn(sourceCode);
+        given(blobCalculator.calculateBlobSha(sourceCode)).willReturn(newSha);
         given(templateBuilder.buildGitTreeEntries(request, newSha)).willReturn(entries);
 
-        given(ctx.baseTreeSha()).willReturn("tree");
-        given(ctx.headCommitSha()).willReturn("head");
-        String newTree = "newTree";
-        given(gitHubApiClient.createTree(request, "tree", entries)).willReturn(newTree);
+        given(gitHubApiClient.fetchCommitContext(request)).willReturn(ctx);
+
+        given(ctx.baseTreeSha()).willReturn(baseTree);
+        given(ctx.headCommitSha()).willReturn(head);
+        given(gitHubApiClient.createTree(request, baseTree, entries)).willReturn(newTree);
 
         // when
         gitHubClientImpl.commitAndPushToRepo(request);
 
         // then
-        then(gitHubApiClient).should().commitAndPush(request, "head", newTree);
+        then(gitHubApiClient).should().commitAndPush(request, head, newTree);
     }
 }


### PR DESCRIPTION
깃허브 이벤트 발행 위치 변경 및 테스트 코드 수정했습니다.

output 이 null 일 때의 방어코드도 추가했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 소스 코드가 새롭거나 변경된 경우에만 GitHub 저장소로 커밋 및 푸시가 이루어지도록 동작이 개선되었습니다.

* **버그 수정**
  * 테스트케이스 출력값 반환 시 null 체크가 추가되어 예외 발생 가능성이 줄었습니다.

* **테스트**
  * 소스 코드 변경이 없는 경우 푸시가 발생하지 않음을 검증하는 테스트가 추가되었습니다.
  * 기존 푸시 성공/실패 테스트가 새로운 동작 방식에 맞게 보완되었습니다.

* **리팩터링**
  * 내부 메서드 구조가 개선되어 코드의 명확성과 유지보수성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->