### PR TITLE
refactor : 기본 언어가 저장되지 않은 유저에 대해 조회시 1번 언어로 자동 설정 및 조회되도록 설정

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
@@ -56,7 +56,7 @@ public class UserService {
 	private final RedisTemplate<String, String> redisTemplate;
 	private final S3Uploader s3Uploader;
 
-	@Transactional(readOnly = true)
+	@Transactional
 	public UserInfoResponse getUserInfo(AuthUser authUser) {
 		log.info("authUserEmail: {}, authUserID : {}", authUser.getEmail(), authUser.getId());
 		User user = userDomainService.getUserById(authUser.getId());
@@ -64,6 +64,10 @@ public class UserService {
 		List<UserAuthType> userAuthTypes = userDomainService.getUserAuthTypesByUser(user);
 		List<AuthType> authTypes = userAuthTypes.stream()
 			.map(UserAuthType::getAuthType).toList();
+		if (user.getLanguage() == null) {
+			Language userLanguage = languageDomainService.getLanguage(1L);
+			user.setLanguage(userLanguage);
+		}
 
 		return UserInfoResponse.builder()
 			.username(user.getUsername())

--- a/src/main/java/org/ezcode/codetest/domain/user/model/entity/User.java
+++ b/src/main/java/org/ezcode/codetest/domain/user/model/entity/User.java
@@ -216,4 +216,8 @@ public class User extends BaseEntity {
 	public void modifyUserRole(UserRole userRole) {
 		this.role = userRole;
 	}
+
+	public void setLanguage(Language userLanguage) {
+		this.language = userLanguage;
+	}
 }


### PR DESCRIPTION
> PR 생성 시 아래 항목을 채워주세요.
>
>
> **제목 예시:** `feat : Pull request template 작성`
>
> (작성 후 이 안내 문구는 삭제해주세요)
>

---

## 작업 내용

- 어떤 기능(또는 수정 사항)을 구현했는지 간략하게 설명해주세요.
- 예) "회원가입 API에 이메일 중복 검사 기능 추가"

---

## 변경 사항

- 구현한 주요 로직, 클래스, 메서드 등을 bullet 형식으로 기술해주세요.
- 예)
    - `UserService.createUser()` 메서드 추가
    - `@Email` 유효성 검증 적용

---

## 트러블 슈팅

- 구현 중 마주한 문제와 해결 방법을 기술해주세요.
- 예)
    - 문제: `@Transactional`이 적용되지 않음
    - 해결: 메서드 호출 방식 변경 (`this.` → `AopProxyUtils.` 사용)

---

## 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.
- 예)D
    - `UserController`에서 비즈니스 로직 일부 처리 → 서비스로 이전 고려 필요

---

## 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 사용자 언어 설정이 안정적으로 반영되어, 프로필에서 언어 선호도를 일관되게 표시합니다.
- 버그 수정
  - 사용자 정보 조회 시 언어 값이 비어 있는 계정에도 기본 언어가 자동 적용되어 빈 값 표시나 조회 오류를 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->