### PR TITLE
feat : 코딩 테스트 코드 자동 저장(Draft) 기능 및 동시성 제어 구현

### DIFF
--- a/src/main/java/org/ezcode/codetest/application/draft/dto/request/DraftSaveRequest.java
+++ b/src/main/java/org/ezcode/codetest/application/draft/dto/request/DraftSaveRequest.java
@@ -1,0 +1,19 @@
+package org.ezcode.codetest.application.draft.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record DraftSaveRequest(
+	@NotNull(message = "문제 ID는 필수입니다.")
+	Long problemId,
+
+	@NotNull(message = "언어 ID는 필수입니다.")
+	Long languageId,
+
+	@NotNull(message = "코드는 필수입니다.")
+	@Size(max = 100000, message = "코드는 최대 100,000자까지 입력 가능합니다.")
+	String code,
+
+	Long version  // 새 엔티티는 null일 수 있으므로 @NotNull 제외
+) {
+}

--- a/src/main/java/org/ezcode/codetest/application/draft/dto/response/DraftResponse.java
+++ b/src/main/java/org/ezcode/codetest/application/draft/dto/response/DraftResponse.java
@@ -1,0 +1,22 @@
+package org.ezcode.codetest.application.draft.dto.response;
+
+import org.ezcode.codetest.domain.draft.model.entity.Draft;
+
+import lombok.Builder;
+
+@Builder
+public record DraftResponse(
+	Long problemId,
+	Long languageId,
+	String code,
+	Long version
+) {
+	public static DraftResponse from(Draft draft) {
+		return DraftResponse.builder()
+			.problemId(draft.getProblem().getId())
+			.languageId(draft.getLanguage().getId())
+			.code(draft.getCode())
+			.version(draft.getVersion())
+			.build();
+	}
+}

--- a/src/main/java/org/ezcode/codetest/application/draft/servcie/DraftService.java
+++ b/src/main/java/org/ezcode/codetest/application/draft/servcie/DraftService.java
@@ -1,0 +1,67 @@
+package org.ezcode.codetest.application.draft.servcie;
+
+import org.ezcode.codetest.application.draft.dto.request.DraftSaveRequest;
+import org.ezcode.codetest.application.draft.dto.response.DraftResponse;
+import org.ezcode.codetest.domain.draft.exception.DraftException;
+import org.ezcode.codetest.domain.draft.exception.DraftExceptionCode;
+import org.ezcode.codetest.domain.draft.model.entity.Draft;
+import org.ezcode.codetest.domain.draft.service.DraftDomainService;
+import org.ezcode.codetest.domain.language.model.entity.Language;
+import org.ezcode.codetest.domain.language.service.LanguageDomainService;
+import org.ezcode.codetest.domain.problem.model.entity.Problem;
+import org.ezcode.codetest.domain.problem.service.ProblemDomainService;
+import org.ezcode.codetest.domain.user.model.entity.User;
+import org.ezcode.codetest.domain.user.service.UserDomainService;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DraftService {
+
+	private final DraftDomainService draftDomainService;
+
+	private final UserDomainService userDomainService;
+	private final ProblemDomainService problemDomainService;
+	private final LanguageDomainService languageDomainService;
+
+	@Transactional
+	public DraftResponse autoSave(Long userId, DraftSaveRequest request) {
+
+		User user = userDomainService.getUserById(userId);
+		Problem problem = problemDomainService.getProblem(request.problemId());
+		Language language = languageDomainService.getLanguage(request.languageId());
+
+		Draft draft;
+		try {
+			draft = draftDomainService.autoSave(
+				user,
+				problem,
+				language,
+				request.code(),
+				request.version()
+			);
+		} catch (ObjectOptimisticLockingFailureException e) {
+			throw new DraftException(DraftExceptionCode.DRAFT_VERSION_CONFLICT);
+		}
+
+		return DraftResponse.from(draft);
+	}
+
+	@Transactional
+	public DraftResponse getDraft(Long userId, Long problemId, Long languageId) {
+
+		User user = userDomainService.getUserById(userId);
+		Problem problem = problemDomainService.getProblem(problemId);
+		Language language = languageDomainService.getLanguage(languageId);
+
+		Draft draft = draftDomainService.getDraft(user, problem, language);
+
+		return DraftResponse.from(draft);
+	}
+}

