### PR TITLE
fix : 웹소켓 연결 후 일정 시간이 지나면 ActiveMQ와의 연결이 끊기는 문제 해결

### DIFF
--- a/src/main/java/org/ezcode/codetest/infrastructure/scheduler/StompKeepAliveScheduler.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/scheduler/StompKeepAliveScheduler.java
@@ -1,0 +1,21 @@
+package org.ezcode.codetest.infrastructure.scheduler;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StompKeepAliveScheduler {
+
+	private final SimpMessagingTemplate messagingTemplate;
+
+	public StompKeepAliveScheduler(SimpMessagingTemplate messagingTemplate) {
+		this.messagingTemplate = messagingTemplate;
+	}
+
+	// 15초마다 실행 (ActiveMQ TTL인 20초보다 짧게 설정)
+	@Scheduled(fixedDelay = 15000)
+	public void sendKeepAliveMessage() {
+		this.messagingTemplate.convertAndSend("/topic/keep-alive", "ping");
+	}
+}


### PR DESCRIPTION
## 작업 내용

- 일정 시간동안 아무런 데이터가 오가지 않으면 웹소켓의 메시지 브로커(ActiveMQ)가 자동으로 연결을 끊어버림
- heart beat 기능을 애플리케이션 단에 직접 구현함
- idle timeout 이슈를 해결하기 위해 activemq가 실행되고 있는 ec2 인스턴스의 인바운드 규칙을 편집함

## 참고 사항

- [5분 기록 보드](https://www.notion.so/teamsparta/1-5-2002dc3ef51481e7afbec86e90d0010e?p=2542dc3ef5148099a9dce9b488fbf3b1&pm=s)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 새 기능
  * 실시간 알림/메시징 연결의 안정성을 강화했습니다. 서버가 주기적으로 keep-alive 신호를 전송하여 비활성 시간에도 연결이 끊기지 않도록 해, 라이브 업데이트 지연·예기치 않은 연결 종료를 줄입니다.
  * 장시간 브라우저 탭 유지 시에도 STOMP 기반 주제 구독이 더 안정적으로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->