### PR TITLE
fix: 프로필 이미지 업로드 시 413 에러 해결

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -186,3 +186,10 @@ management.metrics.enable.jvm=false
 
 management.metrics.export.defaults.enabled=false
 management.metrics.enable.all=false
+
+# ========================
+# Multipart File Upload
+# ========================
+spring.servlet.multipart.enabled=true
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=5MB


### PR DESCRIPTION
## 작업 내용

### 문제
- 프로필 이미지 업로드 시 1MB 이상 파일에서 413 에러 발생
- 원래 의도는 5MB 이상일 때만 에러가 발생해야 함

### 해결
- multipart 파일 크기 제한을 5MB로 설정



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 파일 업로드 기능이 활성화되었습니다. 최대 파일 크기는 5MB입니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->