--- a/src/main/java/org/ezcode/codetest/application/draft/servcie/DraftService.java
+++ b/src/main/java/org/ezcode/codetest/application/draft/servcie/DraftService.java
@@ -1,5 +1,7 @@
 package org.ezcode.codetest.application.draft.servcie;
 
+import java.util.Optional;
+
 import org.ezcode.codetest.application.draft.dto.request.DraftSaveRequest;
 import org.ezcode.codetest.application.draft.dto.response.DraftResponse;
 import org.ezcode.codetest.domain.draft.exception.DraftException;
@@ -53,15 +55,14 @@ public class DraftService {
 		return DraftResponse.from(draft);
 	}
 
-	@Transactional
-	public DraftResponse getDraft(Long userId, Long problemId, Long languageId) {
+	@Transactional(readOnly = true)
+	public Optional<DraftResponse> getDraft(Long userId, Long problemId, Long languageId) {
 
 		User user = userDomainService.getUserById(userId);
 		Problem problem = problemDomainService.getProblem(problemId);
 		Language language = languageDomainService.getLanguage(languageId);
 
-		Draft draft = draftDomainService.getDraft(user, problem, language);
-
-		return DraftResponse.from(draft);
+		return draftDomainService.getDraft(user, problem, language)
+			.map(DraftResponse::from);
 	}
 }

--- a/src/main/java/org/ezcode/codetest/application/draft/service/DraftService.java
+++ b/src/main/java/org/ezcode/codetest/application/draft/service/DraftService.java
@@ -1,4 +1,4 @@
-package org.ezcode.codetest.application.draft.servcie;
+package org.ezcode.codetest.application.draft.service;
 
 import java.util.Optional;
 

--- a/src/main/java/org/ezcode/codetest/domain/draft/exception/DraftException.java
+++ b/src/main/java/org/ezcode/codetest/domain/draft/exception/DraftException.java
@@ -1,0 +1,21 @@
+package org.ezcode.codetest.domain.draft.exception;
+
+import org.ezcode.codetest.common.base.exception.BaseException;
+import org.ezcode.codetest.common.base.exception.ResponseCode;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class DraftException extends BaseException {
+
+    private final ResponseCode responseCode;
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public DraftException(ResponseCode responseCode) {
+        this.responseCode = responseCode;
+        this.httpStatus = responseCode.getStatus();
+        this.message = responseCode.getMessage();
+    }
+}

--- a/src/main/java/org/ezcode/codetest/domain/draft/exception/DraftExceptionCode.java
+++ b/src/main/java/org/ezcode/codetest/domain/draft/exception/DraftExceptionCode.java
@@ -1,0 +1,25 @@
+package org.ezcode.codetest.domain.draft.exception;
+
+import org.ezcode.codetest.common.base.exception.ResponseCode;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DraftExceptionCode implements ResponseCode {
+
+	DRAFT_NOT_FOUND(false, HttpStatus.NOT_FOUND, "해당 임시 저장 내역이 존재하지 않습니다."),
+
+	// 409 Conflict: 낙관적 락 충돌 발생 시 사용
+	DRAFT_VERSION_CONFLICT(false, HttpStatus.CONFLICT, "다른 탭에서 저장된 최신 코드가 존재합니다. 새로고침이 필요합니다."),
+
+	// 본인의 Draft가 아닌데 조회/수정하려 할 때 (URL 조작 등)
+	DRAFT_ACCESS_DENIED(false, HttpStatus.FORBIDDEN, "해당 임시 저장 내역에 접근할 권한이 없습니다."),
+	;
+
+	private final boolean success;
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/org/ezcode/codetest/domain/draft/model/entity/Draft.java
+++ b/src/main/java/org/ezcode/codetest/domain/draft/model/entity/Draft.java
@@ -1,0 +1,72 @@
+package org.ezcode.codetest.domain.draft.model.entity;
+
+import org.ezcode.codetest.domain.language.model.entity.Language;
+import org.ezcode.codetest.domain.problem.model.entity.Problem;
+import org.ezcode.codetest.domain.user.model.entity.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	name = "draft",
+	uniqueConstraints = {
+		// 언어별 저장 지원
+		@UniqueConstraint(
+			name = "uk_draft_user_problem_language",
+			columnNames = {"user_id", "problem_id", "language_id"}
+		)
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Draft {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "problem_id", nullable = false)
+	private Problem problem;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "language_id", nullable = false)
+	private Language language;
+
+	@Lob
+	private String code;
+
+	@Version        // 낙관적 락을 위한 버전 관리
+	private Long version;
+
+	public void updateCode(String newCode) {
+		this.code = newCode;
+	}
+
+	@Builder
+	public Draft(User user, Problem problem, Language language, String code, Long version) {
+		this.user = user;
+		this.problem = problem;
+		this.language = language;
+		this.code = code;
+		this.version = version;
+	}
+}

