### PR TITLE
fix : 회원 정보 수정 API Swagger 및 S3 이미지 삭제 버그 수정

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
@@ -106,10 +106,10 @@ public class UserService {
 			String oldImageUrl = user.getProfileImageUrl();
 
 			user.modifyProfileImage(profileImageUrl);
-			if (oldImageUrl!=null) {
-				s3Uploader.delete(user.getProfileImageUrl(), "profile");
-			}
 
+			if (oldImageUrl != null) {
+				s3Uploader.delete(oldImageUrl, "profile");
+			}
 		}
 
 		return UserInfoResponse.builder()

--- a/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
+++ b/src/main/java/org/ezcode/codetest/application/usermanagement/user/service/UserService.java
@@ -35,6 +35,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
@@ -107,7 +108,7 @@ public class UserService {
 
 			user.modifyProfileImage(profileImageUrl);
 
-			if (oldImageUrl != null) {
+			if (StringUtils.hasText(oldImageUrl)) {
 				s3Uploader.delete(oldImageUrl, "profile");
 			}
 		}

--- a/src/main/java/org/ezcode/codetest/infrastructure/s3/S3Uploader.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/s3/S3Uploader.java
@@ -1,6 +1,8 @@
 package org.ezcode.codetest.infrastructure.s3;
 
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 import org.ezcode.codetest.infrastructure.s3.exception.S3Exception;
@@ -78,7 +80,10 @@ public class S3Uploader {
 			if (dirName.equalsIgnoreCase("profile")) {
 				fileName = extractKeyFromProfileUrl(fileUrl);
 			}
-			amazonS3.deleteObject(bucket, fileName); // S3 내 이미지 객체 제거.
+
+			String decodedFileName = URLDecoder.decode(fileName, StandardCharsets.UTF_8);
+			amazonS3.deleteObject(bucket, decodedFileName); // S3 내 이미지 객체 제거.
+
 			log.info("S3에서 이미지 삭제 완료: {}", fileName);
 		} catch (Exception e) {
 			log.error("S3 이미지 삭제 실패: {}", fileUrl, e);

--- a/src/main/java/org/ezcode/codetest/infrastructure/swagger/config/SwaggerConfig.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/swagger/config/SwaggerConfig.java
@@ -16,6 +16,10 @@ import io.swagger.v3.oas.annotations.servers.Server;
 		@Server(
 			url = "https://api.ezcode.my",           // ← 슬래시 없이 호스트만!
 			description = "Production server"
+		),
+		@Server(
+			url = "http://localhost:8080",
+			description = "Local Server"
 		)
 	},
 	info = @Info(title = "API 문서", version = "v1"),

--- a/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/usermanagement/UserController.java
@@ -1,10 +1,8 @@
 package org.ezcode.codetest.presentation.usermanagement;
 
-import org.ezcode.codetest.application.submission.dto.response.language.LanguageResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.request.ModifyUserInfoRequest;
 import org.ezcode.codetest.application.usermanagement.user.dto.request.ChangeUserPasswordRequest;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.ChangeUserPasswordResponse;
-import org.ezcode.codetest.application.usermanagement.user.dto.response.GrantAdminRoleResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.UserDailySolvedHistoryResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.UserInfoResponse;
 import org.ezcode.codetest.application.usermanagement.user.dto.response.UserProfileImageResponse;
@@ -26,6 +24,9 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -46,7 +47,17 @@ public class UserController {
 		return ResponseEntity.status(HttpStatus.OK).body(userService.getUserInfo(authUser));
 	}
 
-	@Operation(summary = "내 정보 수정", description = "닉네임, 블로그, 깃허브, 소개 등 개인 정보를 추가하거나 수정합니다.")
+	@Operation(
+		summary = "내 정보 수정",
+		description = "닉네임, 블로그, 깃허브, 소개 등 개인 정보를 추가하거나 수정합니다.",
+		// ▼ 이 부분이 핵심입니다. Swagger에게 'request' 파트의 Content-Type을 강제합니다.
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+			content = @Content(
+				mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+				encoding = @Encoding(name = "request", contentType = MediaType.APPLICATION_JSON_VALUE)
+			)
+		)
+	)
     @PutMapping(value = "/users", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	public ResponseEntity<UserInfoResponse> modifyUserInfo(
 		@AuthenticationPrincipal AuthUser authUser,


### PR DESCRIPTION
## 작업 내용

- 회원 정보 수정 API(`PUT /users`) 호출 시 Swagger에서 발생하는 Content-Type 에러 해결
- 프로필 이미지 변경 시 기존 이미지가 S3에서 정상적으로 삭제되지 않는 로직 오류 수정
- S3 파일 삭제 시 파일명 인코딩 및 Null 처리 안정성 강화

---

## 변경 사항

- `UserController`
    - `@Operation` 어노테이션에 `requestBody` 및 `encoding` 설정을 추가하여, Multipart 요청 시 `request` 파트가 `application/json`으로 전송되도록 명시
- `UserService`
    - `modifyUserInfo` 메서드 내 로직 순서 변경: 엔티티가 업데이트되기 전에 `oldImageUrl`을 미리 백업하여, 변경 전 이미지가 삭제되도록 수정
- `S3Uploader`
    - `delete()` 메서드에 `URLDecoder.decode()` 추가 (특수문자 포함된 파일명 처리)
    - 이미지 URL 유효성 검사에 `StringUtils.hasText()` 도입 (Null 및 빈 문자열 `""` 방지)

---

## 트러블 슈팅

- **Swagger Content-Type 문제**
    - 문제: Swagger UI에서 요청 시 DTO 파트가 `application/octet-stream`으로 전송되어 `HttpMediaTypeNotSupportedException` 발생
    - 해결: 컨트롤러 메서드 상단 `@Operation` 설정을 통해 `content-type: application/json`을 강제하도록 수정

- **S3 이미지 삭제 실패 (인코딩)**
    - 문제: 파일명에 공백이나 특수문자가 포함된 경우(예: `%20`), S3 키값과 불일치하여 삭제되지 않음
    - 해결: `URLDecoder`를 사용하여 파일명을 UTF-8로 디코딩한 후 `deleteObject` 요청

- **빈 문자열 에러**
    - 문제: 기존 프로필 이미지가 없는 경우 DB에 `""`(빈 문자열)로 저장되어 있어, `if (url != null)` 조건을 통과해 삭제 로직 수행 중 에러 발생
    - 해결: `StringUtils.hasText()`를 사용하여 빈 문자열까지 안전하게 필터링

---

## 참고 사항

- Swagger UI 및 Postman에서 파일 업로드/수정 정상 동작 확인 완료
- S3 버킷 내 실제 파일 삭제/생성 확인 완료

---

### 코드 리뷰 전 확인 체크리스트

- [x]  불필요한 콘솔 로그, 주석 제거
- [x]  커밋 메시지 컨벤션 준수 (`type : `)
- [x]  기능 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **버그 수정**
  * 프로필 이미지 삭제 로직을 개선하여 올바른 파일이 삭제되도록 수정했습니다.
  * 파일명 인코딩 처리를 추가하여 이미지 삭제 기능의 안정성을 높였습니다.

* **문서화**
  * API 문서에 로컬 서버 옵션을 추가했습니다.
  * 사용자 정보 수정 엔드포인트의 API 문서를 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->