### PR TITLE
refactor : 유저 이미지 변경도 유저 정보 수정에 포함

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/request/ModifyUserInfoRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/request/ModifyUserInfoRequest.java
@@ -13,9 +13,6 @@ public record ModifyUserInfoRequest(
 	@Schema(description = "블로그 주소", example = "https://blog.example.com")
 	String blogUrl,
 
-	@Schema(description = "프로필 이미지 URL", example = "https://cdn.example.com/images/profile.jpg")
-	String profileImageUrl,
-
 	@Schema(description = "자기소개", example = "안녕하세요, 백엔드 개발자입니다.")
 	String introduction,
 

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/UserGitubAutoPushResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/dto/response/UserGitubAutoPushResponse.java
@@ -12,4 +12,8 @@ public class UserGitubAutoPushResponse {
     private final String message;
     @Schema(description = "현재 상태", example = "true")
     private final boolean gitPushStatus;
+    @Schema(description = "선택된 레포", example = "myRepo")
+    private final String githubRepoName;
+    @Schema(description = "선택된 브랜치", example = "dev")
+    private final String branch;
 }

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
@@ -73,16 +73,24 @@ public class UserService {
 	}
 
 	@Transactional
-	public UserInfoResponse modifyUserInfo(AuthUser authUser, ModifyUserInfoRequest modifyUserInfoRequest) {
+	public UserInfoResponse modifyUserInfo(AuthUser authUser, ModifyUserInfoRequest request, MultipartFile image) {
 		User user = userDomainService.getUserById(authUser.getId());
 
 		user.modifyUserInfo(
-			modifyUserInfoRequest.nickname(),
-			modifyUserInfoRequest.githubUrl(),
-			modifyUserInfoRequest.blogUrl(),
-			modifyUserInfoRequest.profileImageUrl(),
-			modifyUserInfoRequest.introduction(),
-			modifyUserInfoRequest.age());
+			request.nickname(),
+			request.githubUrl(),
+			request.blogUrl(),
+			request.introduction(),
+			request.age());
+
+		if (image != null && !image.isEmpty()) {
+			if (user.getProfileImageUrl()!=null) {
+				s3Uploader.delete(user.getProfileImageUrl(), "profile");
+			}
+			String profileImageUrl = uploadProfileImage(image);
+
+			user.modifyProfileImage(profileImageUrl);
+		}
 
 		return UserInfoResponse.builder()
 			.username(user.getUsername())
@@ -140,18 +148,6 @@ public class UserService {
 		long weekLength = ChronoUnit.DAYS.between(startDateTime, endDateTime);
 
 		userDomainService.resetReviewTokensForUsers(UsersByWeek.from(counts, weekLength));
-	}
-
-	@Transactional
-	public UserProfileImageResponse uploadUserProfileImage(AuthUser authUser, MultipartFile image) {
-		User user = userDomainService.getUserById(authUser.getId());
-		if (user.getProfileImageUrl()!=null) {
-			s3Uploader.delete(user.getProfileImageUrl(), "profile");
-		}
-		String profileImageUrl = uploadProfileImage(image);
-
-		user.modifyProfileImage(profileImageUrl);
-		return new UserProfileImageResponse(profileImageUrl);
 	}
 
 	private String uploadProfileImage(MultipartFile image) {

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
@@ -84,12 +84,14 @@ public class UserService {
 			request.age());
 
 		if (image != null && !image.isEmpty()) {
-			if (user.getProfileImageUrl()!=null) {
-				s3Uploader.delete(user.getProfileImageUrl(), "profile");
-			}
 			String profileImageUrl = uploadProfileImage(image);
+			String oldImageUrl = user.getProfileImageUrl();
 
 			user.modifyProfileImage(profileImageUrl);
+			if (oldImageUrl!=null) {
+				s3Uploader.delete(user.getProfileImageUrl(), "profile");
+			}
+
 		}
 
 		return UserInfoResponse.builder()

--- a/src/main/java/org/ezcode/codetest/domain/user/model/entity/User.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/model/entity/User.java
@@ -152,11 +152,10 @@ public class User extends BaseEntity {
 	유저 정보 업데이트
 	- 만약 입력 값이 없다면, 기존 값 유지
 	 */
-	public void modifyUserInfo(String nickname, String githubUrl, String blogUrl, String profileImageUrl, String introduction, Integer age){
+	public void modifyUserInfo(String nickname, String githubUrl, String blogUrl, String introduction, Integer age){
 		this.nickname = (nickname == null || nickname.isBlank()) ? this.nickname : nickname;
 		this.githubUrl = (githubUrl == null || githubUrl.isBlank()) ? this.githubUrl : githubUrl;
 		this.blogUrl = (blogUrl == null || blogUrl.isBlank()) ? this.blogUrl : blogUrl;
-		this.profileImageUrl = (profileImageUrl == null || profileImageUrl.isBlank()) ? this.profileImageUrl : profileImageUrl;
 		this.introduction = (introduction == null || introduction.isBlank()) ? this.introduction : introduction;
 		this.age = (age == null) ? this.age : age;
 	}

--- a/src/main/java/org/ezcode/codetest/domain/user/service/UserGithubService.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/service/UserGithubService.java
@@ -124,7 +124,7 @@ public class UserGithubService {
         user.setGitPushStatus(!userGitPushStatus);
         log.info("기존 status: {} || 변경 status : {}", userGitPushStatus, user.getGitPushStatus());
 
-        return new UserGitubAutoPushResponse("변경되었습니다", user.getGitPushStatus());
+        return new UserGitubAutoPushResponse("변경되었습니다", user.getGitPushStatus(), userGithubInfo.getRepo(), userGithubInfo.getBranch());
     }
 
     public UserGitubAutoPushResponse getAutoPushStatus(AuthUser authUser) {
@@ -133,6 +133,6 @@ public class UserGithubService {
             throw new UserException(UserExceptionCode.NO_GITHUB_INFO);
         }
         User user = userGithubInfo.getUser();
-        return new UserGitubAutoPushResponse("현재 githubAutoPush 설정", user.getGitPushStatus());
+        return new UserGitubAutoPushResponse("현재 githubAutoPush 설정", user.getGitPushStatus(),userGithubInfo.getRepo(), userGithubInfo.getBranch());
     }
 }

--- a/src/main/java/org/ezcode/codetest/domain/user/service/UserGithubService.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/service/UserGithubService.java
@@ -90,9 +90,9 @@ public class UserGithubService {
     @Transactional
     public UserGithubRepoResponse selectGithubRepo(AuthUser authUser, UserGithubRepoSelectRequest request) throws
         Exception {
-        UserGithubInfo userGithub = userGithubInfoRepository.getUserGithubInfo(authUser.getId());
+        UserGithubInfo userGithubInfo = userGithubInfoRepository.getUserGithubInfo(authUser.getId());
 
-        if (userGithub == null) {
+        if (userGithubInfo == null) {
             throw new UserException(UserExceptionCode.NO_GITHUB_INFO);
         }
 
@@ -103,11 +103,11 @@ public class UserGithubService {
             .findFirst()
             .orElseThrow(() -> new UserException(UserExceptionCode.NO_GITHUB_REPO));
 
-        userGithub.setGithubRepo(request.repositoryName(), selectedRepo.getDefaultBranch());
+        userGithubInfo.setGithubRepo(request.repositoryName(), selectedRepo.getDefaultBranch());
 
-        userGithubInfoRepository.updateGithubInfo(userGithub);
+        userGithubInfoRepository.updateGithubInfo(userGithubInfo);
 
-        User user = userGithub.getUser();
+        User user = userGithubInfo.getUser();
         user.setGitPushStatus(true); //레포를 선택하면 자동으로 push 설정이 true
 
         return selectedRepo;

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
@@ -52,21 +52,10 @@ public class UserController {
 	@PutMapping("/users")
 	public ResponseEntity<UserInfoResponse> modifyUserInfo(
 		@AuthenticationPrincipal AuthUser authUser,
-		@RequestBody ModifyUserInfoRequest modifyUserInfoRequest
-	){
-		return ResponseEntity.status(HttpStatus.OK).body(userService.modifyUserInfo(authUser, modifyUserInfoRequest));
-	}
-
-	//유저 프로필 이미지 등록
-	@Operation(
-		summary = "프로필 이미지 등록",
-		description = "유저의 프로필 이미지를 등록합니다. 기존의 이미지가 있는 경우, 기존 이미지가 삭제되고 새로운 이미지로 교체됩니다.")
-	@PutMapping("/users/profile")
-	public ResponseEntity<UserProfileImageResponse> uploadUserProfileImage(
-		@AuthenticationPrincipal AuthUser authUser,
+		@RequestPart("request") ModifyUserInfoRequest request,
 		@RequestPart(value = "image", required = false) MultipartFile image
 	){
-		return ResponseEntity.status(HttpStatus.OK).body(userService.uploadUserProfileImage(authUser, image));
+		return ResponseEntity.status(HttpStatus.OK).body(userService.modifyUserInfo(authUser, request, image));
 	}
 
 	@Operation(

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
@@ -52,7 +52,7 @@ public class UserController {
 	@PutMapping("/users")
 	public ResponseEntity<UserInfoResponse> modifyUserInfo(
 		@AuthenticationPrincipal AuthUser authUser,
-		@RequestPart("request") ModifyUserInfoRequest request,
+		@Valid @RequestPart("request") ModifyUserInfoRequest request,
 		@RequestPart(value = "image", required = false) MultipartFile image
 	){
 		return ResponseEntity.status(HttpStatus.OK).body(userService.modifyUserInfo(authUser, request, image));


### PR DESCRIPTION
## 작업 내용

- 유저 정보 수정 API 리팩토링
    - application/json과 multipart/form-data 요청을 일관성 있게 처리하도록 API 엔드포인트를 리팩토링
- github auto push 상태 변경 시, 레포랑 브랜치명도 함께 response에 제공
    - 만약 설정 안한 유저다? -> null로 반환
---

## 변경 사항

- `@RequestBody ModifyUserInfoRequest`를 `@RequestPart("request") ModifyUserInfoRequest request`로 변경
    - multipart/form-data 요청의 JSON 부분을 처리하도록 수정
    - `userService.modifyUserInfo()` 메서드 내, `image` 파라미터가 null이거나 비어 있는지(!image.isEmpty()) 확인

---

## 참고 사항

- 프론트 구현 참고사항 링크
- https://lace-zenith-49f.notion.site/24fc1a665612809c8c5fc3b4bc9ac142?source=copy_link

---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 사용자 정보 수정 시 텍스트 필드와 프로필 이미지를 한 번에 업로드할 수 있습니다(멀티파트 지원).

- Refactor
  - 사용자 정보 수정 요청에서 profileImageUrl 입력을 제거하고 이미지 파일 파라미터로 처리합니다.
  - 별도 프로필 이미지 업로드 엔드포인트를 제거하고 수정 기능으로 통합했습니다.
  - 요청 형식이 JSON에서 multipart/form-data로 변경되어 클라이언트 업데이트가 필요합니다.
  - 새 이미지 업로드 시 기존 프로필 이미지는 자동으로 대체 및 삭제됩니다.

- New Fields (API 응답)
  - 자동 푸시 관련 응답에 저장소명과 브랜치 정보가 추가되어 반환됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->