--- a/src/main/java/org/ezcode/codetest/domain/draft/repository/DraftRepository.java
+++ b/src/main/java/org/ezcode/codetest/domain/draft/repository/DraftRepository.java
@@ -1,0 +1,18 @@
+package org.ezcode.codetest.domain.draft.repository;
+
+import java.util.Optional;
+
+import org.ezcode.codetest.domain.draft.model.entity.Draft;
+import org.ezcode.codetest.domain.language.model.entity.Language;
+import org.ezcode.codetest.domain.problem.model.entity.Problem;
+import org.ezcode.codetest.domain.user.model.entity.User;
+
+public interface DraftRepository {
+
+	Draft save(Draft draft);
+
+	Optional<Draft> findByUserAndProblemAndLanguage(User user, Problem problem, Language language);
+
+	Draft saveAndFlush(Draft draft);
+
+}

--- a/src/main/java/org/ezcode/codetest/domain/draft/service/DraftDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/draft/service/DraftDomainService.java
@@ -1,5 +1,6 @@
 package org.ezcode.codetest.domain.draft.service;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import org.ezcode.codetest.domain.draft.exception.DraftException;
@@ -29,7 +30,7 @@ public class DraftDomainService {
 			Draft draft = existingDraftOpt.get();
 
 			// 명시적 버전 검증: 클라이언트가 보낸 version과 DB의 version이 일치해야 함
-			if (version != null && !draft.getVersion().equals(version)) {
+			if (version != null && !Objects.equals(version, draft.getVersion())) {
 				throw new DraftException(DraftExceptionCode.DRAFT_VERSION_CONFLICT);
 			}
 

--- a/src/main/java/org/ezcode/codetest/domain/draft/service/DraftDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/draft/service/DraftDomainService.java
@@ -1,0 +1,58 @@
+package org.ezcode.codetest.domain.draft.service;
+
+import java.util.Optional;
+
+import org.ezcode.codetest.domain.draft.exception.DraftException;
+import org.ezcode.codetest.domain.draft.exception.DraftExceptionCode;
+import org.ezcode.codetest.domain.draft.model.entity.Draft;
+import org.ezcode.codetest.domain.draft.repository.DraftRepository;
+import org.ezcode.codetest.domain.language.model.entity.Language;
+import org.ezcode.codetest.domain.problem.model.entity.Problem;
+import org.ezcode.codetest.domain.user.model.entity.User;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DraftDomainService {
+
+	private final DraftRepository draftRepository;
+
+	public Draft autoSave(User user, Problem problem, Language language, String code, Long version) {
+
+		Optional<Draft> existingDraftOpt = draftRepository.findByUserAndProblemAndLanguage(user, problem, language);
+
+		if (existingDraftOpt.isPresent()) {
+			Draft draft = existingDraftOpt.get();
+
+			// 명시적 버전 검증: 클라이언트가 보낸 version과 DB의 version이 일치해야 함
+			if (version != null && !draft.getVersion().equals(version)) {
+				throw new DraftException(DraftExceptionCode.DRAFT_VERSION_CONFLICT);
+			}
+
+			draft.updateCode(code);
+			draftRepository.saveAndFlush(draft);
+
+			return draft;
+		} else {
+			// 새 엔티티인 경우
+			Draft draft = Draft.builder()
+				.user(user)
+				.problem(problem)
+				.language(language)
+				.code(code)
+				.build();
+
+			return draftRepository.saveAndFlush(draft);
+		}
+	}
+
+	public Draft getDraft(User user, Problem problem, Language language) {
+
+		return draftRepository.findByUserAndProblemAndLanguage(user, problem, language)
+			.orElseThrow(() -> new DraftException(DraftExceptionCode.DRAFT_NOT_FOUND));
+	}
+}

--- a/src/main/java/org/ezcode/codetest/domain/draft/service/DraftDomainService.java
+++ b/src/main/java/org/ezcode/codetest/domain/draft/service/DraftDomainService.java
@@ -50,9 +50,8 @@ public class DraftDomainService {
 		}
 	}
 
-	public Draft getDraft(User user, Problem problem, Language language) {
+	public Optional<Draft> getDraft(User user, Problem problem, Language language) {
 
-		return draftRepository.findByUserAndProblemAndLanguage(user, problem, language)
-			.orElseThrow(() -> new DraftException(DraftExceptionCode.DRAFT_NOT_FOUND));
+		return draftRepository.findByUserAndProblemAndLanguage(user, problem, language);
 	}
 }

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/draft/DraftJpaRepository.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/draft/DraftJpaRepository.java
@@ -1,0 +1,14 @@
+package org.ezcode.codetest.infrastructure.persistence.repository.draft;
+
+import java.util.Optional;
+
+import org.ezcode.codetest.domain.draft.model.entity.Draft;
+import org.ezcode.codetest.domain.language.model.entity.Language;
+import org.ezcode.codetest.domain.problem.model.entity.Problem;
+import org.ezcode.codetest.domain.user.model.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DraftJpaRepository extends JpaRepository<Draft, Long> {
+
+	Optional<Draft> findByUserAndProblemAndLanguage(User user, Problem problem, Language language);
+}

--- a/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/draft/DraftRepositoryImpl.java
+++ b/src/main/java/org/ezcode/codetest/infrastructure/persistence/repository/draft/DraftRepositoryImpl.java
@@ -1,0 +1,37 @@
+package org.ezcode.codetest.infrastructure.persistence.repository.draft;
+
+import java.util.Optional;
+
+import org.ezcode.codetest.domain.draft.model.entity.Draft;
+import org.ezcode.codetest.domain.draft.repository.DraftRepository;
+import org.ezcode.codetest.domain.language.model.entity.Language;
+import org.ezcode.codetest.domain.problem.model.entity.Problem;
+import org.ezcode.codetest.domain.user.model.entity.User;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class DraftRepositoryImpl implements DraftRepository {
+
+	private final DraftJpaRepository draftJpaRepository;
+
+	@Override
+	public Draft save(Draft draft) {
+
+		return draftJpaRepository.save(draft);
+	}
+
+	@Override
+	public Optional<Draft> findByUserAndProblemAndLanguage(User user, Problem problem, Language language) {
+
+		return draftJpaRepository.findByUserAndProblemAndLanguage(user, problem, language);
+	}
+
+	@Override
+	public Draft saveAndFlush(Draft draft) {
+
+		return draftJpaRepository.saveAndFlush(draft);
+	}
+}

--- a/src/main/java/org/ezcode/codetest/presentation/draft/DraftController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/draft/DraftController.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 
 import org.ezcode.codetest.application.draft.dto.request.DraftSaveRequest;
 import org.ezcode.codetest.application.draft.dto.response.DraftResponse;
-import org.ezcode.codetest.application.draft.servcie.DraftService;
+import org.ezcode.codetest.application.draft.service.DraftService;
 import org.ezcode.codetest.domain.user.model.entity.AuthUser;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/src/main/java/org/ezcode/codetest/presentation/draft/DraftController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/draft/DraftController.java
@@ -1,5 +1,7 @@
 package org.ezcode.codetest.presentation.draft;
 
+import java.util.Optional;
+
 import org.ezcode.codetest.application.draft.dto.request.DraftSaveRequest;
 import org.ezcode.codetest.application.draft.dto.response.DraftResponse;
 import org.ezcode.codetest.application.draft.servcie.DraftService;
@@ -13,6 +15,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +30,13 @@ public class DraftController {
 
 	private final DraftService draftService;
 
+	@Operation(
+		summary = "코드 자동 저장",
+		description = "작성 중인 코드를 자동으로 임시 저장합니다. 동일한 문제와 언어에 대한 기존 저장 내역이 있으면 업데이트하고, 없으면 새로 생성합니다. 버전 충돌 시 409 에러가 발생합니다."
+	)
+	@ApiResponse(responseCode = "200", description = "코드 저장 성공")
+	@ApiResponse(responseCode = "400", description = "유효하지 않은 요청 데이터")
+	@ApiResponse(responseCode = "409", description = "다른 탭에서 저장된 최신 코드가 존재합니다. 새로고침이 필요합니다.")
 	@PostMapping
 	public ResponseEntity<DraftResponse> saveDraft(
 		@Valid @RequestBody DraftSaveRequest request,
@@ -36,6 +48,15 @@ public class DraftController {
 		return ResponseEntity.ok(response);
 	}
 
+	@Operation(
+		summary = "저장된 코드 조회",
+		description = "특정 문제와 언어에 대해 저장된 임시 저장 코드를 조회합니다. 저장된 데이터가 없으면 result가 null로 반환됩니다.",
+		parameters = {
+			@Parameter(name = "problemId", description = "문제 ID", required = true),
+			@Parameter(name = "languageId", description = "언어 ID", required = true)
+		}
+	)
+	@ApiResponse(responseCode = "200", description = "저장된 코드 조회 성공 (데이터가 없을 경우 result는 null)")
 	@GetMapping
 	public ResponseEntity<DraftResponse> getDraft(
 		@RequestParam Long problemId,
@@ -43,12 +64,14 @@ public class DraftController {
 		@AuthenticationPrincipal AuthUser authUser
 	) {
 
-		DraftResponse response = draftService.getDraft(
+		Optional<DraftResponse> response = draftService.getDraft(
 			authUser.getId(),
 			problemId,
 			languageId
 		);
 
-		return ResponseEntity.ok(response);
+		return response
+			.map(ResponseEntity::ok)
+			.orElse(ResponseEntity.ok().body(null));
 	}
 }

--- a/src/main/java/org/ezcode/codetest/presentation/draft/DraftController.java
+++ b/src/main/java/org/ezcode/codetest/presentation/draft/DraftController.java
@@ -1,0 +1,54 @@
+package org.ezcode.codetest.presentation.draft;
+
+import org.ezcode.codetest.application.draft.dto.request.DraftSaveRequest;
+import org.ezcode.codetest.application.draft.dto.response.DraftResponse;
+import org.ezcode.codetest.application.draft.servcie.DraftService;
+import org.ezcode.codetest.domain.user.model.entity.AuthUser;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/drafts")
+@RequiredArgsConstructor
+@Tag(name = "Drafts", description = "코드 자동 저장 API")
+public class DraftController {
+
+	private final DraftService draftService;
+
+	@PostMapping
+	public ResponseEntity<DraftResponse> saveDraft(
+		@Valid @RequestBody DraftSaveRequest request,
+		@AuthenticationPrincipal AuthUser authUser
+	) {
+
+		DraftResponse response = draftService.autoSave(authUser.getId(), request);
+
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping
+	public ResponseEntity<DraftResponse> getDraft(
+		@RequestParam Long problemId,
+		@RequestParam Long languageId,
+		@AuthenticationPrincipal AuthUser authUser
+	) {
+
+		DraftResponse response = draftService.getDraft(
+			authUser.getId(),
+			problemId,
+			languageId
+		);
+
+		return ResponseEntity.ok(response);
+	}
+}


### PR DESCRIPTION
## 작업 내용

- 사용자가 문제 풀이 중 작성한 코드를 임시로 저장하는 **자동 저장(Draft)** 기능을 구현했습니다.
- 채점 이력(`Submission`)과 분리된 별도의 도메인(`Draft`)을 설계하여 데이터 성격을 명확히 했습니다.
- 다중 탭 환경에서의 덮어쓰기 방지를 위한 **낙관적 락(Optimistic Lock)** 기반 동시성 제어 로직을 적용했습니다.

---

## 변경 사항

- **Domain Layer**
  - `Draft` 엔티티 생성
    - `User` + `Problem` + `Language` 3가지 조합의 **Composite Unique Constraint** 적용 (언어별 저장 지원)
    - `@Version` 필드 추가 (JPA 낙관적 락 적용)
  - `DraftRepository` 추가: `findByUserAndProblemAndLanguage` 조회 메서드 구현

- **Service Layer**
  - `DraftService`, `DraftDomainService` 구현
  - **Fail-Fast 전략 적용:** DB 저장 전 요청 버전과 현재 버전을 비교하여 불필요한 쿼리 방지
  - `saveAndFlush`를 사용하여 갱신된 버전 정보를 즉시 반환하도록 구현
  - 조회 시 데이터가 없으면 404 에러 대신 `빈 문자열("")`과 `version: null`을 반환하여 프론트엔드 처리 간소화

- **Controller Layer**
  - `POST /api/v1/drafts`: 자동 저장 API (Upsert)
  - `ObjectOptimisticLockingFailureException` 발생 시 `409 Conflict` 예외 코드로 매핑하여 반환

- **Configuration**
  - `SecurityConfig`: 로컬 테스트 환경을 위한 CORS 설정 추가 (`AllowedOriginPatterns` 적용)

---

## 트러블 슈팅

- **문제 1: 동시 수정 시 데이터 덮어쓰기 문제**
  - 상황: 여러 탭을 띄워두고 번갈아 수정할 경우, 이전 탭의 내용으로 최신 코드가 덮어씌워지는 현상 발생
  - 해결: JPA의 `@Version`을 이용한 **낙관적 락(Optimistic Lock)**을 도입. 버전 불일치 시 `409 Conflict`를 반환하고, 클라이언트에서 "불러오기 vs 덮어쓰기"를 선택하도록 유도함.

- **문제 2: 초기 진입 시 404 예외 처리의 모호함**
  - 상황: 사용자가 문제를 처음 풀러 들어왔을 때 저장된 Draft가 없어 `EntityNotFoundException`이 발생, 프론트엔드에서 이를 에러로 처리해야 하는 불편함 존재
  - 해결: 예외를 던지는 대신 **빈 객체(Empty Object)**를 200 OK로 반환하도록 변경하여 "정상적인 초기 상태"임을 명확히 함.

---

## 참고 사항

- **기술적 의사결정 (HTTP vs WebSocket)**
  - 이미 프로젝트에 WebSocket(ActiveMQ)이 존재하나, 코드 텍스트 데이터의 페이로드 크기와 t3.small의 메모리 제약을 고려하여 **HTTP Polling + Debouncing** 방식을 채택함.
  - 데이터 정합성이 실시간성보다 중요하다고 판단하여 트랜잭션 관리가 용이한 REST API 방식을 선택함.

---

### 코드 리뷰 전 확인 체크리스트

- [x] 불필요한 콘솔 로그, 주석 제거
- [x] 커밋 메시지 컨벤션 준수 (`type : `)
- [x] 기능 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 코드 임시 저장 기능 추가
  * 저장된 코드 조회 API 추가
  * 여러 탭에서의 동시 수정 시 버전 충돌 감지 및 안내
  * 문제별 프로그래밍 언어별 임시 저장 지원

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->