### PR TITLE
feature : auto push 여부 조회 api

### DIFF
--- a/src/main/java/org/ezcode/codetest/domain/user/service/UserGithubService.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/service/UserGithubService.java
@@ -126,4 +126,13 @@ public class UserGithubService {
 
         return new UserGitubAutoPushResponse("변경되었습니다", user.getGitPushStatus());
     }
+
+    public UserGitubAutoPushResponse getAutoPushStatus(AuthUser authUser) {
+        UserGithubInfo userGithubInfo = userGithubInfoRepository.getUserGithubInfo(authUser.getId());
+        if (userGithubInfo == null) { //유저의 깃허브 정보가 없으면 에러 반환
+            throw new UserException(UserExceptionCode.NO_GITHUB_INFO);
+        }
+        User user = userGithubInfo.getUser();
+        return new UserGitubAutoPushResponse("현재 githubAutoPush 설정", user.getGitPushStatus());
+    }
 }

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserGithubController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserGithubController.java
@@ -54,4 +54,15 @@ public class UserGithubController {
     ){
         return ResponseEntity.status(HttpStatus.OK).body(userGithubService.changeAutoPushSetting(authUser));
     }
+
+    @Operation(
+        summary = "깃허브 자동 push 여부 true false 조회",
+        description = "유저 DB에서 autoPush 여부를 찾아 true/false로 반환합니다. ex- message : '현재 githubAutoPush 설정', gitPushStatus : true "
+    )
+    @GetMapping("/users/github/status")
+    public ResponseEntity<UserGitubAutoPushResponse> AutoPushStatus(
+        @AuthenticationPrincipal AuthUser authUser
+    ){
+        return ResponseEntity.status(HttpStatus.OK).body(userGithubService.getAutoPushStatus(authUser));
+    }
 }


### PR DESCRIPTION


## 작업 내용

- 깃허브 자동 push 여부 true false 조회 api 추가
- user 데이터베이스에서 `git_push_status` 를 찾아 반환합니다

---

## 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자의 GitHub 자동 푸시 상태를 조회할 수 있는 새로운 API 엔드포인트(`/api/users/github/status`)가 추가되었습니다.  
  * 해당 엔드포인트를 통해 현재 자동 푸시 설정 여부를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->