### PR TITLE
refactor : 랭킹 조회 인증 경로 세분화

### DIFF
--- a/src/main/java/org/ezcode/codetest/common/security/config/SecurityConfig.java
+++ b/src/main/java/org/ezcode/codetest/common/security/config/SecurityConfig.java
@@ -78,13 +78,20 @@ public class SecurityConfig {
 						SecurityPath.PUBLIC_PATH).permitAll()
 					//GET요청인 문제 목록 조회, 문제 상세 조회는 가능하게, 나머지 HTTP메서드는 인증 필요하게 설정하기
 					.requestMatchers(HttpMethod.GET, "/api/problems", "/api/problems/{problemId}").permitAll()
-					.requestMatchers("/api/problems/**").authenticated()
 					.requestMatchers("/api/admin/**").hasRole("ADMIN") //어드민 권한 필요 (문제 생성, 관리 등)
 					.requestMatchers(HttpMethod.GET,
 						"/api/languages",
 						"/api/problems/*/discussions",
 						"/api/problems/{problemId}/discussions/{discussionId}/replies",
 						"/api/problems/{problemId}/discussions/{discussionId}/replies/**").permitAll()
+
+					//랭킹 조회
+					.requestMatchers(HttpMethod.GET, "/api/rankings/me/around").authenticated()
+					.requestMatchers(HttpMethod.GET,
+						"/api/rankings/*/around",
+						"/api/rankings/weekly",
+						"/api/rankings/last-week",
+						"/api/rankings/all-time").permitAll()
 					.anyRequest().authenticated() //나머지는 일반 인증
 			)
 			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
로그인 없이 랭킹 조회 가능하도록 get 요청으로 들어오는 하단 경로를 시큐리티에서 열어줌
하지만 로그인한 유저의 경우, 유저의 정보를 가져와서 본인 랭킹을 확인해야하므로 필터 단계는 검증하도록 설정
필터는 거치고, 시큐리티는 넘어가게
`/api/rankings/me/around` -> 이 경로는 인증이 필요함 (본인 랭킹 조회용)

```java
//랭킹 조회
.requestMatchers(HttpMethod.GET, "/api/rankings/me/around").authenticated()
.requestMatchers(HttpMethod.GET,
	"/api/rankings/*/around",
        "/api/rankings/weekly",
	"/api/rankings/last-week",
	"/api/rankings/all-time").permitAll()
```

---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 일부 랭킹 조회 API(주간, 지난주, 전체, 특정 유저 주변 랭킹)에 비로그인 상태에서도 접근할 수 있도록 변경되었습니다.
* **버그 수정**
  * 인증이 필요한 랭킹 API(`/api/rankings/me/around`)는 로그인한 사용자만 접근할 수 있도록 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->