### PR TITLE
fix : 서버 요청 용량 수정

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -186,3 +186,10 @@ management.metrics.enable.jvm=false
 
 management.metrics.export.defaults.enabled=false
 management.metrics.enable.all=false
+
+# ========================
+# Multipart File Upload
+# ========================
+spring.servlet.multipart.enabled=true
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=5MB

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -190,6 +190,7 @@ management.metrics.enable.all=false
 # ========================
 # Multipart File Upload
 # ========================
+server.tomcat.max-swallow-size=-1
 spring.servlet.multipart.enabled=true
 spring.servlet.multipart.max-file-size=5MB
-spring.servlet.multipart.max-request-size=5MB
+spring.servlet.multipart.max-request-size=10MB


### PR DESCRIPTION
- #205 에서 언급한 문제가 배포 서버에서 수정되지 않아 다시 시도
- 2MB 이상의 이미지에 문제가 발생함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **설정 변경**
  * 파일 업로드 관련 서버 설정이 업데이트되었습니다.
  * 멀티파트 요청의 최대 허용 크기가 기존 5MB에서 10MB로 상향 조정되었습니다.
  * Tomcat의 요청 수용 한도가 무제한(-1)으로 설정되어 더 큰 요청도 수신될 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->